### PR TITLE
FEAT: Enhance handling of large integers in JSON parsing and streaming responses

### DIFF
--- a/src/converters/response.ts
+++ b/src/converters/response.ts
@@ -211,8 +211,11 @@ export function createStreamAccumulator(): StreamAccumulator {
 /**
  * Safely parses a JSON string, returning an empty object on failure.
  *
- * Used for parsing function call arguments which may be malformed
- * in edge cases.
+ * Pre-processes the JSON string to convert large integers (17+ digits) to
+ * strings before parsing, preventing IEEE 754 double precision loss.
+ * Numbers with 17+ digits exceed Number.MAX_SAFE_INTEGER (16 digits), so
+ * they are silently rounded by JSON.parse — this is especially problematic
+ * for IDs like Zoho Desk ticket IDs (19 digits).
  *
  * @param str - The JSON string to parse
  * @returns The parsed object, or empty object if parsing fails
@@ -221,7 +224,14 @@ export function createStreamAccumulator(): StreamAccumulator {
  */
 function safeJsonParse(str: string): Record<string, unknown> {
   try {
-    return JSON.parse(str);
+    // Pre-process: wrap large integers (17+ digits) in quotes to prevent
+    // IEEE 754 precision loss. The pattern matches integers that appear as
+    // JSON values (preceded by :, [, or , and followed by ,, ], or }).
+    const safe = str.replace(
+      /([:\[,])\s*(-?\d{17,})(?=\s*[,\]\}])/g,
+      (_, delimiter, num) => `${delimiter} "${num}"`,
+    );
+    return JSON.parse(safe);
   } catch {
     return {};
   }


### PR DESCRIPTION
## Description
This pull request addresses a critical issue with parsing large integer values (such as 19-digit ticket IDs) from LLM tool call arguments, ensuring they are preserved as strings to prevent silent rounding errors due to JavaScript's number precision limits. The changes implement a preprocessing step in the JSON parsing logic to wrap large integers in quotes, and add comprehensive tests to verify correct behavior for both standard and streamed responses.

**Precision-safe JSON parsing for tool call arguments:**
- Updated the `safeJsonParse` function in both `src/converters/response.ts` and `src/providers/anthropic/converters/response.ts` to pre-process JSON strings, wrapping integers with 17 or more digits in quotes before parsing, preventing loss of precision for large IDs (e.g., Zoho Desk ticket IDs) [[1]](diffhunk://#diff-a91dec3e5fbd8864b1c69b597cc9e0e70a01e804c31e93cf3d34d814cdc2a1adL214-R218) [[2]](diffhunk://#diff-a91dec3e5fbd8864b1c69b597cc9e0e70a01e804c31e93cf3d34d814cdc2a1adL224-R234) [[3]](diffhunk://#diff-f946887e97a0ea0f5c642585cf73427865b621767e2c25cd76472bee9ae64ef2R233-R249).

**Anthropic provider integration:**
- Modified the Anthropic provider's `singleResponse` method to use the streaming API (`messages.stream()`) instead of the standard API (`messages.create()`), ensuring that tool-call arguments are parsed by the new precision-safe logic before any potential rounding by the SDK.

**Test coverage for large integer handling:**
- Added tests to `tests/converters/response.test.ts` for both standard and streamed tool call arguments, verifying that large integer IDs are preserved as strings [[1]](diffhunk://#diff-90a7e30fe85fff8c4407ac9b6aa88c9d51c446daa2597d2f646c527a14a1ccb9R104-R140) [[2]](diffhunk://#diff-90a7e30fe85fff8c4407ac9b6aa88c9d51c446daa2597d2f646c527a14a1ccb9R207-R222).
- Added a similar test to `tests/providers/anthropic/converters/response.test.ts` to ensure streamed tool call arguments from Anthropic are also handled correctly.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] I have run `bun run ci` and all checks pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed

## Related Issues
Fixes #(issue number)
