### PR TITLE
feat(examples): enhance basic-agent with multi-agent HelpDesk demo

### DIFF
--- a/examples/basic-agent/README.md
+++ b/examples/basic-agent/README.md
@@ -1,0 +1,159 @@
+# HelpDesk Multi-Agent Example
+
+This example demonstrates a multi-agent system using [adk-llm-bridge](https://www.npmjs.com/package/adk-llm-bridge) with Google ADK.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    User([User]) --> Coordinator
+
+    subgraph Coordinator[HelpDeskCoordinator]
+        direction TB
+        C[Routes users to specialists]
+    end
+
+    Coordinator -->|Payment issues| Billing
+    Coordinator -->|Technical issues| Support
+
+    subgraph Billing[Billing Agent]
+        direction TB
+        B1[check_invoice]
+        B2[process_refund]
+    end
+
+    subgraph Support[Support Agent]
+        direction TB
+        S1[check_system_status]
+        S2[reset_password]
+    end
+```
+
+## Setup
+
+```bash
+cd examples/basic-agent
+bun install
+```
+
+Create a `.env` file:
+
+```env
+AI_GATEWAY_API_KEY=your-api-key
+# Or use provider-specific keys:
+# ANTHROPIC_API_KEY=your-key
+# OPENAI_API_KEY=your-key
+```
+
+## Run
+
+```bash
+# Start the DevTools web UI
+bun run web
+
+# Or run in CLI mode
+bun run dev
+```
+
+## Example Questions
+
+### Billing Agent
+
+Ask these to be routed to the Billing specialist:
+
+**Invoice Lookup (by ID):**
+```
+"Can you check invoice INV-001?"
+"What's the status of invoice INV-002?"
+```
+> Returns: Invoice details with amount ($99.00), status, date, and description
+
+**Invoice Lookup (by Email):**
+```
+"Show me all invoices for john@example.com"
+"What invoices are pending for customer@test.com?"
+```
+> Returns: List of invoices (INV-001 paid, INV-002 pending)
+
+**Process Refund:**
+```
+"I need a refund for invoice INV-001, I was charged twice"
+"Please refund INV-002, the service didn't work"
+```
+> Returns: Refund ID (REF-xxx) with confirmation message
+
+### Support Agent
+
+Ask these to be routed to the Support specialist:
+
+**System Status (all services):**
+```
+"Is the system down?"
+"Check if all services are working"
+```
+> Returns: Status of api (operational), web (operational), database (operational), auth (degraded)
+
+**System Status (specific service):**
+```
+"Is the API working?"
+"Check the auth service status"
+"Why is login slow?"
+```
+> Returns: Service status - Note: auth service shows "degraded" with "Investigating slowness"
+
+**Password Reset:**
+```
+"I forgot my password, my email is user@example.com"
+"Reset password for john@company.com"
+```
+> Returns: Confirmation that reset link was sent (expires in 1 hour)
+
+### Coordinator (General)
+
+Ask these to see the routing in action:
+
+```
+"Hello, I need help"
+"My payment failed"          → Routes to Billing
+"I can't log in"             → Routes to Support
+"I have invoice questions"   → Routes to Billing
+"The website is slow"        → Routes to Support
+```
+
+## How It Works
+
+1. **User sends a message** to the HelpDeskCoordinator
+2. **Coordinator analyzes** the request and determines the appropriate specialist
+3. **Agent transfer** occurs via ADK's `transfer_to_agent` function call
+4. **Specialist handles** the request using their specific tools
+5. **Response** is returned to the user
+
+## Tools Available
+
+### Billing Agent Tools
+
+| Tool | Description |
+|------|-------------|
+| `check_invoice` | Look up invoice by ID or customer email |
+| `process_refund` | Process refund for a specific invoice |
+
+### Support Agent Tools
+
+| Tool | Description |
+|------|-------------|
+| `check_system_status` | Check status of api, web, database, auth services |
+| `reset_password` | Send password reset link to user's email |
+
+## Customization
+
+You can easily modify the agents to use different models:
+
+```typescript
+const billingAgent = new LlmAgent({
+  name: "Billing",
+  model: "openai/gpt-4o",  // Use OpenAI instead
+  // ...
+});
+```
+
+Supported model formats: `provider/model-name` (e.g., `anthropic/claude-sonnet-4`, `openai/gpt-4o`, `google/gemini-2.0-flash`)

--- a/examples/basic-agent/agent.ts
+++ b/examples/basic-agent/agent.ts
@@ -4,25 +4,179 @@ import { z } from "zod";
 
 LLMRegistry.register(AIGatewayLlm);
 
-const getCurrentTime = new FunctionTool({
-  name: "get_current_time",
-  description: "Returns the current time in a specified city.",
+// =============================================================================
+// Billing Agent Tools
+// =============================================================================
+
+const checkInvoice = new FunctionTool({
+  name: "check_invoice",
+  description: "Look up invoice details by invoice ID or customer email.",
   parameters: z.object({
-    city: z.string().describe("The name of the city"),
+    invoiceId: z.string().optional().describe("The invoice ID to look up"),
+    email: z
+      .string()
+      .email()
+      .optional()
+      .describe("Customer email to find invoices"),
   }),
-  execute: ({ city }) => {
-    const time = new Date().toLocaleTimeString("en-US", {
-      timeZone: city === "Tokyo" ? "Asia/Tokyo" : "America/New_York",
-    });
-    return { status: "success", time, city };
+  execute: ({ invoiceId, email }) => {
+    // Simulated invoice lookup
+    if (invoiceId) {
+      return {
+        status: "success",
+        invoice: {
+          id: invoiceId,
+          amount: "$99.00",
+          status: "paid",
+          date: "2024-01-15",
+          description: "Monthly subscription",
+        },
+      };
+    }
+    if (email) {
+      return {
+        status: "success",
+        invoices: [
+          {
+            id: "INV-001",
+            amount: "$99.00",
+            status: "paid",
+            date: "2024-01-15",
+          },
+          {
+            id: "INV-002",
+            amount: "$99.00",
+            status: "pending",
+            date: "2024-02-15",
+          },
+        ],
+      };
+    }
+    return { status: "error", message: "Please provide invoiceId or email" };
   },
 });
 
-export const rootAgent = new LlmAgent({
-  name: "time_agent",
+const processRefund = new FunctionTool({
+  name: "process_refund",
+  description: "Process a refund request for a specific invoice.",
+  parameters: z.object({
+    invoiceId: z.string().describe("The invoice ID to refund"),
+    reason: z.string().describe("Reason for the refund"),
+  }),
+  execute: ({ invoiceId, reason }) => {
+    return {
+      status: "success",
+      refundId: `REF-${Date.now()}`,
+      invoiceId,
+      message: `Refund initiated for invoice ${invoiceId}. Processing time: 3-5 business days.`,
+      reason,
+    };
+  },
+});
+
+// =============================================================================
+// Support Agent Tools
+// =============================================================================
+
+const checkSystemStatus = new FunctionTool({
+  name: "check_system_status",
+  description: "Check the current status of system services.",
+  parameters: z.object({
+    service: z
+      .enum(["api", "web", "database", "auth", "all"])
+      .optional()
+      .describe("Specific service to check, or 'all' for complete status"),
+  }),
+  execute: ({ service = "all" }) => {
+    const services = {
+      api: { status: "operational", latency: "45ms" },
+      web: { status: "operational", latency: "120ms" },
+      database: { status: "operational", latency: "12ms" },
+      auth: {
+        status: "degraded",
+        latency: "250ms",
+        note: "Investigating slowness",
+      },
+    };
+
+    if (service === "all") {
+      return { result: "success", services };
+    }
+    const serviceData = services[service as keyof typeof services];
+    return {
+      result: "success",
+      service,
+      serviceStatus: serviceData.status,
+      latency: serviceData.latency,
+      ...("note" in serviceData ? { note: serviceData.note } : {}),
+    };
+  },
+});
+
+const resetPassword = new FunctionTool({
+  name: "reset_password",
+  description: "Send a password reset link to a user's email.",
+  parameters: z.object({
+    email: z.string().email().describe("User's email address"),
+  }),
+  execute: ({ email }) => {
+    return {
+      status: "success",
+      message: `Password reset link sent to ${email}. Link expires in 1 hour.`,
+    };
+  },
+});
+
+// =============================================================================
+// Sub-Agents
+// =============================================================================
+
+const billingAgent = new LlmAgent({
+  name: "Billing",
   model: "anthropic/claude-sonnet-4",
-  description: "An agent that tells the current time in any city.",
-  instruction: `You are a helpful assistant that tells the current time.
-Use the 'get_current_time' tool when asked about time in a city.`,
-  tools: [getCurrentTime],
+  description:
+    "Handles billing inquiries, invoice lookups, and refund requests.",
+  instruction: `You are a billing specialist assistant. Help customers with:
+- Invoice lookups and payment status
+- Refund requests and processing
+- Billing questions and payment issues
+
+Be professional, empathetic, and efficient. Always verify the invoice/account before processing refunds.`,
+  tools: [checkInvoice, processRefund],
+});
+
+const supportAgent = new LlmAgent({
+  name: "Support",
+  model: "anthropic/claude-sonnet-4",
+  description:
+    "Handles technical support requests, login issues, and system status.",
+  instruction: `You are a technical support specialist. Help customers with:
+- Login and authentication issues
+- Password resets
+- System status inquiries
+- Technical troubleshooting
+
+Be patient and guide users step by step. Check system status when relevant to issues.`,
+  tools: [checkSystemStatus, resetPassword],
+});
+
+// =============================================================================
+// Coordinator (Root Agent)
+// =============================================================================
+
+export const rootAgent = new LlmAgent({
+  name: "HelpDeskCoordinator",
+  model: "anthropic/claude-sonnet-4",
+  description:
+    "Main help desk router that directs users to the appropriate specialist.",
+  instruction: `You are a help desk coordinator. Your job is to:
+
+1. Greet the user and understand their issue
+2. Route to the appropriate specialist:
+   - **Billing**: Payment issues, invoices, refunds, subscription questions
+   - **Support**: Login problems, password resets, technical issues, system status
+
+When routing, briefly explain which specialist will help them.
+If unclear, ask clarifying questions before routing.`,
+  subAgents: [billingAgent, supportAgent],
 });

--- a/examples/basic-agent/bun.lock
+++ b/examples/basic-agent/bun.lock
@@ -6,7 +6,7 @@
       "name": "basic-agent-example",
       "dependencies": {
         "@google/adk": "^0.2.0",
-        "adk-llm-bridge": "^0.1.0",
+        "adk-llm-bridge": "^0.1.1",
       },
     },
   },
@@ -113,7 +113,7 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "adk-llm-bridge": ["adk-llm-bridge@0.1.0", "", { "dependencies": { "openai": "^4.73.0" }, "peerDependencies": { "@google/adk": ">=0.2.0" } }, "sha512-WxWX5hl5SeR85eYK5pXo+ujKhQvr/6Ofj7IsuAozXybienoXxoHiToxTYP4KPVo2r1Z8gL5PgvcJ8JNJeKxjlA=="],
+    "adk-llm-bridge": ["adk-llm-bridge@0.1.1", "", { "dependencies": { "openai": "^4.73.0" }, "peerDependencies": { "@google/adk": ">=0.2.0" } }, "sha512-83LM68ADUeWebvDKADBi6O34yWMg/pY7W+H+gf8leH08/tJ0K7QQNj5iDIHb2OtiYGAUqYUCuNZjndsFqI8CJQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/examples/basic-agent/package.json
+++ b/examples/basic-agent/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "@google/adk": "^0.2.0",
-    "adk-llm-bridge": "^0.1.0"
+    "adk-llm-bridge": "^0.1.1"
   }
 }


### PR DESCRIPTION
## Changes

- Replace simple time_agent with multi-agent HelpDesk system
- Add HelpDeskCoordinator as root agent for routing
- Add Billing sub-agent with `check_invoice` and `process_refund` tools
- Add Support sub-agent with `check_system_status` and `reset_password` tools
- Add comprehensive README with Mermaid architecture diagram and example queries
- Update adk-llm-bridge dependency to 0.1.1

## Testing

Run the example:
```bash
cd examples/basic-agent
bun install
bun run web
```

Try queries like:
- "My payment failed" → Routes to Billing
- "I can't log in" → Routes to Support
- "Check invoice INV-001" → Billing uses check_invoice tool