### PR TITLE
docs: update model references to December 2025 state-of-the-art

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ LLMRegistry.register(AIGatewayLlm);              // 2. Register
 
 const agent = new LlmAgent({                     // 3. Use any model
   name: 'assistant',
-  model: 'anthropic/claude-sonnet-4',            // Claude, GPT-4, Llama, etc.
+  model: 'anthropic/claude-sonnet-4.5',          // Claude, GPT, Llama, etc.
   instruction: 'You are a helpful assistant.',
 });
 ```
@@ -90,7 +90,7 @@ LLMRegistry.register(OpenRouterLlm);
 
 const agent = new LlmAgent({
   name: 'assistant',
-  model: 'anthropic/claude-sonnet-4',
+  model: 'anthropic/claude-sonnet-4.5',
   instruction: 'You are a helpful assistant.',
 });
 ```
@@ -140,14 +140,14 @@ import { AIGateway, OpenRouter } from 'adk-llm-bridge';
 // AI Gateway
 const agent1 = new LlmAgent({
   name: 'assistant',
-  model: AIGateway('anthropic/claude-sonnet-4', { timeout: 30000 }),
+  model: AIGateway('anthropic/claude-sonnet-4.5', { timeout: 30000 }),
   instruction: 'You are helpful.',
 });
 
 // OpenRouter with provider routing
 const agent2 = new LlmAgent({
   name: 'fast-assistant',
-  model: OpenRouter('anthropic/claude-sonnet-4', {
+  model: OpenRouter('anthropic/claude-sonnet-4.5', {
     provider: {
       sort: 'latency',
       allow_fallbacks: true,
@@ -164,7 +164,7 @@ OpenRouter provides additional features not available in AI Gateway:
 ```typescript
 import { OpenRouter } from 'adk-llm-bridge';
 
-const llm = OpenRouter('anthropic/claude-sonnet-4', {
+const llm = OpenRouter('anthropic/claude-sonnet-4.5', {
   // Ranking headers (improves your rate limits)
   siteUrl: 'https://your-site.com',
   appName: 'Your App',
@@ -184,26 +184,26 @@ const llm = OpenRouter('anthropic/claude-sonnet-4', {
 Use the `provider/model` format:
 
 ```
-anthropic/claude-sonnet-4
-openai/gpt-4o
-google/gemini-2.0-flash
-meta/llama-3.1-70b
-mistral/mistral-large
-xai/grok-2
-deepseek/deepseek-chat
+anthropic/claude-opus-4.5
+openai/gpt-5.2-pro
+google/gemini-3-pro
+meta/llama-3.3-70b-instruct
+mistral/mistral-large-3
+xai/grok-4.1
+deepseek/deepseek-r1
 ```
 
 ### Popular Models
 
 | Provider | Models |
 |----------|--------|
-| Anthropic | `anthropic/claude-opus-4`, `anthropic/claude-sonnet-4` |
-| OpenAI | `openai/gpt-4.1`, `openai/o3`, `openai/gpt-4o` |
-| Google | `google/gemini-2.5-pro`, `google/gemini-2.5-flash` |
-| Meta | `meta/llama-4-scout`, `meta/llama-4-maverick` |
-| Mistral | `mistral/mistral-large-2411`, `mistral/pixtral-large` |
-| xAI | `xai/grok-3`, `xai/grok-3-mini` |
-| DeepSeek | `deepseek/deepseek-v3`, `deepseek/deepseek-r1` |
+| Anthropic | `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5` |
+| OpenAI | `openai/gpt-5.2-pro`, `openai/gpt-4.1`, `openai/o3-mini` |
+| Google | `google/gemini-3-pro`, `google/gemini-3-flash`, `google/gemini-2.5-pro` |
+| Meta | `meta/llama-3.3-70b-instruct`, `meta/llama-3.1-405b-instruct` |
+| Mistral | `mistral/mistral-large-3`, `mistral/mistral-large-2411` |
+| xAI | `xai/grok-4.1`, `xai/grok-4-fast`, `xai/grok-3` |
+| DeepSeek | `deepseek/deepseek-v3.2`, `deepseek/deepseek-r1` |
 
 Browse all models:
 - [Vercel AI Gateway Models](https://vercel.com/ai-gateway/models)
@@ -240,7 +240,7 @@ const getWeather = new FunctionTool({
 
 const agent = new LlmAgent({
   name: 'weather-assistant',
-  model: 'anthropic/claude-sonnet-4',
+  model: 'anthropic/claude-sonnet-4.5',
   instruction: 'You help users check the weather.',
   tools: [getWeather],
 });
@@ -261,7 +261,7 @@ LLMRegistry.register(OpenRouterLlm);
 
 export const rootAgent = new LlmAgent({
   name: 'assistant',
-  model: 'anthropic/claude-sonnet-4',
+  model: 'anthropic/claude-sonnet-4.5',
   instruction: 'You are helpful.',
 });
 ```

--- a/examples/basic-agent-ai-gateway/README.md
+++ b/examples/basic-agent-ai-gateway/README.md
@@ -156,4 +156,4 @@ const billingAgent = new LlmAgent({
 });
 ```
 
-Supported model formats: `provider/model-name` (e.g., `anthropic/claude-sonnet-4`, `openai/gpt-4o`, `google/gemini-2.0-flash`)
+Supported model formats: `provider/model-name` (e.g., `anthropic/claude-sonnet-4.5`, `openai/gpt-4.1`, `google/gemini-2.5-flash`)

--- a/examples/basic-agent-ai-gateway/agent.ts
+++ b/examples/basic-agent-ai-gateway/agent.ts
@@ -135,7 +135,7 @@ const resetPassword = new FunctionTool({
 
 const billingAgent = new LlmAgent({
   name: "Billing",
-  model: "anthropic/claude-sonnet-4",
+  model: "anthropic/claude-sonnet-4.5",
   description:
     "Handles billing inquiries, invoice lookups, and refund requests.",
   instruction: `You are a billing specialist assistant. Help customers with:
@@ -149,7 +149,7 @@ Be professional, empathetic, and efficient. Always verify the invoice/account be
 
 const supportAgent = new LlmAgent({
   name: "Support",
-  model: "anthropic/claude-sonnet-4",
+  model: "anthropic/claude-sonnet-4.5",
   description:
     "Handles technical support requests, login issues, and system status.",
   instruction: `You are a technical support specialist. Help customers with:
@@ -168,7 +168,7 @@ Be patient and guide users step by step. Check system status when relevant to is
 
 export const rootAgent = new LlmAgent({
   name: "HelpDeskCoordinator",
-  model: "anthropic/claude-sonnet-4",
+  model: "anthropic/claude-sonnet-4.5",
   description:
     "Main help desk router that directs users to the appropriate specialist.",
   instruction: `You are a help desk coordinator. Your job is to:

--- a/examples/basic-agent-openrouter/README.md
+++ b/examples/basic-agent-openrouter/README.md
@@ -51,7 +51,7 @@ You can configure provider preferences programmatically:
 ```typescript
 import { OpenRouter } from "adk-llm-bridge";
 
-const llm = OpenRouter("anthropic/claude-sonnet-4", {
+const llm = OpenRouter("anthropic/claude-sonnet-4.5", {
   provider: {
     sort: "latency",        // or "price", "throughput"
     allow_fallbacks: true,

--- a/examples/express-server/index.ts
+++ b/examples/express-server/index.ts
@@ -138,7 +138,7 @@ const memoryService = new InMemoryMemoryService();
  */
 const agent = new LlmAgent({
   name: "assistant",
-  model: "anthropic/claude-sonnet-4",
+  model: "anthropic/claude-sonnet-4.5",
   description: "A helpful assistant that can take notes and tell the time.",
   instruction: `You are a helpful assistant. Be concise in your responses.
 
@@ -172,7 +172,7 @@ app.get("/", (_req, res) => {
   res.json({
     status: "ok",
     agent: agent.name,
-    model: "anthropic/claude-sonnet-4",
+    model: "anthropic/claude-sonnet-4.5",
     features: [
       "session-management",
       "state-persistence",
@@ -392,7 +392,7 @@ app.listen(port, () => {
 ║                   ADK Agent API Server                       ║
 ╠══════════════════════════════════════════════════════════════╣
 ║  Agent: ${agent.name.padEnd(52)}║
-║  Model: anthropic/claude-sonnet-4                            ║
+║  Model: anthropic/claude-sonnet-4.5                          ║
 ║                                                              ║
 ║  Features:                                                   ║
 ║    ✓ Session management with state                           ║


### PR DESCRIPTION
## Changes

Updates all model references to the latest December 2025 state-of-the-art models:

### Updated Models
- **Anthropic**: Claude Opus 4.5, Claude Sonnet 4.5
- **OpenAI**: GPT-5.2 Pro, GPT-4.1, o3-mini
- **Google**: Gemini 3 Pro, Gemini 3 Flash (released Dec 17), Gemini 2.5 Pro
- **Meta**: Llama 3.3 70B, Llama 3.1 405B
- **Mistral**: Mistral Large 3, Mistral Large 2411
- **xAI**: Grok 4.1, Grok 4 Fast, Grok 3
- **DeepSeek**: DeepSeek V3.2, DeepSeek R1

### Files Changed
- README.md - Updated Popular Models table and model format examples
- examples/basic-agent-ai-gateway/agent.ts - Updated to claude-sonnet-4.5
- examples/basic-agent-ai-gateway/README.md - Updated model examples
- examples/basic-agent-openrouter/README.md - Updated model examples  
- examples/express-server/index.ts - Updated to claude-sonnet-4.5