### PR TITLE
docs: update CONTRIBUTING.md with GitHub Flow workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ bun run ci
 | `bun run typecheck` | Type check source files |
 | `bun run typecheck:all` | Type check source and test files |
 | `bun run lint` | Run linter |
+| `bun run lint:fix` | Auto-fix lint issues |
+| `bun run check:fix` | Auto-fix lint and formatting |
 | `bun run ci` | Run full CI pipeline (typecheck, lint, test, build) |
 
 ### Code Style
@@ -52,47 +54,139 @@ bun run ci
 - Use `bun:test` for testing
 - Run `bun test` before submitting a PR
 
-## Branch Strategy
+## Branch Strategy (GitHub Flow)
 
-We use a multi-branch workflow:
+We use a simplified GitHub Flow with a single main branch:
 
 ```
-feature/* → develop → staging → main
+main (production)
+  │
+  └── feature/*, fix/*, docs/* (short-lived branches)
 ```
 
-| Branch | Purpose |
-|--------|---------|
-| `main` | Production-ready code |
-| `staging` | Pre-production testing |
-| `develop` | Integration branch for features |
-| `feature/*` | Individual feature development |
+### Branch Types
+
+| Pattern | Purpose | Example |
+|---------|---------|---------|
+| `main` | Production-ready code, always deployable | - |
+| `feature/*` | New features | `feature/add-openrouter-support` |
+| `fix/*` | Bug fixes | `fix/streaming-response-error` |
+| `docs/*` | Documentation updates | `docs/update-readme` |
+| `chore/*` | Maintenance tasks | `chore/update-dependencies` |
+
+### Why GitHub Flow?
+
+- **Simplicity**: One main branch, feature branches, PRs. That's it.
+- **Continuous Deployment**: Every merge to `main` is deployable.
+- **Fast Iteration**: No waiting for staging/develop syncs.
+- **Clear History**: Linear history with squash merges.
+
+### Workflow
+
+```
+1. Create branch from main
+   └── git checkout main && git pull
+   └── git checkout -b feature/my-feature
+
+2. Develop and commit
+   └── git add . && git commit -m "feat: description"
+
+3. Push and create PR
+   └── git push origin feature/my-feature
+   └── gh pr create --base main
+
+4. Review, CI passes, merge
+   └── Squash and merge to main
+
+5. Delete feature branch
+   └── Automatic after merge
+```
 
 ## Pull Request Process
 
-1. **Fork the repository** and create your branch from `develop`
+### Before Creating a PR
+
+1. **Sync with main**: `git pull origin main --rebase`
+2. **Run CI locally**: `bun run ci`
+3. **Keep commits focused**: One logical change per commit
+
+### Creating a PR
+
+1. **Create your branch** from `main`:
+   ```bash
+   git checkout main && git pull
+   git checkout -b feature/my-feature
+   ```
+
 2. **Make your changes** following the code style guidelines
+
 3. **Add tests** for any new functionality
-4. **Run the CI pipeline** (`bun run ci`) and ensure it passes
-5. **Update documentation** if needed
-6. **Submit a pull request** to `develop` with a clear description
-7. After review and merge to `develop`, changes flow: `develop → staging → main`
+
+4. **Run the CI pipeline** and ensure it passes:
+   ```bash
+   bun run ci
+   ```
+
+5. **Push and create PR**:
+   ```bash
+   git push origin feature/my-feature
+   gh pr create --base main
+   ```
+
+### PR Requirements
+
+- CI must pass (typecheck, lint, tests, build)
+- Clear description of changes
+- Tests for new functionality
+- Documentation updates if needed
 
 ### PR Title Format
 
-Use conventional commit format:
-- `feat: add new feature`
-- `fix: resolve bug`
-- `docs: update documentation`
-- `refactor: improve code structure`
-- `test: add tests`
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `feat` | New feature | `feat: add OpenRouter provider` |
+| `fix` | Bug fix | `fix: handle empty response in streaming` |
+| `docs` | Documentation | `docs: update API examples` |
+| `refactor` | Code refactoring | `refactor: simplify request converter` |
+| `test` | Add/update tests | `test: add coverage for edge cases` |
+| `chore` | Maintenance | `chore: update dependencies` |
+
+### Merge Strategy
+
+We use **Squash and Merge** for all PRs:
+- Keeps `main` history clean and linear
+- Each PR becomes a single commit
+- Easy to revert if needed
+
+## Releases
+
+Releases are created from `main` using semantic versioning:
+
+```bash
+# After merging features to main
+git checkout main && git pull
+npm version patch|minor|major  # Updates package.json
+git push origin main --tags
+gh release create v0.x.x --generate-notes
+```
+
+| Version Bump | When to Use |
+|--------------|-------------|
+| `patch` (0.0.x) | Bug fixes, documentation |
+| `minor` (0.x.0) | New features (backward compatible) |
+| `major` (x.0.0) | Breaking changes |
 
 ## Reporting Issues
 
 When reporting issues, please include:
+
 - A clear description of the problem
 - Steps to reproduce
 - Expected vs actual behavior
-- Environment details (Node.js version, OS, etc.)
+- Environment details (Node.js version, Bun version, OS)
+- Relevant error messages or logs
 
 ## Questions?
 


### PR DESCRIPTION
## Changes

- Replace multi-branch GitFlow (develop → staging → main) with simplified GitHub Flow
- Single main branch + short-lived feature branches
- Clearer workflow documentation with examples
- Added merge strategy (squash and merge)
- Added release process documentation
- Expanded PR title format with conventional commits table

## Why GitHub Flow?

- **Simpler**: One main branch eliminates sync issues between develop/staging/main
- **Faster**: No waiting for cascading merges through multiple branches  
- **Cleaner**: Linear history with squash merges
- **Standard**: Used by most modern open source projects

## Removed

- `develop` branch (deleted)
- `staging` branch (deleted)
- Branch protection rules for develop/staging