### PR TITLE
Fix NodeNext declaration import paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "build": "bun run scripts/build.ts && bun run build:types",
-    "build:types": "bunx tsc --project tsconfig.build.json",
+    "build:types": "bunx tsc --project tsconfig.build.json && bun run scripts/fix-declaration-imports.mjs",
     "test": "bun test",
     "typecheck": "bunx tsc --noEmit",
     "typecheck:all": "bunx tsc --noEmit -p tsconfig.test.json",

--- a/scripts/fix-declaration-imports.mjs
+++ b/scripts/fix-declaration-imports.mjs
@@ -1,0 +1,77 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DIST_DIR = resolve("dist");
+const RELATIVE_SPECIFIER_RE =
+  /(\bfrom\s+["']|import\s*\(\s*["'])(\.{1,2}\/[^"']+)(["'])/g;
+
+function hasExplicitExtension(specifier) {
+  return extname(specifier) !== "";
+}
+
+function toJsSpecifier(declarationFile, specifier) {
+  if (hasExplicitExtension(specifier)) {
+    return specifier;
+  }
+
+  const declarationDir = dirname(declarationFile);
+  const target = resolve(declarationDir, specifier);
+
+  if (existsSync(`${target}.d.ts`)) {
+    return `${specifier}.js`;
+  }
+
+  if (existsSync(join(target, "index.d.ts"))) {
+    return `${specifier}/index.js`;
+  }
+
+  return specifier;
+}
+
+export function rewriteDeclarationImports(declarationFile, source) {
+  return source.replace(
+    RELATIVE_SPECIFIER_RE,
+    (_match, prefix, specifier, suffix) =>
+      `${prefix}${toJsSpecifier(declarationFile, specifier)}${suffix}`
+  );
+}
+
+async function listDeclarationFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listDeclarationFiles(path)));
+    } else if (entry.isFile() && entry.name.endsWith(".d.ts")) {
+      files.push(path);
+    }
+  }
+
+  return files;
+}
+
+export async function fixDeclarationImports(distDir = DIST_DIR) {
+  const files = await listDeclarationFiles(distDir);
+
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    const next = rewriteDeclarationImports(file, source);
+    if (next !== source) {
+      await writeFile(file, next);
+    }
+  }
+
+  return files.length;
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  const count = await fixDeclarationImports();
+  console.log(`Fixed relative imports in ${count} declaration file(s)`);
+}

--- a/tests/declaration-imports.test.js
+++ b/tests/declaration-imports.test.js
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { fixDeclarationImports } from "../scripts/fix-declaration-imports.mjs";
+
+let tempDir;
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("fixDeclarationImports", () => {
+  test("adds .js to declaration imports that resolve to files", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "adk-llm-bridge-dts-"));
+    await mkdir(join(tempDir, "converters"), { recursive: true });
+    const indexPath = join(tempDir, "index.d.ts");
+
+    await writeFile(
+      indexPath,
+      'export { convertRequest } from "./converters/request";\n',
+    );
+    await writeFile(join(tempDir, "converters", "request.d.ts"), "");
+
+    await fixDeclarationImports(tempDir);
+
+    await expect(readFile(indexPath, "utf8")).resolves.toBe(
+      'export { convertRequest } from "./converters/request.js";\n',
+    );
+  });
+
+  test("adds /index.js to declaration imports that resolve to directories", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "adk-llm-bridge-dts-"));
+    await mkdir(join(tempDir, "providers", "openai"), { recursive: true });
+    const indexPath = join(tempDir, "index.d.ts");
+
+    await writeFile(
+      indexPath,
+      'export { OpenAI } from "./providers/openai";\n',
+    );
+    await writeFile(join(tempDir, "providers", "openai", "index.d.ts"), "");
+
+    await fixDeclarationImports(tempDir);
+
+    await expect(readFile(indexPath, "utf8")).resolves.toBe(
+      'export { OpenAI } from "./providers/openai/index.js";\n',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a declaration post-build step that rewrites extensionless relative `.d.ts` imports to `.js` or `/index.js`
- wire the rewrite into `build:types`
- add Bun tests covering file and directory declaration specifier rewrites

Fixes #69.

## Verification
- `npx --yes bun install --frozen-lockfile --ignore-scripts` (used because local Windows image lacks VS C++ build tools for sqlite3 lifecycle scripts)
- `npx --yes bun test tests/declaration-imports.test.js`
- `npx --yes bun run typecheck:all`
- `npx --yes bun run lint`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`
