### PR TITLE
fix(examples): fix TypeScript errors in express-server

### DIFF
--- a/examples/express-server/index.ts
+++ b/examples/express-server/index.ts
@@ -60,8 +60,12 @@ const notepadTool = new FunctionTool({
   }),
   execute: async (
     { action, content },
-    context: ToolContext,
+    context?: ToolContext,
   ): Promise<Record<string, unknown>> => {
+    if (!context) {
+      return { status: "error", message: "ToolContext is required" };
+    }
+
     const notesKey = "user:notes"; // User-scoped state (persists across sessions)
 
     switch (action) {
@@ -187,13 +191,13 @@ app.get("/", (_req, res) => {
 app.get("/sessions/:userId", async (req, res) => {
   try {
     const { userId } = req.params;
-    const sessions = await sessionService.listSessions({
+    const response = await sessionService.listSessions({
       appName: APP_NAME,
       userId,
     });
     res.json({
       userId,
-      sessions: sessions.map((s) => ({
+      sessions: response.sessions.map((s) => ({
         id: s.id,
         createdAt: s.events?.[0]?.timestamp,
         eventCount: s.events?.length || 0,


### PR DESCRIPTION
## Changes

Fix two TypeScript errors in the express-server example:

### 1. `listSessions` return type
`sessionService.listSessions()` returns `ListSessionsResponse` which has a `sessions` property, not an array directly.

```typescript
// Before (incorrect)
const sessions = await sessionService.listSessions({...});
sessions.map(...)  // ❌ Error: Property 'map' does not exist

// After (correct)
const response = await sessionService.listSessions({...});
response.sessions.map(...)  // ✅
```

### 2. `ToolContext` is optional
ADK's `execute` function signature defines `context` as `ToolContext | undefined`.

```typescript
// Before (incorrect)
execute: async ({ action, content }, context: ToolContext) => {
  // ❌ Error: Type 'ToolContext | undefined' not assignable

// After (correct)  
execute: async ({ action, content }, context?: ToolContext) => {
  if (!context) {
    return { status: 'error', message: 'ToolContext is required' };
  }
  // ✅
```

## Testing

Ran the server and tested all endpoints:
- ✅ Health check
- ✅ Basic chat
- ✅ Notepad tool (save/get notes with state persistence)
- ✅ Get current time tool
- ✅ List sessions
- ✅ Get session details
- ✅ SSE streaming