### PR TITLE
fix: add tsconfig.build.json for npm publish compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "typescript": "^5.3.0",
       },
       "peerDependencies": {
-        "@google/adk": "^0.2.1",
+        "@google/adk": ">=0.2.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "bun build ./src/index.ts --outdir ./dist --target node --external '@google/adk' --external '@google/genai' --external 'openai' && bun run build:types",
-    "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "build:types": "tsc --project tsconfig.build.json",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "typecheck:all": "tsc --noEmit -p tsconfig.test.json",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedDeclarations": false,
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"],
+}


### PR DESCRIPTION
## Problem
Running `npm publish` failed with `tsc: command not found` because the build script tried to use global tsc.

## Solution
- Create separate `tsconfig.build.json` without `bun-types` for declaration generation
- Update `build:types` script to use the new config
- This follows [Bun best practices](https://dev.to/arshadyaseen/building-a-typescript-library-in-2025-2h0i) for building TypeScript packages

## Verification
- `bun run ci` passes (typecheck, lint, tests, build)