### PR TITLE
refactor: rename OpenAICompatibleProvider to CustomLlm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,13 @@ export {
 } from "./providers/openrouter";
 
 // =============================================================================
+// Custom LLM Provider (Any Compatible API)
+// =============================================================================
+
+export { CustomLlm, type CustomLlmProviderConfig } from "./providers/custom";
+export { createCustomLlm, Custom } from "./providers/custom";
+
+// =============================================================================
 // Types
 // =============================================================================
 
@@ -103,6 +110,8 @@ export type {
   OpenRouterConfig,
   OpenRouterProviderPreferences,
   OpenRouterRegisterOptions,
+  // Custom LLM types
+  CustomLlmConfig,
   // Streaming types
   ToolCallAccumulator,
   StreamAccumulator,

--- a/src/providers/custom/custom-llm.ts
+++ b/src/providers/custom/custom-llm.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Custom LLM provider implementation.
+ *
+ * This module provides an LLM class for connecting to any API that implements
+ * the OpenAI chat completions interface, such as Ollama, LM Studio, vLLM,
+ * Azure OpenAI, or self-hosted models.
+ *
+ * @module providers/custom/custom-llm
+ */
+
+import { OpenAICompatibleLlm } from "../../core/openai-compatible-llm";
+import { DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES } from "../../constants";
+import type { CustomLlmConfig } from "../../types";
+
+/**
+ * Configuration type with required baseURL for custom providers.
+ *
+ * Unlike built-in providers (AI Gateway, OpenRouter) which have default URLs,
+ * custom providers require an explicit baseURL.
+ */
+export type CustomLlmProviderConfig = CustomLlmConfig & {
+  /**
+   * Base URL for the API endpoint (required).
+   *
+   * @example "http://localhost:11434/v1" // Ollama
+   * @example "http://localhost:8000/v1"  // vLLM
+   * @example "https://my-resource.openai.azure.com/openai/deployments/gpt-4" // Azure
+   */
+  baseURL: string;
+};
+
+/**
+ * LLM implementation for any API that supports the chat completions interface.
+ *
+ * This provider allows connecting to any API that implements the OpenAI
+ * chat completions interface. Use this for:
+ *
+ * - **Local models**: Ollama, LM Studio, vLLM, llama.cpp
+ * - **Cloud providers**: Azure OpenAI, Together AI, Anyscale
+ * - **Self-hosted**: Any compatible server
+ *
+ * Unlike AI Gateway and OpenRouter, this provider:
+ * - Requires explicit `baseURL` configuration
+ * - Does not use environment variables for defaults
+ * - Supports custom headers and query parameters
+ *
+ * @example
+ * ```typescript
+ * // Ollama
+ * const llm = new CustomLlm({
+ *   name: "ollama",
+ *   model: "llama3",
+ *   baseURL: "http://localhost:11434/v1"
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Azure OpenAI
+ * const llm = new CustomLlm({
+ *   name: "azure",
+ *   model: "gpt-4",
+ *   baseURL: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+ *   headers: { "api-key": process.env.AZURE_API_KEY },
+ *   queryParams: { "api-version": "2024-02-01" }
+ * });
+ * ```
+ *
+ * @see {@link createCustomLlm} for the factory function
+ * @see {@link Custom} for the shorthand alias
+ */
+export class CustomLlm extends OpenAICompatibleLlm {
+  /**
+   * Model patterns supported by this provider.
+   *
+   * Accepts any model identifier since different APIs use different naming conventions.
+   *
+   * @static
+   */
+  static readonly supportedModels = [/.*/];
+
+  /**
+   * Provider name used for error prefixes.
+   *
+   * @private
+   */
+  private readonly providerName: string;
+
+  /**
+   * Provider-specific options to include in requests.
+   *
+   * @private
+   */
+  private readonly providerOptionsConfig?: Record<string, unknown>;
+
+  /**
+   * Creates a new custom LLM provider instance.
+   *
+   * @param config - Configuration options including model, baseURL, and optional settings
+   *
+   * @example
+   * ```typescript
+   * const llm = new CustomLlm({
+   *   name: "vllm",
+   *   model: "meta-llama/Llama-3-8b",
+   *   baseURL: "http://localhost:8000/v1"
+   * });
+   * ```
+   */
+  constructor(config: CustomLlmProviderConfig) {
+    // Build final URL with query params if provided
+    let finalBaseURL = config.baseURL;
+    if (config.queryParams && Object.keys(config.queryParams).length > 0) {
+      const params = new URLSearchParams(config.queryParams);
+      const separator = config.baseURL.includes("?") ? "&" : "?";
+      finalBaseURL = `${config.baseURL}${separator}${params.toString()}`;
+    }
+
+    super(config, {
+      baseURL: finalBaseURL,
+      apiKey: config.apiKey ?? "",
+      timeout: config.timeout ?? DEFAULT_TIMEOUT,
+      maxRetries: config.maxRetries ?? DEFAULT_MAX_RETRIES,
+      defaultHeaders: config.headers,
+    });
+
+    this.providerName = config.name ?? "CUSTOM";
+    this.providerOptionsConfig = config.providerOptions;
+  }
+
+  /**
+   * Returns the error prefix for this provider.
+   *
+   * Sanitizes the provider name to create a valid error code prefix.
+   * For example, "my-provider" becomes "MY_PROVIDER".
+   *
+   * @returns The sanitized provider name in uppercase
+   * @protected
+   */
+  protected getErrorPrefix(): string {
+    return this.providerName.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+  }
+
+  /**
+   * Returns provider-specific options to include in requests.
+   *
+   * These options are spread into the chat completion request body,
+   * allowing custom parameters beyond the standard OpenAI API.
+   *
+   * @returns The configured provider options or an empty object
+   * @protected
+   */
+  protected getProviderRequestOptions(): Record<string, unknown> {
+    return this.providerOptionsConfig ?? {};
+  }
+}

--- a/src/providers/custom/factory.ts
+++ b/src/providers/custom/factory.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Factory functions for custom LLM providers.
+ *
+ * @module providers/custom/factory
+ */
+
+import { CustomLlm, type CustomLlmProviderConfig } from "./custom-llm";
+import type { CustomLlmConfig } from "../../types";
+
+/**
+ * Creates a custom LLM instance.
+ *
+ * This is the recommended way to connect to any API that implements
+ * the chat completions interface. It provides a clean, functional API.
+ *
+ * @param config - Configuration options including model, baseURL, and optional settings
+ * @returns A configured CustomLlm instance
+ *
+ * @example
+ * ```typescript
+ * // Ollama
+ * const llm = createCustomLlm({
+ *   name: "ollama",
+ *   model: "llama3",
+ *   baseURL: "http://localhost:11434/v1"
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Azure OpenAI
+ * const llm = createCustomLlm({
+ *   name: "azure",
+ *   model: "gpt-4",
+ *   baseURL: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+ *   apiKey: process.env.AZURE_API_KEY,
+ *   headers: { "api-key": process.env.AZURE_API_KEY },
+ *   queryParams: { "api-version": "2024-02-01" }
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // vLLM / LM Studio
+ * const llm = createCustomLlm({
+ *   baseURL: "http://localhost:8000/v1",
+ *   model: "meta-llama/Llama-3-8b"
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With provider-specific options
+ * const llm = createCustomLlm({
+ *   name: "custom",
+ *   model: "my-model",
+ *   baseURL: "https://api.example.com/v1",
+ *   apiKey: "sk-...",
+ *   providerOptions: {
+ *     temperature: 0.7,
+ *     custom_param: "value"
+ *   }
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Use with ADK agent
+ * import { LlmAgent } from "@google/adk";
+ *
+ * const agent = new LlmAgent({
+ *   name: "assistant",
+ *   model: createCustomLlm({
+ *     name: "ollama",
+ *     model: "llama3",
+ *     baseURL: "http://localhost:11434/v1"
+ *   }),
+ *   instruction: "You are a helpful assistant."
+ * });
+ * ```
+ *
+ * @see {@link CustomLlm} for direct class usage
+ * @see {@link Custom} for a shorthand alias
+ */
+export function createCustomLlm(config: CustomLlmProviderConfig): CustomLlm {
+  return new CustomLlm(config);
+}
+
+/**
+ * Configuration options for the Custom factory (model is specified separately).
+ */
+type CustomOptions = Omit<CustomLlmConfig, "model"> & {
+  /**
+   * Base URL for the API endpoint (required).
+   */
+  baseURL: string;
+};
+
+/**
+ * Creates a custom LLM instance with a shorthand syntax.
+ *
+ * This is an alias for `createCustomLlm` that takes the model
+ * as the first argument, similar to the `AIGateway` and `OpenRouter`
+ * factory functions.
+ *
+ * @param model - The model identifier
+ * @param options - Configuration options including baseURL and optional settings
+ * @returns A configured CustomLlm instance
+ *
+ * @example
+ * ```typescript
+ * // Simple usage
+ * const llm = Custom("llama3", {
+ *   baseURL: "http://localhost:11434/v1"
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With full options
+ * const llm = Custom("gpt-4", {
+ *   name: "azure",
+ *   baseURL: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+ *   apiKey: process.env.AZURE_API_KEY,
+ *   headers: { "api-key": process.env.AZURE_API_KEY },
+ *   queryParams: { "api-version": "2024-02-01" }
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Use with ADK agent
+ * import { LlmAgent } from "@google/adk";
+ *
+ * const agent = new LlmAgent({
+ *   name: "assistant",
+ *   model: Custom("llama3", { baseURL: "http://localhost:11434/v1" }),
+ *   instruction: "You are a helpful assistant."
+ * });
+ * ```
+ *
+ * @see {@link createCustomLlm} for the full configuration syntax
+ */
+export function Custom(model: string, options: CustomOptions): CustomLlm {
+  return createCustomLlm({ model, ...options });
+}

--- a/src/providers/custom/index.ts
+++ b/src/providers/custom/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Custom LLM provider for any compatible API.
+ *
+ * This module provides support for connecting to any API that implements
+ * the chat completions interface, including Ollama, LM Studio, vLLM,
+ * Azure OpenAI, and self-hosted models.
+ *
+ * ## Quick Start
+ *
+ * ```typescript
+ * import { createCustomLlm, Custom } from "adk-llm-bridge";
+ *
+ * // Full configuration
+ * const llm = createCustomLlm({
+ *   name: "ollama",
+ *   model: "llama3",
+ *   baseURL: "http://localhost:11434/v1"
+ * });
+ *
+ * // Shorthand syntax
+ * const llm2 = Custom("llama3", {
+ *   baseURL: "http://localhost:11434/v1"
+ * });
+ * ```
+ *
+ * @module providers/custom
+ */
+
+export { CustomLlm, type CustomLlmProviderConfig } from "./custom-llm";
+export { createCustomLlm, Custom } from "./factory";

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -10,6 +10,7 @@
  * This module exports all supported LLM providers:
  * - **AI Gateway**: Vercel's unified gateway for 100+ models
  * - **OpenRouter**: Multi-provider routing with fallbacks and optimization
+ * - **Custom**: Connect to any compatible API (Ollama, vLLM, Azure, etc.)
  *
  * @module providers
  *
@@ -18,6 +19,8 @@
  * import {
  *   AIGateway,
  *   OpenRouter,
+ *   createCustomLlm,
+ *   Custom,
  *   registerAIGateway,
  *   registerOpenRouter
  * } from "adk-llm-bridge";
@@ -26,3 +29,4 @@
 
 export * from "./ai-gateway";
 export * from "./openrouter";
+export * from "./custom";

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,100 @@ export interface OpenRouterRegisterOptions {
 }
 
 // =============================================================================
+// Custom LLM Provider Types
+// =============================================================================
+
+/**
+ * Configuration options for custom LLM providers.
+ *
+ * Use this to connect any API that implements the OpenAI chat completions
+ * interface, such as Ollama, LM Studio, vLLM, Azure OpenAI, or self-hosted models.
+ *
+ * @example
+ * ```typescript
+ * // Ollama
+ * const config: CustomLlmConfig = {
+ *   name: "ollama",
+ *   model: "llama3",
+ *   baseURL: "http://localhost:11434/v1"
+ * };
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Azure OpenAI
+ * const config: CustomLlmConfig = {
+ *   name: "azure",
+ *   model: "gpt-4",
+ *   baseURL: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+ *   headers: { "api-key": process.env.AZURE_API_KEY },
+ *   queryParams: { "api-version": "2024-02-01" }
+ * };
+ * ```
+ *
+ * @see {@link BaseProviderConfig} for inherited options
+ * @see {@link createCustomLlm} for the factory function
+ */
+export interface CustomLlmConfig extends BaseProviderConfig {
+  /**
+   * Provider name for identification in logs and error messages.
+   *
+   * Used to generate error codes like `OLLAMA_ERROR` or `AZURE_ERROR`.
+   *
+   * @defaultValue "CUSTOM"
+   * @example "ollama"
+   * @example "azure"
+   * @example "vllm"
+   */
+  name?: string;
+
+  /**
+   * Additional HTTP headers to include in all requests.
+   *
+   * Useful for custom authentication schemes or provider-specific headers.
+   *
+   * @example
+   * ```typescript
+   * headers: {
+   *   "api-key": process.env.AZURE_API_KEY,
+   *   "X-Custom-Header": "value"
+   * }
+   * ```
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Query parameters to append to all API requests.
+   *
+   * Required by some providers like Azure OpenAI for API versioning.
+   *
+   * @example
+   * ```typescript
+   * queryParams: {
+   *   "api-version": "2024-02-01"
+   * }
+   * ```
+   */
+  queryParams?: Record<string, string>;
+
+  /**
+   * Additional options to include in the request body.
+   *
+   * These are spread into the chat completion request, allowing
+   * provider-specific parameters beyond the standard OpenAI API.
+   *
+   * @example
+   * ```typescript
+   * providerOptions: {
+   *   temperature: 0.7,
+   *   custom_field: "value"
+   * }
+   * ```
+   */
+  providerOptions?: Record<string, unknown>;
+}
+
+// =============================================================================
 // Streaming Types (shared)
 // =============================================================================
 

--- a/tests/providers/custom/custom-llm.test.ts
+++ b/tests/providers/custom/custom-llm.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "bun:test";
+import { CustomLlm } from "../../../src/providers/custom/custom-llm";
+
+describe("CustomLlm", () => {
+  describe("supportedModels", () => {
+    it("has static supportedModels property", () => {
+      expect(CustomLlm.supportedModels).toBeDefined();
+      expect(Array.isArray(CustomLlm.supportedModels)).toBe(true);
+    });
+
+    it("accepts any model format", () => {
+      const testModels = [
+        "llama3",
+        "gpt-4",
+        "my-custom-model",
+        "meta-llama/Llama-3-8b",
+        "anthropic/claude-sonnet-4",
+        "model-with-numbers-123",
+        "model_with_underscores",
+      ];
+
+      for (const model of testModels) {
+        const matches = CustomLlm.supportedModels.some((pattern) => {
+          if (pattern instanceof RegExp) return pattern.test(model);
+          return pattern === model;
+        });
+        expect(matches).toBe(true);
+      }
+    });
+  });
+
+  describe("constructor", () => {
+    it("creates instance with minimal config", () => {
+      const llm = new CustomLlm({
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+      });
+      expect(llm.model).toBe("llama3");
+    });
+
+    it("creates instance with full config", () => {
+      const llm = new CustomLlm({
+        name: "ollama",
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+        apiKey: "test-key",
+        timeout: 30000,
+        maxRetries: 3,
+        headers: { "X-Custom": "value" },
+        queryParams: { "api-version": "2024-02-01" },
+        providerOptions: { temperature: 0.7 },
+      });
+      expect(llm.model).toBe("llama3");
+    });
+
+    it("handles empty apiKey", () => {
+      const llm = new CustomLlm({
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+      });
+      expect(llm.model).toBe("llama3");
+    });
+  });
+
+  describe("queryParams handling", () => {
+    it("appends query params to baseURL", () => {
+      // We can't directly access the client, but we can verify the instance is created
+      const llm = new CustomLlm({
+        model: "gpt-4",
+        baseURL: "https://api.example.com/v1",
+        queryParams: { "api-version": "2024-02-01" },
+      });
+      expect(llm.model).toBe("gpt-4");
+    });
+
+    it("handles baseURL with existing query params", () => {
+      const llm = new CustomLlm({
+        model: "gpt-4",
+        baseURL: "https://api.example.com/v1?existing=param",
+        queryParams: { "api-version": "2024-02-01" },
+      });
+      expect(llm.model).toBe("gpt-4");
+    });
+
+    it("handles empty queryParams", () => {
+      const llm = new CustomLlm({
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+        queryParams: {},
+      });
+      expect(llm.model).toBe("llama3");
+    });
+  });
+
+  describe("error prefix", () => {
+    it("uses custom name for error prefix", () => {
+      const llm = new CustomLlm({
+        name: "my-provider",
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+      });
+      // Error prefix is used internally, verified through error handling
+      expect(llm.model).toBe("llama3");
+    });
+
+    it("defaults to CUSTOM when name not provided", () => {
+      const llm = new CustomLlm({
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+      });
+      expect(llm.model).toBe("llama3");
+    });
+
+    it("sanitizes special characters in name", () => {
+      const llm = new CustomLlm({
+        name: "my-custom.provider",
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+      });
+      expect(llm.model).toBe("llama3");
+    });
+  });
+
+  describe("connect", () => {
+    it("throws error indicating connect is not supported", async () => {
+      const llm = new CustomLlm({
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+      });
+
+      const request = {
+        contents: [],
+        liveConnectConfig: {},
+        toolsDict: {},
+      } as Parameters<typeof llm.connect>[0];
+
+      expect(llm.connect(request)).rejects.toThrow(
+        "does not support bidirectional streaming",
+      );
+    });
+  });
+});

--- a/tests/providers/custom/factory.test.ts
+++ b/tests/providers/custom/factory.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "bun:test";
+import { createCustomLlm, Custom } from "../../../src/providers/custom/factory";
+import { CustomLlm } from "../../../src/providers/custom/custom-llm";
+
+describe("createCustomLlm", () => {
+  it("creates a CustomLlm instance", () => {
+    const llm = createCustomLlm({
+      model: "llama3",
+      baseURL: "http://localhost:11434/v1",
+    });
+    expect(llm).toBeInstanceOf(CustomLlm);
+    expect(llm.model).toBe("llama3");
+  });
+
+  it("passes all config options", () => {
+    const llm = createCustomLlm({
+      name: "ollama",
+      model: "llama3",
+      baseURL: "http://localhost:11434/v1",
+      apiKey: "test-key",
+      timeout: 30000,
+      maxRetries: 3,
+      headers: { "X-Custom": "value" },
+      queryParams: { "api-version": "2024-02-01" },
+      providerOptions: { temperature: 0.7 },
+    });
+    expect(llm).toBeInstanceOf(CustomLlm);
+    expect(llm.model).toBe("llama3");
+  });
+
+  describe("common use cases", () => {
+    it("works for Ollama", () => {
+      const llm = createCustomLlm({
+        name: "ollama",
+        model: "llama3",
+        baseURL: "http://localhost:11434/v1",
+      });
+      expect(llm.model).toBe("llama3");
+    });
+
+    it("works for vLLM", () => {
+      const llm = createCustomLlm({
+        name: "vllm",
+        model: "meta-llama/Llama-3-8b",
+        baseURL: "http://localhost:8000/v1",
+      });
+      expect(llm.model).toBe("meta-llama/Llama-3-8b");
+    });
+
+    it("works for Azure OpenAI", () => {
+      const llm = createCustomLlm({
+        name: "azure",
+        model: "gpt-4",
+        baseURL:
+          "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+        apiKey: "azure-key",
+        headers: { "api-key": "azure-key" },
+        queryParams: { "api-version": "2024-02-01" },
+      });
+      expect(llm.model).toBe("gpt-4");
+    });
+
+    it("works for LM Studio", () => {
+      const llm = createCustomLlm({
+        name: "lmstudio",
+        model: "local-model",
+        baseURL: "http://localhost:1234/v1",
+      });
+      expect(llm.model).toBe("local-model");
+    });
+  });
+});
+
+describe("Custom", () => {
+  it("creates a CustomLlm instance", () => {
+    const llm = Custom("llama3", {
+      baseURL: "http://localhost:11434/v1",
+    });
+    expect(llm).toBeInstanceOf(CustomLlm);
+    expect(llm.model).toBe("llama3");
+  });
+
+  it("accepts model as first argument", () => {
+    const llm = Custom("my-model", {
+      baseURL: "http://localhost:8000/v1",
+    });
+    expect(llm.model).toBe("my-model");
+  });
+
+  it("passes all config options", () => {
+    const llm = Custom("gpt-4", {
+      name: "azure",
+      baseURL: "https://my-resource.openai.azure.com/openai/deployments/gpt-4",
+      apiKey: "azure-key",
+      headers: { "api-key": "azure-key" },
+      queryParams: { "api-version": "2024-02-01" },
+      providerOptions: { temperature: 0.7 },
+    });
+    expect(llm).toBeInstanceOf(CustomLlm);
+    expect(llm.model).toBe("gpt-4");
+  });
+
+  it("provides shorthand for simple cases", () => {
+    // Minimal usage
+    const llm = Custom("llama3", {
+      baseURL: "http://localhost:11434/v1",
+    });
+    expect(llm.model).toBe("llama3");
+  });
+});
+
+describe("export consistency", () => {
+  it("createCustomLlm and Custom produce equivalent results", () => {
+    const llm1 = createCustomLlm({
+      name: "test",
+      model: "llama3",
+      baseURL: "http://localhost:11434/v1",
+      apiKey: "key",
+    });
+
+    const llm2 = Custom("llama3", {
+      name: "test",
+      baseURL: "http://localhost:11434/v1",
+      apiKey: "key",
+    });
+
+    expect(llm1.model).toBe(llm2.model);
+    expect(llm1).toBeInstanceOf(CustomLlm);
+    expect(llm2).toBeInstanceOf(CustomLlm);
+  });
+});


### PR DESCRIPTION
## Summary

Rename the custom provider to remove OpenAI-specific naming, following industry best practices where the chat completions API standard is now universal.

## Changes

| Before | After |
|--------|-------|
| `OpenAICompatibleProvider` | `CustomLlm` |
| `createOpenAICompatible()` | `createCustomLlm()` |
| `OpenAICompatibleConfig` | `CustomLlmConfig` |
| `src/providers/openai-compatible/` | `src/providers/custom/` |

## Motivation

1. The chat completions API standard has become universal (not just OpenAI)
2. Many providers (Ollama, vLLM, LM Studio) are not "OpenAI" but use the same format
3. Google ADK uses simpler, more generic naming conventions
4. Follows the pattern used by Vercel AI SDK's `customProvider()`

## Breaking Changes

```typescript
// Before
import { createOpenAICompatible, OpenAICompatibleProvider } from 'adk-llm-bridge';

// After
import { createCustomLlm, CustomLlm } from 'adk-llm-bridge';
```

The `Custom()` shorthand alias remains unchanged.

## Checklist

- [x] TypeScript types updated
- [x] Tests updated and passing (79 tests)
- [x] Documentation updated (README.md)
- [x] CI passes (typecheck, lint, test, build)

## Related

ADR: `/Users/alejandrosanchez/.claude/plans/adr-rename-custom-provider.md`