### PR TITLE
chore: release 0.5.1

### DIFF
--- a/examples/basic-agent-ai-gateway/package.json
+++ b/examples/basic-agent-ai-gateway/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@google/adk": "^0.5.0",
-    "adk-llm-bridge": "^0.5.0",
+    "adk-llm-bridge": "^0.5.1",
     "zod": "^3.24.0"
   }
 }

--- a/examples/basic-agent-anthropic/package.json
+++ b/examples/basic-agent-anthropic/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@google/adk": "^0.5.0",
-    "adk-llm-bridge": "^0.5.0",
+    "adk-llm-bridge": "^0.5.1",
     "zod": "^3.24.0"
   }
 }

--- a/examples/basic-agent-lmstudio/package.json
+++ b/examples/basic-agent-lmstudio/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@google/adk": "^0.5.0",
-    "adk-llm-bridge": "^0.5.0",
+    "adk-llm-bridge": "^0.5.1",
     "zod": "^3.24.0"
   }
 }

--- a/examples/basic-agent-openai/package.json
+++ b/examples/basic-agent-openai/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@google/adk": "^0.5.0",
-    "adk-llm-bridge": "^0.5.0",
+    "adk-llm-bridge": "^0.5.1",
     "zod": "^3.24.0"
   }
 }

--- a/examples/basic-agent-openrouter/package.json
+++ b/examples/basic-agent-openrouter/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@google/adk": "^0.5.0",
-    "adk-llm-bridge": "^0.5.0",
+    "adk-llm-bridge": "^0.5.1",
     "zod": "^3.24.0"
   }
 }

--- a/examples/basic-agent-xai/package.json
+++ b/examples/basic-agent-xai/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@google/adk": "^0.5.0",
-    "adk-llm-bridge": "^0.5.0",
+    "adk-llm-bridge": "^0.5.1",
     "zod": "^3.24.0"
   }
 }

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@google/adk": "^0.5.0",
     "@types/express": "^5.0.0",
-    "adk-llm-bridge": "^0.5.0",
+    "adk-llm-bridge": "^0.5.1",
     "express": "^5.0.0",
     "zod": "^3.24.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adk-llm-bridge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Use any LLM with Google ADK TypeScript - supports AI Gateway, OpenRouter, and 100+ models",
   "keywords": [
     "adk",


### PR DESCRIPTION
## Summary

- Bump `adk-llm-bridge` package version to `0.5.1`.
- Update all examples to depend on `adk-llm-bridge@^0.5.1`.
- Keep the release PR scoped to the already-merged PR #70 changes on `main`.

## Validation

- `bun install --frozen-lockfile`
- `bun run ci`
- `npm pack --dry-run`
- Verified npm latest remains `0.5.0` before publish.
- Verified `v0.5.1` tag does not exist before release.
- Installed the generated `adk-llm-bridge-0.5.1.tgz` into a temporary copy of `examples/basic-agent-anthropic` and confirmed `@google/adk` is deduped.