### PR TITLE
feat: pass ADK native model config through to all providers

### DIFF
--- a/src/converters/request.ts
+++ b/src/converters/request.ts
@@ -14,8 +14,77 @@
  */
 
 import type { LlmRequest } from "@google/adk";
-import type { Content, Part } from "@google/genai";
+import {
+  type Content,
+  FunctionCallingConfigMode,
+  type Part,
+} from "@google/genai";
 import type OpenAI from "openai";
+import { normalizeSchema } from "./schema";
+
+/**
+ * Extracts the bare model name from a possibly provider-prefixed id.
+ *
+ * OpenAI-compatible providers accept ids like `gpt-5`, `openai/gpt-5`,
+ * `o3-mini`, or `x-ai/grok-4`. For feature gating we only care about the final
+ * segment (the actual model name), lowercased for case-insensitive matching.
+ *
+ * @internal
+ */
+function bareModelName(model: string | undefined): string {
+  if (!model) return "";
+  const slash = model.lastIndexOf("/");
+  const name = slash >= 0 ? model.slice(slash + 1) : model;
+  return name.toLowerCase();
+}
+
+/**
+ * Detects OpenAI reasoning-style models that reject `max_tokens` and require
+ * `max_completion_tokens` instead.
+ *
+ * These are the GPT-5 family and the o-series (o1/o3/o4...). Sending plain
+ * `max_tokens` to these models returns a 400 ("Unsupported parameter:
+ * 'max_tokens' ... Use 'max_completion_tokens' instead"). Non-OpenAI providers
+ * (xAI Grok, OpenRouter, etc.) continue to use `max_tokens`.
+ *
+ * @internal
+ */
+export function usesMaxCompletionTokens(model: string | undefined): boolean {
+  const name = bareModelName(model);
+  if (!name) return false;
+  // GPT-5 family (gpt-5, gpt-5-mini, gpt-5.1, gpt-5-codex, ...).
+  if (/^gpt-5/.test(name)) return true;
+  // o-series reasoning models: o1, o3, o4 (and -mini/-pro variants).
+  // Guard against false positives like "gpt-4o" by anchoring at the start.
+  if (/^o[134](?:-|$)/.test(name)) return true;
+  return false;
+}
+
+/**
+ * Detects models that accept the `reasoning_effort` parameter.
+ *
+ * Reasoning-capable models only — sending `reasoning_effort` to a plain chat
+ * model (gpt-4.1, gpt-4o, grok-4 non-reasoning, ...) returns a 400
+ * ("Unsupported value: 'reasoning_effort' ..."). Covers:
+ * - OpenAI GPT-5 family + o-series (same set as {@link usesMaxCompletionTokens})
+ * - xAI Grok reasoning variants (e.g. `grok-4-fast-reasoning`,
+ *   `grok-3-mini`/`grok-3-mini-fast`, which expose reasoning_effort)
+ *
+ * When in doubt this returns false, so reasoning_effort is dropped rather than
+ * risking a 400 on a non-reasoning model.
+ *
+ * @internal
+ */
+export function supportsReasoningEffort(model: string | undefined): boolean {
+  const name = bareModelName(model);
+  if (!name) return false;
+  if (usesMaxCompletionTokens(name)) return true;
+  // xAI Grok reasoning variants expose reasoning_effort. Grok-3 mini models and
+  // the explicit "*-reasoning" Grok variants reason; plain grok-4 does not.
+  if (/^grok-3-mini/.test(name)) return true;
+  if (/^grok-.*reasoning/.test(name)) return true;
+  return false;
+}
 
 /**
  * Result of converting an ADK LlmRequest to OpenAI format.
@@ -38,6 +107,21 @@ export interface ConvertedRequest {
    * Converted from ADK function declarations with schema normalization.
    */
   tools?: OpenAI.ChatCompletionTool[];
+
+  /**
+   * Generation + structured-output parameters mapped from `config`.
+   *
+   * Built from a strict allowlist (temperature, top_p, max_tokens, etc. plus
+   * response_format). Spread directly into the chat completion request body.
+   */
+  params?: Record<string, unknown>;
+
+  /**
+   * OpenAI `tool_choice` mapped from `config.toolConfig.functionCallingConfig`.
+   *
+   * Only meaningful when tools are present.
+   */
+  toolChoice?: OpenAI.ChatCompletionToolChoiceOption;
 }
 
 /**
@@ -89,7 +173,10 @@ export interface ConvertedRequest {
  * // tools[0].function.parameters.type = "object" (normalized from "OBJECT")
  * ```
  */
-export function convertRequest(llmRequest: LlmRequest): ConvertedRequest {
+export function convertRequest(
+  llmRequest: LlmRequest,
+  model?: string,
+): ConvertedRequest {
   const messages: OpenAI.ChatCompletionMessageParam[] = [];
 
   const systemContent = extractSystemInstruction(llmRequest);
@@ -101,7 +188,288 @@ export function convertRequest(llmRequest: LlmRequest): ConvertedRequest {
     processContent(content, messages);
   }
 
-  return { messages, tools: convertTools(llmRequest) };
+  const tools = convertTools(llmRequest);
+
+  // Prefer the caller-supplied model (the LLM instance's resolved model id),
+  // falling back to the request's model field. Used for provider feature gating
+  // (max_completion_tokens vs max_tokens, reasoning_effort eligibility).
+  const resolvedModel = model ?? llmRequest.model;
+
+  const params: Record<string, unknown> = {
+    ...convertGenerationConfig(llmRequest, resolvedModel),
+    ...convertStructuredOutput(llmRequest),
+    ...convertReasoningConfig(llmRequest, resolvedModel),
+    ...convertLogprobsConfig(llmRequest, resolvedModel),
+  };
+
+  return {
+    messages,
+    tools,
+    params: Object.keys(params).length ? params : undefined,
+    toolChoice: convertToolChoice(llmRequest),
+  };
+}
+
+/**
+ * Maps ADK generation config to OpenAI chat completion params.
+ *
+ * Uses a STRICT allowlist — the ADK `config` is never blind-spread, so
+ * Gemini-only knobs (safetySettings, responseModalities, etc.) cannot leak
+ * into the OpenAI request body. `topK` is intentionally dropped (no OpenAI
+ * Chat Completions equivalent).
+ *
+ * @param req - The LLM request
+ * @returns An OpenAI params object, or `{}` when no fields are set
+ */
+export function convertGenerationConfig(
+  req: LlmRequest,
+  model?: string,
+): Record<string, unknown> {
+  const config = req.config;
+  if (!config) return {};
+
+  const resolvedModel = model ?? req.model;
+  const reasoningModel = usesMaxCompletionTokens(resolvedModel);
+
+  const params: Record<string, unknown> = {};
+
+  // OpenAI reasoning models (gpt-5*, o-series) reject sampling controls
+  // ENTIRELY: temperature and top_p both return a 400 ("Unsupported value")
+  // even when set to their defaults. They only accept reasoning_effort/verbosity
+  // for steering. Drop temperature/top_p for reasoning models; keep them for
+  // every other provider/model (xAI, OpenRouter, plain OpenAI chat).
+  if (config.temperature !== undefined && !reasoningModel)
+    params.temperature = config.temperature;
+  if (config.topP !== undefined && !reasoningModel) params.top_p = config.topP;
+  if (config.maxOutputTokens !== undefined) {
+    // OpenAI reasoning models (gpt-5*, o-series) REJECT max_tokens with a 400 —
+    // they require max_completion_tokens (which also covers reasoning tokens).
+    // Everything else (xAI, OpenRouter, plain OpenAI chat models) uses max_tokens.
+    if (reasoningModel) {
+      params.max_completion_tokens = config.maxOutputTokens;
+    } else {
+      params.max_tokens = config.maxOutputTokens;
+    }
+  }
+  // Reasoning models reject sampling knobs like stop/penalties (and often
+  // temperature/top_p), but at minimum stop + the penalties trigger 400s. Keep
+  // them off reasoning models; emit them for everything else.
+  if (config.stopSequences !== undefined && !reasoningModel)
+    params.stop = config.stopSequences;
+  if (config.seed !== undefined) params.seed = config.seed;
+  if (config.presencePenalty !== undefined && !reasoningModel)
+    params.presence_penalty = config.presencePenalty;
+  if (config.frequencyPenalty !== undefined && !reasoningModel)
+    params.frequency_penalty = config.frequencyPenalty;
+  // n>1 stays cosmetic: convertResponse reads choices[0] only.
+  if (config.candidateCount !== undefined) params.n = config.candidateCount;
+  // topK intentionally dropped — no OpenAI Chat Completions equivalent.
+  // Reasoning is handled separately in convertReasoningConfig.
+
+  return params;
+}
+
+/**
+ * Maps ADK `thinkingConfig` to an OpenAI-compatible `reasoning_effort`.
+ *
+ * GPT-5 / o-series and other reasoning-capable OpenAI-compatible models accept
+ * a `reasoning_effort` of "low" | "medium" | "high" on the Chat Completions
+ * body. ADK expresses reasoning intent via `config.thinkingConfig`
+ * (`thinkingBudget`, `includeThoughts`). We map the budget to coarse buckets:
+ *
+ * - budget <= 0 (or `includeThoughts === false` with no budget) -> not emitted
+ * - 0 < budget <= 2048 -> "low"
+ * - 2048 < budget <= 8192 -> "medium"
+ * - budget > 8192 -> "high"
+ * - no budget set (but thinkingConfig present) -> "medium" (sensible default)
+ *
+ * CRITICAL: `reasoning_effort` is only emitted when `thinkingConfig` is present
+ * AND the resolved model is reasoning-capable. gpt-4.1, gpt-4o, plain grok-4,
+ * etc. return a 400 on `reasoning_effort`, so when a model is supplied and it is
+ * NOT reasoning-capable we drop it entirely. When no model is supplied we keep
+ * the legacy thinkingConfig-only behavior (used by callers that gate elsewhere).
+ *
+ * @param req - The LLM request
+ * @param model - The resolved model id (for reasoning-capability gating)
+ * @returns A params object with `reasoning_effort`, or `{}` when not applicable
+ */
+export function convertReasoningConfig(
+  req: LlmRequest,
+  model?: string,
+): Record<string, unknown> {
+  const thinking = req.config?.thinkingConfig;
+  if (!thinking) return {};
+
+  // When a model is known, only emit reasoning_effort for reasoning-capable
+  // models. If no model is supplied, fall back to the request's model field;
+  // if that is also absent, keep the legacy behavior (emit).
+  const resolvedModel = model ?? req.model;
+  if (resolvedModel && !supportsReasoningEffort(resolvedModel)) return {};
+
+  const budget = thinking.thinkingBudget;
+
+  // An explicit budget of 0 disables thinking — emit nothing so the model is
+  // left at its own default behavior rather than forced to reason.
+  if (budget !== undefined && budget !== null && budget <= 0) return {};
+
+  let effort: "low" | "medium" | "high";
+  if (budget === undefined || budget === null) {
+    effort = "medium";
+  } else if (budget <= 2048) {
+    effort = "low";
+  } else if (budget <= 8192) {
+    effort = "medium";
+  } else {
+    effort = "high";
+  }
+
+  return { reasoning_effort: effort };
+}
+
+/**
+ * Maps ADK logprobs config to OpenAI-compatible `logprobs` / `top_logprobs`.
+ *
+ * ADK (@google/genai GenerateContentConfig) expresses logprobs intent via:
+ * - `responseLogprobs` (boolean) — request log probabilities of output tokens
+ * - `logprobs` (number) — how many top alternatives to return per token
+ *
+ * OpenAI Chat Completions uses:
+ * - `logprobs` (boolean) — return log probabilities of output tokens
+ * - `top_logprobs` (integer 0-5) — top-N alternatives per token; requires
+ *   `logprobs: true`
+ *
+ * Mapping rules (each field only emitted when set, never blind-spread):
+ * - `responseLogprobs === true` -> `logprobs: true`
+ * - `logprobs` (number) -> `top_logprobs: <n>`. Because OpenAI requires
+ *   `logprobs: true` whenever `top_logprobs` is present, we also force
+ *   `logprobs: true` so the count is never sent in isolation (which providers
+ *   reject).
+ *
+ * CRITICAL: nothing is emitted unless one of these ADK fields is explicitly
+ * set, so non-logprobs requests are completely unaffected.
+ *
+ * OpenAI reasoning models (gpt-5*, o-series) do NOT support logprobs at all —
+ * sending `logprobs`/`top_logprobs` returns a 400. When the resolved model is a
+ * reasoning model these fields are dropped (rather than risking the 400). They
+ * are still emitted for every other model that requested them.
+ *
+ * @param req - The LLM request
+ * @param model - The resolved model id (for reasoning-model gating)
+ * @returns A params object with `logprobs`/`top_logprobs`, or `{}` when not set
+ */
+export function convertLogprobsConfig(
+  req: LlmRequest,
+  model?: string,
+): Record<string, unknown> {
+  const config = req.config;
+  if (!config) return {};
+
+  // Reasoning models reject logprobs/top_logprobs outright — drop them.
+  const resolvedModel = model ?? req.model;
+  if (usesMaxCompletionTokens(resolvedModel)) return {};
+
+  const params: Record<string, unknown> = {};
+
+  if (config.responseLogprobs === true) {
+    params.logprobs = true;
+  }
+  if (config.logprobs !== undefined && config.logprobs !== null) {
+    params.top_logprobs = config.logprobs;
+    // top_logprobs requires logprobs:true on OpenAI-compatible APIs.
+    params.logprobs = true;
+  }
+
+  return params;
+}
+
+/**
+ * Maps ADK `functionCallingConfig` to an OpenAI `tool_choice`.
+ *
+ * - AUTO -> "auto"
+ * - NONE -> "none"
+ * - ANY / VALIDATED -> "required" (or a specific function when exactly one
+ *   allowedFunctionName is given)
+ *
+ * @param req - The LLM request
+ * @returns The OpenAI tool_choice, or undefined when no toolConfig is present
+ */
+export function convertToolChoice(
+  req: LlmRequest,
+): OpenAI.ChatCompletionToolChoiceOption | undefined {
+  const fcc = req.config?.toolConfig?.functionCallingConfig;
+  if (!fcc) return undefined;
+
+  switch (fcc.mode) {
+    case FunctionCallingConfigMode.AUTO:
+      return "auto";
+    case FunctionCallingConfigMode.NONE:
+      return "none";
+    case FunctionCallingConfigMode.ANY:
+    case FunctionCallingConfigMode.VALIDATED: {
+      const allowed = fcc.allowedFunctionNames;
+      if (allowed?.length === 1) {
+        return { type: "function", function: { name: allowed[0] } };
+      }
+      return "required";
+    }
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Maps ADK structured-output config to an OpenAI `response_format`.
+ *
+ * - `responseJsonSchema` -> json_schema (passthrough, already JSON Schema)
+ * - `responseSchema` -> json_schema (normalized from Gemini types)
+ * - `responseMimeType === "application/json"` only -> json_object
+ *
+ * `strict` is intentionally `false`. OpenAI strict mode imposes hard structural
+ * requirements (every object must set `additionalProperties: false` and list
+ * ALL properties in `required`) that Gemini-derived / arbitrary caller schemas
+ * routinely violate, producing a 400. Lenient (`strict: false`) accepts partial
+ * schemas, which is the lower-risk default for caller-supplied schemas.
+ *
+ * @param req - The LLM request
+ * @returns A params object with `response_format`, or `{}` when not applicable
+ */
+export function convertStructuredOutput(
+  req: LlmRequest,
+): Record<string, unknown> {
+  const config = req.config;
+  if (!config) return {};
+
+  if (config.responseJsonSchema) {
+    return {
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "response",
+          strict: false,
+          schema: config.responseJsonSchema,
+        },
+      },
+    };
+  }
+
+  if (config.responseSchema) {
+    return {
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "response",
+          strict: false,
+          schema: normalizeSchema(config.responseSchema) ?? {},
+        },
+      },
+    };
+  }
+
+  if (config.responseMimeType === "application/json") {
+    return { response_format: { type: "json_object" } };
+  }
+
+  return {};
 }
 
 /**
@@ -154,11 +522,14 @@ function processContent(
   if (!content.parts?.length) return;
 
   const texts: string[] = [];
+  const images: OpenAI.ChatCompletionContentPartImage[] = [];
   const calls: { id: string; name: string; arguments: string }[] = [];
   const responses: { id: string; content: string }[] = [];
 
   for (const part of content.parts) {
     if (part.text) texts.push(part.text);
+    const image = partToOpenAIImage(part);
+    if (image) images.push(image);
     if (part.functionCall) {
       if (!part.functionCall.id) {
         console.warn(
@@ -176,9 +547,7 @@ function processContent(
     }
     if (part.functionResponse) {
       if (!part.functionResponse.id) {
-        console.warn(
-          "[adk-llm-bridge] functionResponse missing id",
-        );
+        console.warn("[adk-llm-bridge] functionResponse missing id");
       }
       responses.push({
         id: part.functionResponse.id ?? "",
@@ -188,8 +557,17 @@ function processContent(
   }
 
   if (content.role === "user") {
-    if (texts.length)
+    if (images.length) {
+      // Mixed multimodal content: text + image parts.
+      const contentParts: OpenAI.ChatCompletionContentPart[] = [];
+      for (const text of texts) {
+        contentParts.push({ type: "text", text });
+      }
+      contentParts.push(...images);
+      messages.push({ role: "user", content: contentParts });
+    } else if (texts.length) {
       messages.push({ role: "user", content: texts.join("\n") });
+    }
     for (const r of responses) {
       messages.push({ role: "tool", tool_call_id: r.id, content: r.content });
     }
@@ -212,7 +590,103 @@ function processContent(
 }
 
 /**
+ * Maps an ADK Part with image media to an OpenAI image content part.
+ *
+ * - `inlineData` (base64) -> `data:` URL
+ * - `fileData` -> the http(s) URI (gs:// and other schemes are dropped)
+ *
+ * Non-image media (audio/video) is dropped with a single warning. Returns
+ * undefined when the part carries no usable image.
+ *
+ * @internal
+ */
+function partToOpenAIImage(
+  part: Part,
+): OpenAI.ChatCompletionContentPartImage | undefined {
+  const inline = part.inlineData;
+  if (inline?.data && inline.mimeType) {
+    if (!inline.mimeType.startsWith("image/")) {
+      console.warn(
+        `[adk-llm-bridge] dropping unsupported inlineData mime type: ${inline.mimeType}`,
+      );
+      return undefined;
+    }
+    return {
+      type: "image_url",
+      image_url: { url: `data:${inline.mimeType};base64,${inline.data}` },
+    };
+  }
+
+  const file = part.fileData;
+  if (file?.fileUri) {
+    const isImage = !file.mimeType || file.mimeType.startsWith("image/");
+    if (
+      file.fileUri.startsWith("http://") ||
+      file.fileUri.startsWith("https://")
+    ) {
+      if (!isImage) {
+        console.warn(
+          `[adk-llm-bridge] dropping unsupported fileData mime type: ${file.mimeType}`,
+        );
+        return undefined;
+      }
+      return { type: "image_url", image_url: { url: file.fileUri } };
+    }
+    // gs:// and other non-fetchable schemes are dropped cleanly.
+    console.warn(
+      `[adk-llm-bridge] dropping non-http fileData URI: ${file.fileUri}`,
+    );
+  }
+
+  return undefined;
+}
+
+/**
+ * Gemini-only built-in tool group keys.
+ *
+ * These are server-side tools (grounding, code execution, retrieval, etc.) that
+ * only Gemini/Vertex executes. On OpenAI-compatible providers they have no
+ * equivalent, so they are skipped cleanly (never forwarded) and the user is
+ * warned once per request that the named built-in(s) won't run.
+ *
+ * @internal
+ */
+const GEMINI_ONLY_TOOL_KEYS = [
+  "googleSearch",
+  "googleSearchRetrieval",
+  "codeExecution",
+  "urlContext",
+  "retrieval",
+  "googleMaps",
+  "enterpriseWebSearch",
+  "computerUse",
+  "fileSearch",
+  "parallelAiSearch",
+  "mcpServers",
+] as const;
+
+/**
+ * Collects the names of Gemini-only built-in tools present in a tool group.
+ *
+ * @param group - A single ADK tool group object
+ * @returns The Gemini-only keys present on the group (e.g. ["googleSearch"])
+ *
+ * @internal
+ */
+function collectGeminiOnlyToolNames(group: Record<string, unknown>): string[] {
+  return GEMINI_ONLY_TOOL_KEYS.filter(
+    (key) => group[key] !== undefined && group[key] !== null,
+  );
+}
+
+/**
  * Converts ADK tool declarations to OpenAI format.
+ *
+ * Only `functionDeclarations` are forwarded. Gemini-only built-in tool groups
+ * (googleSearch, codeExecution, urlContext, retrieval, googleMaps, etc.) are
+ * skipped without crashing; if any are present a SINGLE warning is emitted
+ * naming the dropped built-in tool(s) so users know grounding / code execution
+ * will not run on a non-Gemini provider.
  *
  * @param req - The LLM request containing tool definitions
  * @returns Array of OpenAI tool objects, or undefined if no tools
@@ -226,6 +700,7 @@ function convertTools(
   if (!adkTools?.length) return undefined;
 
   const tools: OpenAI.ChatCompletionTool[] = [];
+  const droppedBuiltins = new Set<string>();
 
   for (const group of adkTools) {
     if (
@@ -250,52 +725,22 @@ function convertTools(
         });
       }
     }
-  }
 
-  return tools.length ? tools : undefined;
-}
-
-/**
- * Normalizes Gemini-style schema to OpenAI-style schema.
- *
- * Converts UPPERCASE type names (Gemini format) to lowercase (OpenAI format).
- * For example: "OBJECT" → "object", "STRING" → "string".
- *
- * @param schema - The schema object to normalize
- * @returns The normalized schema, or undefined if input is invalid
- *
- * @internal
- *
- * @example
- * ```typescript
- * normalizeSchema({ type: "OBJECT", properties: { name: { type: "STRING" } } });
- * // Returns: { type: "object", properties: { name: { type: "string" } } }
- * ```
- */
-function normalizeSchema(schema: unknown): Record<string, unknown> | undefined {
-  if (!schema || typeof schema !== "object") return undefined;
-
-  const result: Record<string, unknown> = {};
-  const input = schema as Record<string, unknown>;
-
-  for (const [key, value] of Object.entries(input)) {
-    if (key === "type" && typeof value === "string") {
-      // Convert UPPERCASE type to lowercase (OBJECT -> object, STRING -> string, etc.)
-      result[key] = value.toLowerCase();
-    } else if (
-      typeof value === "object" &&
-      value !== null &&
-      !Array.isArray(value)
-    ) {
-      // Recursively normalize nested objects (like properties)
-      result[key] = normalizeSchema(value);
-    } else if (Array.isArray(value)) {
-      // Handle arrays (like required)
-      result[key] = value;
-    } else {
-      result[key] = value;
+    // Skip (and record) any Gemini-only built-in tools on this group.
+    for (const name of collectGeminiOnlyToolNames(
+      group as Record<string, unknown>,
+    )) {
+      droppedBuiltins.add(name);
     }
   }
 
-  return result;
+  if (droppedBuiltins.size > 0) {
+    console.warn(
+      `[adk-llm-bridge] dropping Gemini-only built-in tool(s) not supported on this provider: ${[
+        ...droppedBuiltins,
+      ].join(", ")}`,
+    );
+  }
+
+  return tools.length ? tools : undefined;
 }

--- a/src/converters/response.ts
+++ b/src/converters/response.ts
@@ -14,10 +14,35 @@
  */
 
 import type { LlmResponse } from "@google/adk";
-import type { Part } from "@google/genai";
+import { FinishReason, type Part } from "@google/genai";
 import type OpenAI from "openai";
 import type { StreamAccumulator, StreamChunkResult } from "../types";
 import { safeJsonParse } from "../utils";
+
+/**
+ * Maps an OpenAI `finish_reason` to the ADK/genai {@link FinishReason} enum.
+ *
+ * @param reason - The OpenAI finish reason (may be null/undefined)
+ * @returns The mapped FinishReason, or undefined when unknown
+ *
+ * @internal
+ */
+function mapOpenAIFinishReason(
+  reason: string | null | undefined,
+): FinishReason | undefined {
+  switch (reason) {
+    case "stop":
+    case "tool_calls":
+    case "function_call":
+      return FinishReason.STOP;
+    case "length":
+      return FinishReason.MAX_TOKENS;
+    case "content_filter":
+      return FinishReason.SAFETY;
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Converts an OpenAI chat completion response to ADK LlmResponse format.
@@ -57,6 +82,14 @@ export function convertResponse(response: OpenAI.ChatCompletion): LlmResponse {
 
   const parts: Part[] = [];
 
+  // Surface provider reasoning text as a thought part before the answer text.
+  // OpenAI/OpenRouter use `reasoning`; xAI/DeepSeek use `reasoning_content`.
+  // These fields are not in the OpenAI SDK types, so read them defensively.
+  const reasoning = extractReasoning(choice.message);
+  if (reasoning) {
+    parts.push({ text: reasoning, thought: true });
+  }
+
   if (choice.message.content) {
     parts.push({ text: choice.message.content });
   }
@@ -75,14 +108,63 @@ export function convertResponse(response: OpenAI.ChatCompletion): LlmResponse {
   return {
     content: parts.length ? { role: "model", parts } : undefined,
     turnComplete: true,
+    finishReason: mapOpenAIFinishReason(choice.finish_reason),
     usageMetadata: response.usage
-      ? {
-          promptTokenCount: response.usage.prompt_tokens,
-          candidatesTokenCount: response.usage.completion_tokens,
-          totalTokenCount: response.usage.total_tokens,
-        }
+      ? buildUsageMetadata(response.usage)
+      : undefined,
+    // Surface per-token logprobs (when the caller requested them) under a
+    // namespaced key so downstream code can read them off the response.
+    customMetadata: choice.logprobs?.content?.length
+      ? { logprobs: choice.logprobs }
       : undefined,
   };
+}
+
+/**
+ * Reads provider reasoning text from a chat message/delta.
+ *
+ * Tolerates the two field names emitted across the OpenAI-compatible family
+ * (neither is present in the OpenAI SDK types):
+ * - `reasoning` (OpenAI, some OpenRouter models)
+ * - `reasoning_content` (xAI Grok, DeepSeek, some OpenRouter models)
+ *
+ * @returns The reasoning string when present and non-empty, otherwise undefined
+ *
+ * @internal
+ */
+function extractReasoning(source: unknown): string | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  const obj = source as Record<string, unknown>;
+  const value =
+    typeof obj.reasoning_content === "string"
+      ? obj.reasoning_content
+      : typeof obj.reasoning === "string"
+        ? obj.reasoning
+        : undefined;
+  return value ? value : undefined;
+}
+
+/**
+ * Maps an OpenAI usage object to ADK `usageMetadata`.
+ *
+ * `completion_tokens_details.reasoning_tokens` (present on reasoning models) is
+ * surfaced as `thoughtsTokenCount` when available.
+ *
+ * @internal
+ */
+function buildUsageMetadata(
+  usage: OpenAI.CompletionUsage,
+): NonNullable<LlmResponse["usageMetadata"]> {
+  const metadata: NonNullable<LlmResponse["usageMetadata"]> = {
+    promptTokenCount: usage.prompt_tokens,
+    candidatesTokenCount: usage.completion_tokens,
+    totalTokenCount: usage.total_tokens,
+  };
+  const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens;
+  if (reasoningTokens !== undefined && reasoningTokens !== null) {
+    metadata.thoughtsTokenCount = reasoningTokens;
+  }
+  return metadata;
 }
 
 /**
@@ -125,20 +207,33 @@ export function convertStreamChunk(
   chunk: OpenAI.ChatCompletionChunk,
   acc: StreamAccumulator,
 ): StreamChunkResult {
+  // The final usage chunk (stream_options.include_usage) has empty choices and
+  // carries the cumulative token usage — capture it without completing.
+  if (chunk.usage) {
+    acc.usage = buildUsageMetadata(chunk.usage);
+  }
+
   const choice = chunk.choices[0];
   if (!choice) return { isComplete: false };
 
   const delta = choice.delta;
 
+  // A single chunk can legitimately carry a reasoning delta AND a content delta
+  // AND/OR tool_call fragments AND/OR a finish_reason. Process every facet of
+  // the chunk; never early-return on the first one seen.
+  const partialParts: Part[] = [];
+
+  // Stream provider reasoning deltas immediately as thought parts and keep a
+  // running copy so the final accumulated response can include them too.
+  const reasoningDelta = extractReasoning(delta);
+  if (reasoningDelta) {
+    acc.reasoning += reasoningDelta;
+    partialParts.push({ text: reasoningDelta, thought: true });
+  }
+
   if (delta?.content) {
     acc.text += delta.content;
-    return {
-      response: {
-        content: { role: "model", parts: [{ text: delta.content }] },
-        partial: true,
-      },
-      isComplete: false,
-    };
+    partialParts.push({ text: delta.content });
   }
 
   if (delta?.tool_calls) {
@@ -157,6 +252,7 @@ export function convertStreamChunk(
 
   if (choice.finish_reason) {
     const parts: Part[] = [];
+    if (acc.reasoning) parts.push({ text: acc.reasoning, thought: true });
     if (acc.text) parts.push({ text: acc.text });
     for (const tc of Array.from(acc.toolCalls.values())) {
       if (tc.name) {
@@ -170,15 +266,34 @@ export function convertStreamChunk(
       }
     }
 
+    const finishReason = mapOpenAIFinishReason(choice.finish_reason);
+    const usageMetadata = acc.usage;
+
     acc.text = "";
+    acc.reasoning = "";
     acc.toolCalls.clear();
+    acc.usage = undefined;
 
     return {
       response: {
         content: parts.length ? { role: "model", parts } : undefined,
         turnComplete: true,
+        finishReason,
+        usageMetadata,
       },
       isComplete: true,
+    };
+  }
+
+  // No finish in this chunk: surface any streamed text/reasoning parts as a
+  // partial response (tool_call fragments are accumulated, not streamed).
+  if (partialParts.length) {
+    return {
+      response: {
+        content: { role: "model", parts: partialParts },
+        partial: true,
+      },
+      isComplete: false,
     };
   }
 
@@ -207,5 +322,5 @@ export function convertStreamChunk(
  * ```
  */
 export function createStreamAccumulator(): StreamAccumulator {
-  return { text: "", toolCalls: new Map() };
+  return { text: "", reasoning: "", toolCalls: new Map() };
 }

--- a/src/converters/schema.ts
+++ b/src/converters/schema.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Shared schema normalization.
+ *
+ * Converts Gemini-style schemas (UPPERCASE type names) to the lowercase
+ * JSON-Schema-style types expected by OpenAI and Anthropic. Used by tool
+ * conversion and structured-output mapping across providers.
+ *
+ * @module converters/schema
+ */
+
+/**
+ * Normalizes a Gemini-style schema to a JSON-Schema-style schema.
+ *
+ * Converts UPPERCASE type names (Gemini format) to lowercase, recursing into
+ * nested objects and preserving arrays. Already-lowercase types are left
+ * unchanged, making the function idempotent.
+ *
+ * @param schema - The schema object to normalize
+ * @returns The normalized schema, or undefined if the input is not an object
+ *
+ * @example
+ * ```typescript
+ * normalizeSchema({ type: "OBJECT", properties: { name: { type: "STRING" } } });
+ * // Returns: { type: "object", properties: { name: { type: "string" } } }
+ * ```
+ */
+export function normalizeSchema(
+  schema: unknown,
+): Record<string, unknown> | undefined {
+  if (!schema || typeof schema !== "object") return undefined;
+
+  const result: Record<string, unknown> = {};
+  const input = schema as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(input)) {
+    if (key === "type" && typeof value === "string") {
+      // Convert UPPERCASE type to lowercase (OBJECT -> object, STRING -> string)
+      result[key] = value.toLowerCase();
+    } else if (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      // Recursively normalize nested objects (like properties)
+      result[key] = normalizeSchema(value);
+    } else if (Array.isArray(value)) {
+      // Handle arrays (like required) — recurse into object entries (e.g. items[])
+      result[key] = value.map((item) =>
+        typeof item === "object" && item !== null && !Array.isArray(item)
+          ? normalizeSchema(item)
+          : item,
+      );
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -38,8 +38,8 @@
  */
 
 export { BaseProviderLlm } from "./base-provider-llm";
-export { resolveConfig, resolveEnvVar } from "./config-resolver";
 export type { ResolvedConfig } from "./config-resolver";
+export { resolveConfig, resolveEnvVar } from "./config-resolver";
 export { createProviderClass, createProviderFactory } from "./create-provider";
 export { createRegisterFunction } from "./create-register";
 export type { OpenAIClientConfig } from "./openai-compatible-llm";

--- a/src/core/openai-compatible-llm.ts
+++ b/src/core/openai-compatible-llm.ts
@@ -145,12 +145,15 @@ export class OpenAICompatibleLlm extends BaseProviderLlm {
     stream = false,
   ): AsyncGenerator<LlmResponse, void> {
     try {
-      const { messages, tools } = convertRequest(llmRequest);
+      const { messages, tools, params, toolChoice } = convertRequest(
+        llmRequest,
+        this.model,
+      );
 
       if (stream) {
-        yield* this.streamResponse(messages, tools);
+        yield* this.streamResponse(messages, tools, params, toolChoice);
       } else {
-        yield await this.singleResponse(messages, tools);
+        yield await this.singleResponse(messages, tools, params, toolChoice);
       }
     } catch (error) {
       yield this.createErrorResponse(error, this.getErrorPrefix());
@@ -160,11 +163,15 @@ export class OpenAICompatibleLlm extends BaseProviderLlm {
   private async singleResponse(
     messages: OpenAI.ChatCompletionMessageParam[],
     tools?: OpenAI.ChatCompletionTool[],
+    params?: Record<string, unknown>,
+    toolChoice?: OpenAI.ChatCompletionToolChoiceOption,
   ): Promise<LlmResponse> {
     const response = await this.client.chat.completions.create({
       model: this.model,
       messages,
+      ...params,
       ...(tools?.length ? { tools } : {}),
+      ...(toolChoice && tools?.length ? { tool_choice: toolChoice } : {}),
       ...this.getProviderRequestOptions(),
     });
     return convertResponse(response);
@@ -173,21 +180,44 @@ export class OpenAICompatibleLlm extends BaseProviderLlm {
   private async *streamResponse(
     messages: OpenAI.ChatCompletionMessageParam[],
     tools?: OpenAI.ChatCompletionTool[],
+    params?: Record<string, unknown>,
+    toolChoice?: OpenAI.ChatCompletionToolChoiceOption,
   ): AsyncGenerator<LlmResponse, void> {
     const stream = await this.client.chat.completions.create({
       model: this.model,
       messages,
       stream: true,
+      stream_options: { include_usage: true },
+      ...params,
       ...(tools?.length ? { tools } : {}),
+      ...(toolChoice && tools?.length ? { tool_choice: toolChoice } : {}),
       ...this.getProviderRequestOptions(),
     });
 
     const acc = createStreamAccumulator();
 
+    // OpenAI with stream_options.include_usage emits the cumulative usage in a
+    // SEPARATE, choices-empty chunk that arrives AFTER the finish chunk. If we
+    // broke the loop on finish we would drop that usage. Instead, stash the
+    // final (isComplete) response, keep draining the stream so the trailing
+    // usage chunk is read into acc.usage, then merge and yield it last.
+    let finalResponse: LlmResponse | undefined;
+
     for await (const chunk of stream) {
       const { response, isComplete } = convertStreamChunk(chunk, acc);
+      if (isComplete) {
+        // Hold the final response; do not break — a usage-only chunk may follow.
+        finalResponse = response;
+        continue;
+      }
       if (response) yield response;
-      if (isComplete) break;
+    }
+
+    if (finalResponse) {
+      // acc.usage is repopulated by a post-finish usage chunk (if any); prefer
+      // it over whatever was captured before finish.
+      if (acc.usage) finalResponse.usageMetadata = acc.usage;
+      yield finalResponse;
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,9 +199,15 @@ export {
 // Converters (for building custom providers)
 // =============================================================================
 
-export { convertRequest } from "./converters/request";
+export {
+  convertGenerationConfig,
+  convertRequest,
+  convertStructuredOutput,
+  convertToolChoice,
+} from "./converters/request";
 export {
   convertResponse,
   convertStreamChunk,
   createStreamAccumulator,
 } from "./converters/response";
+export { normalizeSchema } from "./converters/schema";

--- a/src/providers/anthropic/anthropic-llm.ts
+++ b/src/providers/anthropic/anthropic-llm.ts
@@ -20,6 +20,7 @@ import { DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT } from "../../constants";
 import { BaseProviderLlm } from "../../core/base-provider-llm";
 import type { AnthropicProviderConfig } from "../../types";
 import { clampPositive } from "../../utils/validate";
+
 /** Environment variable names for Anthropic configuration. */
 const ANTHROPIC_ENV = { API_KEY: "ANTHROPIC_API_KEY" } as const;
 
@@ -28,7 +29,12 @@ const DEFAULT_ANTHROPIC_MAX_TOKENS = 4096;
 
 /** Model patterns for Anthropic models. Matches claude-* */
 export const ANTHROPIC_MODEL_PATTERNS = [/claude-.*/];
-import { convertAnthropicRequest } from "./converters/request";
+
+import type { AnthropicGenerationParams } from "./converters/request";
+import {
+  applyAnthropicPromptCaching,
+  convertAnthropicRequest,
+} from "./converters/request";
 import {
   convertAnthropicResponse,
   convertAnthropicStreamEvent,
@@ -89,6 +95,13 @@ export class AnthropicLlm extends BaseProviderLlm {
   private readonly maxTokens: number;
 
   /**
+   * Whether opt-in prompt caching is enabled for this instance.
+   *
+   * @private
+   */
+  private readonly promptCaching: boolean;
+
+  /**
    * Creates a new Anthropic LLM instance.
    *
    * @param config - Configuration options for the Anthropic provider
@@ -121,10 +134,15 @@ export class AnthropicLlm extends BaseProviderLlm {
     }
 
     this.maxTokens = clampPositive(
-      config.maxTokens ?? globalConfig.maxTokens ?? DEFAULT_ANTHROPIC_MAX_TOKENS,
+      config.maxTokens ??
+        globalConfig.maxTokens ??
+        DEFAULT_ANTHROPIC_MAX_TOKENS,
       DEFAULT_ANTHROPIC_MAX_TOKENS,
       1,
     );
+
+    this.promptCaching =
+      config.promptCaching ?? globalConfig.promptCaching ?? false;
 
     this.client = new AnthropicSDK({
       apiKey,
@@ -156,12 +174,19 @@ export class AnthropicLlm extends BaseProviderLlm {
     stream = false,
   ): AsyncGenerator<LlmResponse, void> {
     try {
-      const { messages, system, tools } = convertAnthropicRequest(llmRequest);
+      const { messages, system, tools, params, toolChoice } =
+        convertAnthropicRequest(llmRequest);
 
       if (stream) {
-        yield* this.streamResponse(messages, system, tools);
+        yield* this.streamResponse(messages, system, tools, params, toolChoice);
       } else {
-        yield await this.singleResponse(messages, system, tools);
+        yield await this.singleResponse(
+          messages,
+          system,
+          tools,
+          params,
+          toolChoice,
+        );
       }
     } catch (error) {
       yield this.createErrorResponse(error, "ANTHROPIC");
@@ -171,19 +196,67 @@ export class AnthropicLlm extends BaseProviderLlm {
   /**
    * Builds the shared request parameters for the Anthropic API.
    *
+   * Per-request `config.maxOutputTokens` (params.max_tokens) overrides the
+   * instance default. Anthropic requires `max_tokens` to always be present.
+   *
    * @private
    */
   private buildRequestParams(
     messages: AnthropicSDK.MessageParam[],
     system: string | undefined,
     tools: AnthropicSDK.Tool[] | undefined,
-  ) {
+    params?: AnthropicGenerationParams,
+    toolChoice?: AnthropicSDK.ToolChoice,
+  ): AnthropicSDK.MessageCreateParamsNonStreaming {
+    const { max_tokens, ...sampling } = params ?? {};
+
+    // Anthropic requires max_tokens to be strictly greater than the thinking
+    // budget. When extended thinking is enabled, raise max_tokens if the
+    // configured/default value would not leave room for the response.
+    let resolvedMaxTokens = max_tokens ?? this.maxTokens;
+    if (sampling.thinking?.type === "enabled") {
+      const minMaxTokens = sampling.thinking.budget_tokens + 1;
+      if (resolvedMaxTokens <= sampling.thinking.budget_tokens) {
+        resolvedMaxTokens = minMaxTokens;
+      }
+    }
+
+    // Opt-in prompt caching: attach ephemeral cache breakpoints to the static
+    // prefix (system block + last tool). When disabled, the system string and
+    // tools pass through unchanged (no behavior change).
+    let systemField: AnthropicSDK.MessageCreateParams["system"] = system;
+    let toolsField = tools;
+    if (this.promptCaching) {
+      const cached = applyAnthropicPromptCaching(system, tools);
+      if (cached.system) systemField = cached.system;
+      if (cached.tools) toolsField = cached.tools;
+    }
+
+    // thinking + forced tool_choice -> 400. Anthropic only allows tool_choice
+    // auto/none when extended thinking is enabled; { type: "any" } and
+    // { type: "tool", name } both error. When thinking is on, downgrade any
+    // forced choice (structured-output's forced json_output tool, or a
+    // functionCallingConfig ANY/VALIDATED mapping) to { type: "auto" } so
+    // thinking + forced-tool never co-occur. Structured output therefore
+    // becomes best-effort under thinking; "none" is preserved (still valid).
+    let resolvedToolChoice = toolChoice;
+    if (
+      sampling.thinking?.type === "enabled" &&
+      (toolChoice?.type === "any" || toolChoice?.type === "tool")
+    ) {
+      resolvedToolChoice = { type: "auto" };
+    }
+
     return {
       model: this.model,
-      max_tokens: this.maxTokens,
+      max_tokens: resolvedMaxTokens,
       messages,
-      ...(system ? { system } : {}),
-      ...(tools?.length ? { tools } : {}),
+      ...sampling,
+      ...(systemField ? { system: systemField } : {}),
+      ...(toolsField?.length ? { tools: toolsField } : {}),
+      ...(resolvedToolChoice && toolsField?.length
+        ? { tool_choice: resolvedToolChoice }
+        : {}),
     };
   }
 
@@ -196,9 +269,11 @@ export class AnthropicLlm extends BaseProviderLlm {
     messages: AnthropicSDK.MessageParam[],
     system: string | undefined,
     tools: AnthropicSDK.Tool[] | undefined,
+    params?: AnthropicGenerationParams,
+    toolChoice?: AnthropicSDK.ToolChoice,
   ): Promise<LlmResponse> {
     const response = await this.client.messages.create(
-      this.buildRequestParams(messages, system, tools),
+      this.buildRequestParams(messages, system, tools, params, toolChoice),
     );
     return convertAnthropicResponse(response);
   }
@@ -212,9 +287,11 @@ export class AnthropicLlm extends BaseProviderLlm {
     messages: AnthropicSDK.MessageParam[],
     system: string | undefined,
     tools: AnthropicSDK.Tool[] | undefined,
+    params?: AnthropicGenerationParams,
+    toolChoice?: AnthropicSDK.ToolChoice,
   ): AsyncGenerator<LlmResponse, void> {
     const stream = this.client.messages.stream(
-      this.buildRequestParams(messages, system, tools),
+      this.buildRequestParams(messages, system, tools, params, toolChoice),
     );
 
     const acc = createAnthropicStreamAccumulator();

--- a/src/providers/anthropic/converters/request.ts
+++ b/src/providers/anthropic/converters/request.ts
@@ -20,7 +20,15 @@
 
 import type Anthropic from "@anthropic-ai/sdk";
 import type { LlmRequest } from "@google/adk";
-import type { Content, Part } from "@google/genai";
+import {
+  type Content,
+  FunctionCallingConfigMode,
+  type Part,
+} from "@google/genai";
+import { normalizeSchema as normalizeSharedSchema } from "../../../converters/schema";
+
+/** Name of the synthetic tool used to emulate structured JSON output. */
+const JSON_OUTPUT_TOOL_NAME = "json_output";
 
 /**
  * Result of converting an ADK LlmRequest to Anthropic format.
@@ -40,6 +48,98 @@ export interface ConvertedAnthropicRequest {
    * Array of Anthropic-format tool definitions.
    */
   tools?: Anthropic.Tool[];
+
+  /**
+   * Generation parameters mapped from `config` (temperature, top_p, top_k,
+   * max_tokens, stop_sequences). Built from a strict allowlist.
+   */
+  params?: AnthropicGenerationParams;
+
+  /**
+   * Anthropic `tool_choice` mapped from `config.toolConfig.functionCallingConfig`
+   * (or forced when structured output is requested). Only meaningful with tools.
+   */
+  toolChoice?: Anthropic.ToolChoice;
+}
+
+/**
+ * Result of applying opt-in prompt caching to a converted request.
+ *
+ * The `system` field is widened to Anthropic's block-array form because
+ * `cache_control` can only be attached to a content block, not to a bare
+ * string.
+ */
+export interface CachedAnthropicPrefix {
+  /**
+   * System instruction as an array of text blocks, with `cache_control` on
+   * the (single) block. Undefined when there is no system instruction.
+   */
+  system?: Anthropic.TextBlockParam[];
+
+  /**
+   * Tool definitions with `cache_control` on the last tool. Undefined when
+   * there are no tools.
+   */
+  tools?: Anthropic.Tool[];
+}
+
+/** Anthropic ephemeral cache breakpoint. */
+const EPHEMERAL_CACHE_CONTROL = { type: "ephemeral" } as const;
+
+/**
+ * Applies opt-in Anthropic prompt caching to a converted request's prefix.
+ *
+ * Marks the largely-static prefix (system instruction + tool schemas) as
+ * cacheable by attaching `cache_control: { type: "ephemeral" }` to the system
+ * block and to the last tool definition. The system string is widened to a
+ * single-element text block array (Anthropic requires a block to carry
+ * `cache_control`).
+ *
+ * This is a pure transform; the caller decides whether to invoke it based on
+ * the bridge's `promptCaching` instance config. It never mutates its inputs.
+ *
+ * @param system - The converted system instruction string (if any)
+ * @param tools - The converted tool definitions (if any)
+ * @returns System blocks and tools carrying cache breakpoints
+ */
+export function applyAnthropicPromptCaching(
+  system: string | undefined,
+  tools: Anthropic.Tool[] | undefined,
+): CachedAnthropicPrefix {
+  const result: CachedAnthropicPrefix = {};
+
+  if (system) {
+    result.system = [
+      { type: "text", text: system, cache_control: EPHEMERAL_CACHE_CONTROL },
+    ];
+  }
+
+  if (tools?.length) {
+    const last = tools.length - 1;
+    result.tools = tools.map((tool, i) =>
+      i === last ? { ...tool, cache_control: EPHEMERAL_CACHE_CONTROL } : tool,
+    );
+  }
+
+  return result;
+}
+
+/** Minimum thinking budget Anthropic accepts (must be >= 1024). */
+const MIN_THINKING_BUDGET = 1024;
+
+/** Default thinking budget when thinkingConfig is set without a budget. */
+const DEFAULT_THINKING_BUDGET = 1024;
+
+/**
+ * Anthropic generation params built from ADK config (strict allowlist).
+ */
+export interface AnthropicGenerationParams {
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  max_tokens?: number;
+  stop_sequences?: string[];
+  thinking?: Anthropic.ThinkingConfigEnabled;
 }
 
 /**
@@ -78,10 +178,187 @@ export function convertAnthropicRequest(
     });
   }
 
+  let tools = convertTools(llmRequest);
+  let toolChoice = convertAnthropicToolChoice(llmRequest);
+
+  // Structured output: inject a forced single output tool. It takes precedence
+  // over an explicit tool_choice EXCEPT when the caller set mode=NONE
+  // (tool_choice none) — forcing the json_output tool there would contradict an
+  // explicit "do not call tools" instruction and 400. Respect NONE.
+  const structured = convertAnthropicStructuredOutput(llmRequest);
+  if (structured && toolChoice?.type !== "none") {
+    tools = [...(tools ?? []), structured.tool];
+    toolChoice = structured.toolChoice;
+  }
+
   return {
     messages,
     system: system || undefined,
-    tools: convertTools(llmRequest),
+    tools,
+    params: convertAnthropicGenerationConfig(llmRequest),
+    toolChoice,
+  };
+}
+
+/**
+ * Maps ADK generation config to Anthropic message params (strict allowlist).
+ *
+ * Anthropic's temperature range is 0..1 (vs OpenAI's 0..2), so values >1 are
+ * clamped. `seed`, penalties, and `candidateCount` have no Anthropic
+ * equivalent and are dropped cleanly.
+ *
+ * @param req - The LLM request
+ * @returns Anthropic generation params, or undefined when no fields are set
+ */
+export function convertAnthropicGenerationConfig(
+  req: LlmRequest,
+): AnthropicGenerationParams | undefined {
+  const config = req.config;
+  if (!config) return undefined;
+
+  const params: AnthropicGenerationParams = {};
+
+  if (config.temperature !== undefined) {
+    params.temperature = Math.min(config.temperature, 1);
+  }
+  if (config.topP !== undefined) params.top_p = config.topP;
+  if (config.topK !== undefined) params.top_k = config.topK;
+  if (config.maxOutputTokens !== undefined)
+    params.max_tokens = config.maxOutputTokens;
+  if (config.stopSequences !== undefined)
+    params.stop_sequences = config.stopSequences;
+
+  // Extended thinking: only emitted when ADK thinkingConfig is present, so
+  // non-reasoning requests are unaffected. Anthropic requires a budget >= 1024.
+  if (config.thinkingConfig) {
+    const budget = config.thinkingConfig.thinkingBudget;
+    params.thinking = {
+      type: "enabled",
+      budget_tokens:
+        budget !== undefined && budget >= MIN_THINKING_BUDGET
+          ? budget
+          : DEFAULT_THINKING_BUDGET,
+    };
+  }
+
+  reconcileAnthropicSamplingParams(params);
+
+  return Object.keys(params).length ? params : undefined;
+}
+
+/**
+ * Reconciles Anthropic sampling-parameter combinations the API rejects.
+ *
+ * Anthropic enforces two mutually-exclusive constraints that 332 shape-only
+ * unit tests don't catch because each field is valid in isolation:
+ *
+ * 1. **thinking + sampling → 400.** When extended thinking is enabled,
+ *    Anthropic forbids `top_p`, `top_k`, and any `temperature` other than 1.
+ *    We drop `top_p`/`top_k` and omit a `temperature !== 1` (Anthropic uses
+ *    temperature 1 internally with thinking).
+ * 2. **temperature + top_p → 400 (Claude 4.5).** The API rejects sending both;
+ *    we prefer `temperature` and drop `top_p` when both are present.
+ *
+ * Mutates `params` in place. Applied after all fields are populated so the
+ * thinking constraint (which subsumes the temp/top_p one) takes precedence.
+ *
+ * @internal
+ */
+function reconcileAnthropicSamplingParams(
+  params: AnthropicGenerationParams,
+): void {
+  if (params.thinking?.type === "enabled") {
+    // Thinking forbids top_p/top_k and a non-1 temperature.
+    params.top_p = undefined;
+    params.top_k = undefined;
+    if (params.temperature !== undefined && params.temperature !== 1) {
+      params.temperature = undefined;
+    }
+    // Strip the keys so the emitted body never carries undefined values.
+    if (params.top_p === undefined) delete params.top_p;
+    if (params.top_k === undefined) delete params.top_k;
+    if (params.temperature === undefined) delete params.temperature;
+    return;
+  }
+
+  // Outside thinking: never send temperature and top_p together. Prefer
+  // temperature (Anthropic's recommended primary control) and drop top_p.
+  if (params.temperature !== undefined && params.top_p !== undefined) {
+    delete params.top_p;
+  }
+}
+
+/**
+ * Maps ADK `functionCallingConfig` to an Anthropic `tool_choice`.
+ *
+ * - AUTO -> { type: "auto" }
+ * - NONE -> { type: "none" }
+ * - ANY / VALIDATED -> { type: "any" } (or { type: "tool", name } for a single
+ *   allowedFunctionName)
+ *
+ * @param req - The LLM request
+ * @returns The Anthropic tool_choice, or undefined when no toolConfig is present
+ */
+export function convertAnthropicToolChoice(
+  req: LlmRequest,
+): Anthropic.ToolChoice | undefined {
+  const fcc = req.config?.toolConfig?.functionCallingConfig;
+  if (!fcc) return undefined;
+
+  switch (fcc.mode) {
+    case FunctionCallingConfigMode.AUTO:
+      return { type: "auto" };
+    case FunctionCallingConfigMode.NONE:
+      return { type: "none" };
+    case FunctionCallingConfigMode.ANY:
+    case FunctionCallingConfigMode.VALIDATED: {
+      const allowed = fcc.allowedFunctionNames;
+      if (allowed?.length === 1) {
+        return { type: "tool", name: allowed[0] };
+      }
+      return { type: "any" };
+    }
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Emulates structured JSON output on Anthropic via a forced output tool.
+ *
+ * When `responseSchema`/`responseJsonSchema` is set, a synthetic
+ * `json_output` tool carrying the (normalized) schema is injected and forced
+ * via `tool_choice: { type: "tool", name }`. The model's tool_use input is the
+ * JSON object — surfaced downstream as a functionCall part by the response
+ * converter (acceptable: ADK reads the forced tool args).
+ *
+ * @param req - The LLM request
+ * @returns The injected tool + forced tool_choice, or undefined when N/A
+ */
+export function convertAnthropicStructuredOutput(
+  req: LlmRequest,
+): { tool: Anthropic.Tool; toolChoice: Anthropic.ToolChoice } | undefined {
+  const config = req.config;
+  if (!config) return undefined;
+
+  let schema: Anthropic.Tool.InputSchema | undefined;
+  if (config.responseJsonSchema) {
+    schema = config.responseJsonSchema as Anthropic.Tool.InputSchema;
+  } else if (config.responseSchema) {
+    schema = normalizeSharedSchema(config.responseSchema) as
+      | Anthropic.Tool.InputSchema
+      | undefined;
+  }
+
+  if (!schema) return undefined;
+
+  return {
+    tool: {
+      name: JSON_OUTPUT_TOOL_NAME,
+      description: "Return the response as a structured JSON object.",
+      input_schema: schema,
+    },
+    toolChoice: { type: "tool", name: JSON_OUTPUT_TOOL_NAME },
   };
 }
 
@@ -115,9 +392,24 @@ function processContent(content: Content): Anthropic.MessageParam | null {
   const contentBlocks: Anthropic.ContentBlockParam[] = [];
 
   for (const part of content.parts) {
+    // Extended-thinking round-trip: parts captured from a prior assistant turn
+    // carry { thought: true, thoughtSignature }. They MUST be replayed as
+    // Anthropic thinking/redacted_thinking content blocks (carrying the
+    // signature) — re-sending them as plain text drops the signature and
+    // breaks multi-turn tool+thinking requests with a 400. Handled before the
+    // plain-text branch so a thought part never falls through to `type: text`.
+    if (part.thought) {
+      const block = thoughtPartToAnthropicBlock(part);
+      if (block) contentBlocks.push(block);
+      continue;
+    }
+
     if (part.text) {
       contentBlocks.push({ type: "text", text: part.text });
     }
+
+    const media = partToAnthropicMedia(part);
+    if (media) contentBlocks.push(media);
 
     if (part.functionCall) {
       if (!part.functionCall.id) {
@@ -162,13 +454,173 @@ function processContent(content: Content): Anthropic.MessageParam | null {
 }
 
 /**
+ * Re-emits an ADK thought Part as an Anthropic thinking content block.
+ *
+ * The response converter captures Anthropic thinking blocks as ADK parts:
+ * - `thinking` block  -> { text, thought: true, thoughtSignature: signature }
+ * - `redacted_thinking` block -> { thought: true, thoughtSignature: data } (no text)
+ *
+ * On the request side we reverse that so the assistant turn replays the SIGNED
+ * thinking block Anthropic requires for multi-turn tool+thinking continuations.
+ * A thought part WITH text maps back to a `thinking` block (signature carried on
+ * `signature`); a thought part WITHOUT text maps back to a `redacted_thinking`
+ * block (the opaque encrypted payload carried on `data`).
+ *
+ * A thought part with neither text nor signature carries nothing replayable and
+ * is dropped (returns undefined) rather than emitted as an empty block.
+ *
+ * @internal
+ */
+function thoughtPartToAnthropicBlock(
+  part: Part,
+): Anthropic.ContentBlockParam | undefined {
+  const signature = part.thoughtSignature;
+
+  if (part.text) {
+    // Visible thinking: replay as a signed thinking block. Anthropic requires a
+    // signature on a thinking block; without one there is nothing to replay.
+    if (!signature) return undefined;
+    return { type: "thinking", thinking: part.text, signature };
+  }
+
+  // No text: this came from a redacted_thinking block (opaque encrypted data
+  // stored on thoughtSignature). Replay it as redacted_thinking.
+  if (signature) {
+    return { type: "redacted_thinking", data: signature };
+  }
+
+  return undefined;
+}
+
+/** Anthropic image media types supported for base64 source blocks. */
+const ANTHROPIC_IMAGE_MEDIA_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+/**
+ * Maps an ADK Part with image/document media to an Anthropic content block.
+ *
+ * - `inlineData` image/* (base64) -> image block (base64 source)
+ * - `inlineData` application/pdf -> document block (base64 source)
+ * - `fileData` http(s) image -> image block (url source)
+ * - `fileData` http(s) pdf -> document block (url source)
+ *
+ * gs:// and unsupported media are dropped (with a warning). Returns undefined
+ * when the part carries no usable media.
+ *
+ * @internal
+ */
+function partToAnthropicMedia(
+  part: Part,
+): Anthropic.ContentBlockParam | undefined {
+  const inline = part.inlineData;
+  if (inline?.data && inline.mimeType) {
+    if (ANTHROPIC_IMAGE_MEDIA_TYPES.has(inline.mimeType)) {
+      return {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type:
+            inline.mimeType as Anthropic.Base64ImageSource["media_type"],
+          data: inline.data,
+        },
+      };
+    }
+    if (inline.mimeType === "application/pdf") {
+      return {
+        type: "document",
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          data: inline.data,
+        },
+      };
+    }
+    console.warn(
+      `[adk-llm-bridge] dropping unsupported inlineData mime type: ${inline.mimeType}`,
+    );
+    return undefined;
+  }
+
+  const file = part.fileData;
+  if (file?.fileUri) {
+    const isHttp =
+      file.fileUri.startsWith("http://") || file.fileUri.startsWith("https://");
+    if (!isHttp) {
+      console.warn(
+        `[adk-llm-bridge] dropping non-http fileData URI: ${file.fileUri}`,
+      );
+      return undefined;
+    }
+    if (file.mimeType === "application/pdf") {
+      return {
+        type: "document",
+        source: { type: "url", url: file.fileUri },
+      };
+    }
+    if (!file.mimeType || file.mimeType.startsWith("image/")) {
+      return { type: "image", source: { type: "url", url: file.fileUri } };
+    }
+    console.warn(
+      `[adk-llm-bridge] dropping unsupported fileData mime type: ${file.mimeType}`,
+    );
+  }
+
+  return undefined;
+}
+
+/**
+ * Gemini-only built-in tool group keys.
+ *
+ * These are server-side tools (grounding, code execution, retrieval, etc.) that
+ * only Gemini/Vertex executes. Anthropic has no equivalent, so they are skipped
+ * cleanly (never forwarded) and the user is warned once per request that the
+ * named built-in(s) won't run.
+ *
+ * @internal
+ */
+const GEMINI_ONLY_TOOL_KEYS = [
+  "googleSearch",
+  "googleSearchRetrieval",
+  "codeExecution",
+  "urlContext",
+  "retrieval",
+  "googleMaps",
+  "enterpriseWebSearch",
+  "computerUse",
+  "fileSearch",
+  "parallelAiSearch",
+  "mcpServers",
+] as const;
+
+/**
+ * Collects the names of Gemini-only built-in tools present in a tool group.
+ *
+ * @internal
+ */
+function collectGeminiOnlyToolNames(group: Record<string, unknown>): string[] {
+  return GEMINI_ONLY_TOOL_KEYS.filter(
+    (key) => group[key] !== undefined && group[key] !== null,
+  );
+}
+
+/**
  * Converts ADK tool declarations to Anthropic format.
+ *
+ * Only `functionDeclarations` are forwarded. Gemini-only built-in tool groups
+ * (googleSearch, codeExecution, urlContext, retrieval, googleMaps, etc.) are
+ * skipped without crashing; if any are present a SINGLE warning is emitted
+ * naming the dropped built-in tool(s).
  */
 function convertTools(req: LlmRequest): Anthropic.Tool[] | undefined {
   const adkTools = req.config?.tools;
   if (!adkTools?.length) return undefined;
 
   const tools: Anthropic.Tool[] = [];
+  const droppedBuiltins = new Set<string>();
 
   for (const group of adkTools) {
     if (
@@ -183,46 +635,31 @@ function convertTools(req: LlmRequest): Anthropic.Tool[] | undefined {
         tools.push({
           name: fn.name,
           description: fn.description ?? "",
-          input_schema: normalizeSchema(fn.parameters) ?? {
+          input_schema: (normalizeSharedSchema(fn.parameters) as
+            | Anthropic.Tool.InputSchema
+            | undefined) ?? {
             type: "object",
             properties: {},
           },
         });
       }
     }
-  }
 
-  return tools.length ? tools : undefined;
-}
-
-/**
- * Normalizes Gemini-style schema to Anthropic-style schema.
- *
- * Converts UPPERCASE type names to lowercase.
- */
-function normalizeSchema(
-  schema: unknown,
-): Anthropic.Tool.InputSchema | undefined {
-  if (!schema || typeof schema !== "object") return undefined;
-
-  const result: Record<string, unknown> = {};
-  const input = schema as Record<string, unknown>;
-
-  for (const [key, value] of Object.entries(input)) {
-    if (key === "type" && typeof value === "string") {
-      result[key] = value.toLowerCase();
-    } else if (
-      typeof value === "object" &&
-      value !== null &&
-      !Array.isArray(value)
-    ) {
-      result[key] = normalizeSchema(value);
-    } else if (Array.isArray(value)) {
-      result[key] = value;
-    } else {
-      result[key] = value;
+    // Skip (and record) any Gemini-only built-in tools on this group.
+    for (const name of collectGeminiOnlyToolNames(
+      group as Record<string, unknown>,
+    )) {
+      droppedBuiltins.add(name);
     }
   }
 
-  return result as Anthropic.Tool.InputSchema;
+  if (droppedBuiltins.size > 0) {
+    console.warn(
+      `[adk-llm-bridge] dropping Gemini-only built-in tool(s) not supported on this provider: ${[
+        ...droppedBuiltins,
+      ].join(", ")}`,
+    );
+  }
+
+  return tools.length ? tools : undefined;
 }

--- a/src/providers/anthropic/converters/response.ts
+++ b/src/providers/anthropic/converters/response.ts
@@ -15,8 +15,33 @@
 
 import type Anthropic from "@anthropic-ai/sdk";
 import type { LlmResponse } from "@google/adk";
-import type { Part } from "@google/genai";
+import { FinishReason, type Part } from "@google/genai";
 import { safeJsonParse } from "../../../utils";
+
+/**
+ * Maps an Anthropic `stop_reason` to the ADK/genai {@link FinishReason} enum.
+ *
+ * @param reason - The Anthropic stop reason (may be null/undefined)
+ * @returns The mapped FinishReason, or undefined when unknown
+ *
+ * @internal
+ */
+function mapAnthropicStopReason(
+  reason: string | null | undefined,
+): FinishReason | undefined {
+  switch (reason) {
+    case "end_turn":
+    case "stop_sequence":
+    case "tool_use":
+      return FinishReason.STOP;
+    case "max_tokens":
+      return FinishReason.MAX_TOKENS;
+    case "refusal":
+      return FinishReason.SAFETY;
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Accumulator for Anthropic streaming responses.
@@ -35,6 +60,15 @@ export interface AnthropicStreamAccumulator {
     }
   >;
 
+  /** Accumulated thinking (extended reasoning) blocks, keyed by block index */
+  thinkingBlocks: Map<
+    number,
+    {
+      thinking: string;
+      signature: string;
+    }
+  >;
+
   /** Current content block index being processed */
   currentBlockIndex: number;
 
@@ -43,6 +77,9 @@ export interface AnthropicStreamAccumulator {
 
   /** Output tokens accumulated during streaming */
   outputTokens?: number;
+
+  /** Stop reason captured from the message_delta event */
+  stopReason?: string | null;
 }
 
 /**
@@ -72,6 +109,25 @@ export function convertAnthropicResponse(
       parts.push({ text: block.text });
     }
 
+    // Extended thinking: surface as an ADK thought part. The signature
+    // (encrypted full reasoning) is preserved on thoughtSignature so it can be
+    // echoed back on multi-turn requests.
+    if (block.type === "thinking") {
+      parts.push({
+        text: block.thinking,
+        thought: true,
+        thoughtSignature: block.signature,
+      });
+    }
+
+    // Redacted thinking carries only opaque encrypted data (no signature/text).
+    if (block.type === "redacted_thinking") {
+      parts.push({
+        thought: true,
+        thoughtSignature: block.data,
+      });
+    }
+
     if (block.type === "tool_use") {
       const input =
         typeof block.input === "object" && block.input !== null
@@ -90,6 +146,7 @@ export function convertAnthropicResponse(
   return {
     content: parts.length ? { role: "model", parts } : undefined,
     turnComplete: true,
+    finishReason: mapAnthropicStopReason(message.stop_reason),
     usageMetadata: message.usage
       ? {
           promptTokenCount: message.usage.input_tokens,
@@ -108,9 +165,11 @@ export function createAnthropicStreamAccumulator(): AnthropicStreamAccumulator {
   return {
     text: "",
     toolUses: new Map(),
+    thinkingBlocks: new Map(),
     currentBlockIndex: -1,
     inputTokens: undefined,
     outputTokens: undefined,
+    stopReason: undefined,
   };
 }
 
@@ -139,6 +198,10 @@ export function convertAnthropicStreamEvent(
       if (event.usage?.output_tokens) {
         acc.outputTokens = event.usage.output_tokens;
       }
+      // Capture the stop reason (carried on the message_delta).
+      if (event.delta?.stop_reason) {
+        acc.stopReason = event.delta.stop_reason;
+      }
       return { isComplete: false };
     }
 
@@ -151,6 +214,29 @@ export function convertAnthropicStreamEvent(
           name: event.content_block.name,
           input: "",
         });
+      }
+
+      if (event.content_block.type === "thinking") {
+        acc.thinkingBlocks.set(event.index, {
+          thinking: event.content_block.thinking ?? "",
+          signature: event.content_block.signature ?? "",
+        });
+      }
+
+      // Redacted thinking arrives whole (opaque encrypted data, no deltas).
+      if (event.content_block.type === "redacted_thinking") {
+        return {
+          response: {
+            content: {
+              role: "model",
+              parts: [
+                { thought: true, thoughtSignature: event.content_block.data },
+              ],
+            },
+            partial: true,
+          },
+          isComplete: false,
+        };
       }
 
       return { isComplete: false };
@@ -175,14 +261,61 @@ export function convertAnthropicStreamEvent(
         if (toolUse) {
           toolUse.input += delta.partial_json;
         }
+        return { isComplete: false };
+      }
+
+      if (delta.type === "thinking_delta") {
+        const block = acc.thinkingBlocks.get(event.index) ?? {
+          thinking: "",
+          signature: "",
+        };
+        block.thinking += delta.thinking;
+        acc.thinkingBlocks.set(event.index, block);
+        return {
+          response: {
+            content: {
+              role: "model",
+              parts: [{ text: delta.thinking, thought: true }],
+            },
+            partial: true,
+          },
+          isComplete: false,
+        };
+      }
+
+      // The signature arrives after the thinking text; record it for the final
+      // assembled thought part (carried on thoughtSignature).
+      if (delta.type === "signature_delta") {
+        const block = acc.thinkingBlocks.get(event.index) ?? {
+          thinking: "",
+          signature: "",
+        };
+        block.signature += delta.signature;
+        acc.thinkingBlocks.set(event.index, block);
       }
 
       return { isComplete: false };
     }
 
     case "message_stop": {
-      // Build final response with accumulated content
+      // Build final response with accumulated content. Thinking parts are
+      // emitted first (in block-index order) so the final assistant turn can be
+      // echoed back with signatures intact.
       const parts: Part[] = [];
+
+      for (const index of [...acc.thinkingBlocks.keys()].sort(
+        (a, b) => a - b,
+      )) {
+        const block = acc.thinkingBlocks.get(index);
+        if (!block) continue;
+        parts.push({
+          text: block.thinking,
+          thought: true,
+          ...(block.signature
+            ? { thoughtSignature: block.signature }
+            : undefined),
+        });
+      }
 
       if (acc.text) {
         parts.push({ text: acc.text });
@@ -211,17 +344,22 @@ export function convertAnthropicStreamEvent(
           }
         : undefined;
 
+      const finishReason = mapAnthropicStopReason(acc.stopReason);
+
       // Reset accumulator
       acc.text = "";
       acc.toolUses.clear();
+      acc.thinkingBlocks.clear();
       acc.currentBlockIndex = -1;
       acc.inputTokens = undefined;
       acc.outputTokens = undefined;
+      acc.stopReason = undefined;
 
       return {
         response: {
           content: parts.length ? { role: "model", parts } : undefined,
           turnComplete: true,
+          finishReason,
           usageMetadata,
         },
         isComplete: true,

--- a/src/providers/anthropic/index.ts
+++ b/src/providers/anthropic/index.ts
@@ -12,11 +12,14 @@
 
 import { LLMRegistry } from "@google/adk";
 import { resetProviderConfig, setProviderConfig } from "../../config";
-import type { AnthropicProviderConfig, AnthropicRegisterOptions } from "../../types";
+import type {
+  AnthropicProviderConfig,
+  AnthropicRegisterOptions,
+} from "../../types";
 import { AnthropicLlm } from "./anthropic-llm";
 
 // Re-exports
-export { AnthropicLlm, ANTHROPIC_MODEL_PATTERNS } from "./anthropic-llm";
+export { ANTHROPIC_MODEL_PATTERNS, AnthropicLlm } from "./anthropic-llm";
 export type { ConvertedAnthropicRequest } from "./converters/request";
 export { convertAnthropicRequest } from "./converters/request";
 export type {

--- a/src/types.ts
+++ b/src/types.ts
@@ -544,6 +544,23 @@ export interface AnthropicProviderConfig extends BaseProviderConfig {
    * @defaultValue 4096
    */
   maxTokens?: number;
+
+  /**
+   * Opt-in Anthropic prompt caching.
+   *
+   * When `true`, attaches `cache_control: { type: "ephemeral" }` to the
+   * system prompt block and the last tool definition, marking the largely
+   * static prefix of the request (system instruction + tool schemas) as
+   * cacheable. This can substantially reduce cost and latency for prompts
+   * that reuse the same system instruction and tools across turns.
+   *
+   * This is a bridge-level instance setting, NOT derived from ADK's
+   * `config.cachedContent` (which is a non-portable Gemini resource name).
+   *
+   * @defaultValue false
+   * @see {@link https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching|Anthropic Prompt Caching}
+   */
+  promptCaching?: boolean;
 }
 
 /**
@@ -573,6 +590,18 @@ export interface AnthropicRegisterOptions {
    * @defaultValue 4096
    */
   maxTokens?: number;
+
+  /**
+   * Opt-in Anthropic prompt caching for all models created through the
+   * registry.
+   *
+   * When `true`, attaches `cache_control: { type: "ephemeral" }` to the
+   * system prompt block and the last tool definition.
+   *
+   * @defaultValue false
+   * @see {@link AnthropicProviderConfig.promptCaching}
+   */
+  promptCaching?: boolean;
 }
 
 // =============================================================================
@@ -623,8 +652,25 @@ export interface StreamAccumulator {
   /** Accumulated text content from all chunks */
   text: string;
 
+  /**
+   * Accumulated reasoning/thinking text from all chunks.
+   *
+   * Populated from provider `delta.reasoning` / `delta.reasoning_content`
+   * fields. Emitted as a `{ thought: true }` part.
+   */
+  reasoning: string;
+
   /** Map of tool call index to accumulated tool call data */
   toolCalls: Map<number, ToolCallAccumulator>;
+
+  /**
+   * Token usage captured from the final OpenAI streaming chunk.
+   *
+   * Populated when `stream_options.include_usage` is enabled; emitted as
+   * `usageMetadata` on the final response. Includes `thoughtsTokenCount` when
+   * the provider reports `completion_tokens_details.reasoning_tokens`.
+   */
+  usage?: LlmResponse["usageMetadata"];
 }
 
 /**

--- a/tests/converters/request.test.ts
+++ b/tests/converters/request.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import type { LlmRequest } from "@google/adk";
-import { convertRequest } from "../../src/converters/request";
+import { FunctionCallingConfigMode } from "@google/genai";
+import {
+  convertGenerationConfig,
+  convertLogprobsConfig,
+  convertReasoningConfig,
+  convertRequest,
+  convertStructuredOutput,
+  convertToolChoice,
+} from "../../src/converters/request";
 
 function createLlmRequest(overrides: Partial<LlmRequest> = {}): LlmRequest {
   return {
@@ -231,7 +239,11 @@ describe("convertRequest", () => {
                     string,
                     unknown
                   >,
-                } as unknown as { name: string; description: string; parameters: Record<string, unknown> },
+                } as unknown as {
+                  name: string;
+                  description: string;
+                  parameters: Record<string, unknown>;
+                },
               ],
             },
           ],
@@ -241,6 +253,862 @@ describe("convertRequest", () => {
       const result = convertRequest(request);
 
       expect(result.tools).toBeUndefined();
+    });
+  });
+
+  describe("generation config", () => {
+    it("maps each sampling field to its OpenAI key", () => {
+      const request = createLlmRequest({
+        config: {
+          temperature: 0.7,
+          topP: 0.9,
+          maxOutputTokens: 256,
+          stopSequences: ["END"],
+          seed: 42,
+          presencePenalty: 0.5,
+          frequencyPenalty: 0.3,
+          candidateCount: 2,
+        },
+      });
+
+      expect(convertGenerationConfig(request)).toEqual({
+        temperature: 0.7,
+        top_p: 0.9,
+        max_tokens: 256,
+        stop: ["END"],
+        seed: 42,
+        presence_penalty: 0.5,
+        frequency_penalty: 0.3,
+        n: 2,
+      });
+    });
+
+    it("drops topK (no OpenAI equivalent)", () => {
+      const request = createLlmRequest({
+        config: { temperature: 0.5, topK: 40 },
+      });
+
+      const result = convertGenerationConfig(request);
+      expect(result).toEqual({ temperature: 0.5 });
+      expect(result).not.toHaveProperty("top_k");
+    });
+
+    it("omits undefined fields", () => {
+      const request = createLlmRequest({ config: { temperature: 0.2 } });
+      expect(convertGenerationConfig(request)).toEqual({ temperature: 0.2 });
+    });
+
+    it("returns empty object for empty config", () => {
+      expect(convertGenerationConfig(createLlmRequest({ config: {} }))).toEqual(
+        {},
+      );
+      expect(convertGenerationConfig(createLlmRequest({}))).toEqual({});
+    });
+
+    it("folds generation params into convertRequest result", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+        config: { temperature: 0.1, maxOutputTokens: 10 },
+      });
+
+      const result = convertRequest(request);
+      expect(result.params).toEqual({ temperature: 0.1, max_tokens: 10 });
+    });
+
+    it("leaves params undefined when no config fields are set", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+      });
+      expect(convertRequest(request).params).toBeUndefined();
+    });
+  });
+
+  describe("tool choice", () => {
+    it("maps AUTO to 'auto'", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.AUTO },
+          },
+        },
+      });
+      expect(convertToolChoice(request)).toBe("auto");
+    });
+
+    it("maps NONE to 'none'", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.NONE },
+          },
+        },
+      });
+      expect(convertToolChoice(request)).toBe("none");
+    });
+
+    it("maps ANY to 'required'", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.ANY },
+          },
+        },
+      });
+      expect(convertToolChoice(request)).toBe("required");
+    });
+
+    it("maps VALIDATED to 'required'", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: {
+              mode: FunctionCallingConfigMode.VALIDATED,
+            },
+          },
+        },
+      });
+      expect(convertToolChoice(request)).toBe("required");
+    });
+
+    it("maps ANY with single allowedFunctionName to a function tool_choice", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: {
+              mode: FunctionCallingConfigMode.ANY,
+              allowedFunctionNames: ["get_weather"],
+            },
+          },
+        },
+      });
+      expect(convertToolChoice(request)).toEqual({
+        type: "function",
+        function: { name: "get_weather" },
+      });
+    });
+
+    it("returns undefined when no toolConfig present", () => {
+      expect(
+        convertToolChoice(createLlmRequest({ config: {} })),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("structured output", () => {
+    it("maps responseSchema to a normalized json_schema response_format", () => {
+      const request = createLlmRequest({
+        config: {
+          responseSchema: {
+            type: "OBJECT",
+            properties: { answer: { type: "STRING" } },
+          },
+        },
+      });
+
+      expect(convertStructuredOutput(request)).toEqual({
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "response",
+            strict: false,
+            schema: {
+              type: "object",
+              properties: { answer: { type: "string" } },
+            },
+          },
+        },
+      });
+    });
+
+    it("maps responseMimeType only to json_object", () => {
+      const request = createLlmRequest({
+        config: { responseMimeType: "application/json" },
+      });
+
+      expect(convertStructuredOutput(request)).toEqual({
+        response_format: { type: "json_object" },
+      });
+    });
+
+    it("passes responseJsonSchema through unchanged", () => {
+      const schema = {
+        type: "object",
+        properties: { x: { type: "number" } },
+      };
+      const request = createLlmRequest({
+        config: { responseJsonSchema: schema },
+      });
+
+      expect(convertStructuredOutput(request)).toEqual({
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "response", strict: false, schema },
+        },
+      });
+    });
+
+    it("returns empty object when no structured output config", () => {
+      expect(convertStructuredOutput(createLlmRequest({ config: {} }))).toEqual(
+        {},
+      );
+    });
+  });
+
+  describe("multimodal input", () => {
+    it("maps inlineData image to an image_url data URL content part", () => {
+      const request = createLlmRequest({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              { text: "What is this?" },
+              {
+                inlineData: { mimeType: "image/png", data: "AAAA" },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = convertRequest(request);
+      expect(result.messages[0]).toEqual({
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          {
+            type: "image_url",
+            image_url: { url: "data:image/png;base64,AAAA" },
+          },
+        ],
+      });
+    });
+
+    it("maps http fileData image to an image_url url content part", () => {
+      const request = createLlmRequest({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              {
+                fileData: {
+                  mimeType: "image/jpeg",
+                  fileUri: "https://example.com/cat.jpg",
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = convertRequest(request);
+      expect(result.messages[0]).toEqual({
+        role: "user",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/cat.jpg" },
+          },
+        ],
+      });
+    });
+
+    it("drops gs:// fileData URIs", () => {
+      const request = createLlmRequest({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              { text: "hi" },
+              {
+                fileData: {
+                  mimeType: "image/png",
+                  fileUri: "gs://bucket/img.png",
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = convertRequest(request);
+      // No image present -> falls back to string content path.
+      expect(result.messages[0]).toEqual({ role: "user", content: "hi" });
+    });
+
+    it("keeps text-only path as string content (back-compat)", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "plain text" }] }],
+      });
+
+      const result = convertRequest(request);
+      expect(result.messages[0]).toEqual({
+        role: "user",
+        content: "plain text",
+      });
+    });
+  });
+
+  describe("reasoning_effort (thinkingConfig)", () => {
+    it("does NOT emit reasoning_effort when thinkingConfig is absent", () => {
+      const request = createLlmRequest({ config: { temperature: 0.5 } });
+      const result = convertRequest(request);
+      expect(result.params?.reasoning_effort).toBeUndefined();
+    });
+
+    it("defaults to medium when thinkingConfig is set without a budget", () => {
+      const request = createLlmRequest({ config: { thinkingConfig: {} } });
+      const result = convertRequest(request);
+      expect(result.params?.reasoning_effort).toBe("medium");
+    });
+
+    it("maps a small budget to low", () => {
+      const request = createLlmRequest({
+        config: { thinkingConfig: { thinkingBudget: 1000 } },
+      });
+      expect(convertReasoningConfig(request)).toEqual({
+        reasoning_effort: "low",
+      });
+    });
+
+    it("maps a mid budget to medium", () => {
+      const request = createLlmRequest({
+        config: { thinkingConfig: { thinkingBudget: 4096 } },
+      });
+      expect(convertReasoningConfig(request)).toEqual({
+        reasoning_effort: "medium",
+      });
+    });
+
+    it("maps a large budget to high", () => {
+      const request = createLlmRequest({
+        config: { thinkingConfig: { thinkingBudget: 20000 } },
+      });
+      expect(convertReasoningConfig(request)).toEqual({
+        reasoning_effort: "high",
+      });
+    });
+
+    it("emits nothing when the budget disables thinking (<= 0)", () => {
+      const request = createLlmRequest({
+        config: { thinkingConfig: { thinkingBudget: 0 } },
+      });
+      expect(convertReasoningConfig(request)).toEqual({});
+    });
+
+    it("emits nothing when there is no config at all", () => {
+      expect(convertReasoningConfig(createLlmRequest({}))).toEqual({});
+    });
+  });
+
+  describe("provider API combination gating (model-aware)", () => {
+    describe("max_tokens vs max_completion_tokens", () => {
+      it("emits max_completion_tokens for gpt-5 reasoning models", () => {
+        const request = createLlmRequest({
+          config: { maxOutputTokens: 256 },
+        });
+        const result = convertGenerationConfig(request, "gpt-5");
+        expect(result.max_completion_tokens).toBe(256);
+        expect(result).not.toHaveProperty("max_tokens");
+      });
+
+      it("emits max_completion_tokens for o-series (o1/o3/o4)", () => {
+        for (const model of ["o1", "o1-mini", "o3-mini", "o4-mini"]) {
+          const request = createLlmRequest({
+            config: { maxOutputTokens: 100 },
+          });
+          const result = convertGenerationConfig(request, model);
+          expect(result.max_completion_tokens).toBe(100);
+          expect(result).not.toHaveProperty("max_tokens");
+        }
+      });
+
+      it("emits max_completion_tokens for provider-prefixed openai/gpt-5", () => {
+        const request = createLlmRequest({
+          config: { maxOutputTokens: 64 },
+        });
+        const result = convertGenerationConfig(request, "openai/gpt-5-mini");
+        expect(result.max_completion_tokens).toBe(64);
+        expect(result).not.toHaveProperty("max_tokens");
+      });
+
+      it("keeps max_tokens for gpt-4.1 (non-reasoning)", () => {
+        const request = createLlmRequest({
+          config: { maxOutputTokens: 256 },
+        });
+        const result = convertGenerationConfig(request, "gpt-4.1");
+        expect(result.max_tokens).toBe(256);
+        expect(result).not.toHaveProperty("max_completion_tokens");
+      });
+
+      it("does NOT mistake gpt-4o for an o-series model", () => {
+        const request = createLlmRequest({
+          config: { maxOutputTokens: 256 },
+        });
+        const result = convertGenerationConfig(request, "gpt-4o");
+        expect(result.max_tokens).toBe(256);
+        expect(result).not.toHaveProperty("max_completion_tokens");
+      });
+
+      it("keeps max_tokens for xAI grok-4", () => {
+        const request = createLlmRequest({
+          config: { maxOutputTokens: 512 },
+        });
+        const result = convertGenerationConfig(request, "grok-4");
+        expect(result.max_tokens).toBe(512);
+        expect(result).not.toHaveProperty("max_completion_tokens");
+      });
+
+      it("keeps max_tokens when no model is supplied (legacy)", () => {
+        const request = createLlmRequest({
+          config: { maxOutputTokens: 10 },
+        });
+        expect(convertGenerationConfig(request).max_tokens).toBe(10);
+      });
+    });
+
+    describe("sampling / penalties / stop dropped for reasoning models", () => {
+      it("drops stop / presence_penalty / frequency_penalty / temperature / top_p for gpt-5", () => {
+        const request = createLlmRequest({
+          config: {
+            stopSequences: ["END"],
+            presencePenalty: 0.5,
+            frequencyPenalty: 0.3,
+            temperature: 0.4,
+            topP: 0.9,
+          },
+        });
+        const result = convertGenerationConfig(request, "gpt-5");
+        expect(result).not.toHaveProperty("stop");
+        expect(result).not.toHaveProperty("presence_penalty");
+        expect(result).not.toHaveProperty("frequency_penalty");
+        // Reasoning models reject temperature/top_p outright (400) — drop them.
+        expect(result).not.toHaveProperty("temperature");
+        expect(result).not.toHaveProperty("top_p");
+      });
+
+      it("drops temperature / top_p for the o-series (o1/o3/o4)", () => {
+        for (const model of ["o1", "o1-mini", "o3-mini", "o4-mini"]) {
+          const request = createLlmRequest({
+            config: { temperature: 0.7, topP: 0.8 },
+          });
+          const result = convertGenerationConfig(request, model);
+          expect(result).not.toHaveProperty("temperature");
+          expect(result).not.toHaveProperty("top_p");
+        }
+      });
+
+      it("drops temperature / top_p for provider-prefixed openai/gpt-5-mini", () => {
+        const request = createLlmRequest({
+          config: { temperature: 0.5, topP: 0.6 },
+        });
+        const result = convertGenerationConfig(request, "openai/gpt-5-mini");
+        expect(result).not.toHaveProperty("temperature");
+        expect(result).not.toHaveProperty("top_p");
+      });
+
+      it("keeps stop / penalties / temperature / top_p for gpt-4.1", () => {
+        const request = createLlmRequest({
+          config: {
+            stopSequences: ["END"],
+            presencePenalty: 0.5,
+            frequencyPenalty: 0.3,
+            temperature: 0.4,
+            topP: 0.9,
+          },
+        });
+        const result = convertGenerationConfig(request, "gpt-4.1");
+        expect(result.stop).toEqual(["END"]);
+        expect(result.presence_penalty).toBe(0.5);
+        expect(result.frequency_penalty).toBe(0.3);
+        expect(result.temperature).toBe(0.4);
+        expect(result.top_p).toBe(0.9);
+      });
+
+      it("keeps temperature / top_p for non-OpenAI providers (grok-4)", () => {
+        const request = createLlmRequest({
+          config: { temperature: 0.7, topP: 0.8 },
+        });
+        const result = convertGenerationConfig(request, "x-ai/grok-4");
+        expect(result.temperature).toBe(0.7);
+        expect(result.top_p).toBe(0.8);
+      });
+
+      it("end-to-end: gpt-5 request carries no temperature/top_p/logprobs but keeps reasoning_effort", () => {
+        const request = createLlmRequest({
+          contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+          config: {
+            temperature: 0.5,
+            topP: 0.9,
+            maxOutputTokens: 100,
+            responseLogprobs: true,
+            logprobs: 3,
+            thinkingConfig: { thinkingBudget: 1000 },
+          },
+        });
+        const result = convertRequest(request, "gpt-5");
+        expect(result.params).not.toHaveProperty("temperature");
+        expect(result.params).not.toHaveProperty("top_p");
+        expect(result.params).not.toHaveProperty("logprobs");
+        expect(result.params).not.toHaveProperty("top_logprobs");
+        expect(result.params?.max_completion_tokens).toBe(100);
+        expect(result.params?.reasoning_effort).toBe("low");
+      });
+    });
+
+    describe("reasoning_effort model gating", () => {
+      it("emits reasoning_effort for gpt-5 with thinkingConfig", () => {
+        const request = createLlmRequest({
+          config: { thinkingConfig: { thinkingBudget: 1000 } },
+        });
+        expect(convertReasoningConfig(request, "gpt-5")).toEqual({
+          reasoning_effort: "low",
+        });
+      });
+
+      it("emits reasoning_effort for o3-mini", () => {
+        const request = createLlmRequest({
+          config: { thinkingConfig: {} },
+        });
+        expect(convertReasoningConfig(request, "o3-mini")).toEqual({
+          reasoning_effort: "medium",
+        });
+      });
+
+      it("does NOT emit reasoning_effort for gpt-4.1 even with thinkingConfig", () => {
+        const request = createLlmRequest({
+          config: { thinkingConfig: { thinkingBudget: 4096 } },
+        });
+        expect(convertReasoningConfig(request, "gpt-4.1")).toEqual({});
+      });
+
+      it("does NOT emit reasoning_effort for plain grok-4", () => {
+        const request = createLlmRequest({
+          config: { thinkingConfig: { thinkingBudget: 4096 } },
+        });
+        expect(convertReasoningConfig(request, "grok-4")).toEqual({});
+      });
+
+      it("emits reasoning_effort for grok reasoning variants", () => {
+        const request = createLlmRequest({
+          config: { thinkingConfig: { thinkingBudget: 4096 } },
+        });
+        expect(convertReasoningConfig(request, "grok-3-mini")).toEqual({
+          reasoning_effort: "medium",
+        });
+        expect(
+          convertReasoningConfig(request, "grok-4-fast-reasoning"),
+        ).toEqual({ reasoning_effort: "medium" });
+      });
+
+      it("end-to-end: reasoning model uses max_completion_tokens AND reasoning_effort via convertRequest", () => {
+        const request = createLlmRequest({
+          contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+          config: {
+            maxOutputTokens: 200,
+            thinkingConfig: { thinkingBudget: 5000 },
+          },
+        });
+        const result = convertRequest(request, "gpt-5");
+        expect(result.params?.max_completion_tokens).toBe(200);
+        expect(result.params).not.toHaveProperty("max_tokens");
+        expect(result.params?.reasoning_effort).toBe("medium");
+      });
+
+      it("end-to-end: gpt-4.1 keeps max_tokens and drops reasoning_effort", () => {
+        const request = createLlmRequest({
+          contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+          config: {
+            maxOutputTokens: 200,
+            thinkingConfig: { thinkingBudget: 5000 },
+          },
+        });
+        const result = convertRequest(request, "gpt-4.1");
+        expect(result.params?.max_tokens).toBe(200);
+        expect(result.params).not.toHaveProperty("max_completion_tokens");
+        expect(result.params?.reasoning_effort).toBeUndefined();
+      });
+    });
+
+    describe("strict:false on partial schemas", () => {
+      it("defaults strict:false for a responseSchema missing additionalProperties/required", () => {
+        const request = createLlmRequest({
+          config: {
+            responseSchema: {
+              type: "OBJECT",
+              properties: {
+                a: { type: "STRING" },
+                b: { type: "NUMBER" },
+              },
+              // no required, no additionalProperties -> would 400 under strict
+            },
+          },
+        });
+        const result = convertStructuredOutput(request);
+        const rf = result.response_format as {
+          json_schema: { strict: boolean };
+        };
+        expect(rf.json_schema.strict).toBe(false);
+      });
+    });
+  });
+
+  describe("logprobs", () => {
+    it("maps responseLogprobs:true to logprobs:true", () => {
+      const request = createLlmRequest({
+        config: { responseLogprobs: true },
+      });
+      expect(convertLogprobsConfig(request)).toEqual({ logprobs: true });
+    });
+
+    it("maps logprobs (number) to top_logprobs and forces logprobs:true", () => {
+      const request = createLlmRequest({ config: { logprobs: 3 } });
+      expect(convertLogprobsConfig(request)).toEqual({
+        top_logprobs: 3,
+        logprobs: true,
+      });
+    });
+
+    it("maps both responseLogprobs and logprobs together", () => {
+      const request = createLlmRequest({
+        config: { responseLogprobs: true, logprobs: 5 },
+      });
+      expect(convertLogprobsConfig(request)).toEqual({
+        logprobs: true,
+        top_logprobs: 5,
+      });
+    });
+
+    it("emits top_logprobs:0 when logprobs is 0", () => {
+      const request = createLlmRequest({ config: { logprobs: 0 } });
+      expect(convertLogprobsConfig(request)).toEqual({
+        top_logprobs: 0,
+        logprobs: true,
+      });
+    });
+
+    it("does NOT emit logprobs when responseLogprobs is false", () => {
+      const request = createLlmRequest({
+        config: { responseLogprobs: false },
+      });
+      expect(convertLogprobsConfig(request)).toEqual({});
+    });
+
+    it("emits nothing when neither field is set", () => {
+      expect(convertLogprobsConfig(createLlmRequest({ config: {} }))).toEqual(
+        {},
+      );
+      expect(convertLogprobsConfig(createLlmRequest({}))).toEqual({});
+    });
+
+    it("folds logprobs params into convertRequest result", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+        config: { responseLogprobs: true, logprobs: 2 },
+      });
+      const result = convertRequest(request);
+      expect(result.params?.logprobs).toBe(true);
+      expect(result.params?.top_logprobs).toBe(2);
+    });
+
+    it("drops logprobs/top_logprobs for reasoning models (gpt-5)", () => {
+      const request = createLlmRequest({
+        config: { responseLogprobs: true, logprobs: 3 },
+      });
+      expect(convertLogprobsConfig(request, "gpt-5")).toEqual({});
+    });
+
+    it("drops logprobs for the o-series and openai-prefixed reasoning ids", () => {
+      for (const model of ["o1", "o3-mini", "o4-mini", "openai/gpt-5-mini"]) {
+        const request = createLlmRequest({
+          config: { responseLogprobs: true, logprobs: 2 },
+        });
+        expect(convertLogprobsConfig(request, model)).toEqual({});
+      }
+    });
+
+    it("keeps logprobs for non-reasoning models (gpt-4o)", () => {
+      const request = createLlmRequest({
+        config: { responseLogprobs: true, logprobs: 4 },
+      });
+      expect(convertLogprobsConfig(request, "gpt-4o")).toEqual({
+        logprobs: true,
+        top_logprobs: 4,
+      });
+    });
+
+    it("end-to-end: gpt-5 request omits logprobs even when requested", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+        config: { responseLogprobs: true, logprobs: 2 },
+      });
+      const result = convertRequest(request, "gpt-5");
+      expect(result.params ?? {}).not.toHaveProperty("logprobs");
+      expect(result.params ?? {}).not.toHaveProperty("top_logprobs");
+    });
+
+    it("leaves logprobs out of params when not requested", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+        config: { temperature: 0.2 },
+      });
+      const result = convertRequest(request);
+      expect(result.params).not.toHaveProperty("logprobs");
+      expect(result.params).not.toHaveProperty("top_logprobs");
+    });
+  });
+
+  describe("Gemini-only built-in tools", () => {
+    function withConsoleWarn<T>(fn: () => T): { result: T; warns: string[] } {
+      const warns: string[] = [];
+      const original = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warns.push(args.map(String).join(" "));
+      };
+      try {
+        const result = fn();
+        return { result, warns };
+      } finally {
+        console.warn = original;
+      }
+    }
+
+    it("skips a googleSearch tool group without crashing and emits no function tool", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        config: {
+          // googleSearch is a Gemini server-side tool with no OpenAI equivalent.
+          tools: [{ googleSearch: {} } as unknown as Record<string, unknown>],
+        },
+      });
+
+      const { result, warns } = withConsoleWarn(() => convertRequest(request));
+
+      expect(result.tools).toBeUndefined();
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("googleSearch");
+    });
+
+    it("keeps functionDeclarations while dropping a built-in in the same request", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        config: {
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: "get_weather",
+                  description: "Get weather",
+                  parameters: { type: "object", properties: {} } as Record<
+                    string,
+                    unknown
+                  >,
+                },
+              ],
+            },
+            { codeExecution: {} } as unknown as Record<string, unknown>,
+          ],
+        },
+      });
+
+      const { result, warns } = withConsoleWarn(() => convertRequest(request));
+
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools?.[0].function.name).toBe("get_weather");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("codeExecution");
+    });
+
+    it("emits a SINGLE warn naming all dropped built-ins", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        config: {
+          tools: [
+            { googleSearch: {} } as unknown as Record<string, unknown>,
+            { codeExecution: {} } as unknown as Record<string, unknown>,
+            { urlContext: {} } as unknown as Record<string, unknown>,
+          ],
+        },
+      });
+
+      const { warns } = withConsoleWarn(() => convertRequest(request));
+
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("googleSearch");
+      expect(warns[0]).toContain("codeExecution");
+      expect(warns[0]).toContain("urlContext");
+    });
+
+    it("does NOT warn when only functionDeclarations are present", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        config: {
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: "do_thing",
+                  description: "",
+                  parameters: { type: "object", properties: {} } as Record<
+                    string,
+                    unknown
+                  >,
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      const { result, warns } = withConsoleWarn(() => convertRequest(request));
+
+      expect(result.tools).toHaveLength(1);
+      expect(warns).toHaveLength(0);
+    });
+  });
+
+  describe("Gemini-only config fields never leak into the body", () => {
+    it("never forwards safetySettings / responseModalities / cachedContent / labels / routingConfig", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+        config: {
+          temperature: 0.5,
+          maxOutputTokens: 100,
+          // Gemini-only fields that must NOT appear in the produced body.
+          safetySettings: [
+            { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" },
+          ],
+          responseModalities: ["TEXT"],
+          cachedContent: "cachedContents/abc123",
+          labels: { team: "research" },
+          routingConfig: { autoMode: { modelRoutingPreference: "BALANCED" } },
+        } as unknown as LlmRequest["config"],
+      });
+
+      const result = convertRequest(request);
+      const body = {
+        ...result.params,
+        // Mirror how the LLM class assembles the request body.
+        ...(result.tools ? { tools: result.tools } : {}),
+        ...(result.toolChoice ? { tool_choice: result.toolChoice } : {}),
+      };
+
+      // Allowlisted sampling fields still pass through.
+      expect(result.params).toEqual({ temperature: 0.5, max_tokens: 100 });
+
+      for (const forbidden of [
+        "safetySettings",
+        "safety_settings",
+        "responseModalities",
+        "response_modalities",
+        "cachedContent",
+        "cached_content",
+        "labels",
+        "routingConfig",
+        "routing_config",
+      ]) {
+        expect(body).not.toHaveProperty(forbidden);
+        expect(result.params ?? {}).not.toHaveProperty(forbidden);
+      }
     });
   });
 });

--- a/tests/converters/response.test.ts
+++ b/tests/converters/response.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { FinishReason } from "@google/genai";
 import type OpenAI from "openai";
 import {
   convertResponse,
@@ -115,12 +116,93 @@ describe("convertResponse", () => {
     });
   });
 
+  it("surfaces choice.logprobs.content into customMetadata.logprobs", () => {
+    const logprobs = {
+      content: [
+        { token: "Hi", logprob: -0.1, bytes: [72, 105], top_logprobs: [] },
+      ],
+    };
+    const response = createCompletion({
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "Hi", refusal: null },
+          finish_reason: "stop",
+          logprobs,
+        },
+      ],
+    } as Partial<ChatCompletion>);
+
+    const result = convertResponse(response);
+    expect(result.customMetadata).toEqual({ logprobs });
+  });
+
+  it("leaves customMetadata undefined when logprobs.content is empty", () => {
+    const response = createCompletion({
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "Hi", refusal: null },
+          finish_reason: "stop",
+          logprobs: { content: [] },
+        },
+      ],
+    } as Partial<ChatCompletion>);
+
+    expect(convertResponse(response).customMetadata).toBeUndefined();
+  });
+
+  it("leaves customMetadata undefined when logprobs is null", () => {
+    const response = createCompletion();
+    expect(convertResponse(response).customMetadata).toBeUndefined();
+  });
+
   it("returns error for empty choices", () => {
     const response = createCompletion({ choices: [] });
     const result = convertResponse(response);
 
     expect(result.errorCode).toBe("NO_CHOICE");
     expect(result.turnComplete).toBe(true);
+  });
+
+  describe("finishReason mapping", () => {
+    function withFinish(reason: string) {
+      return createCompletion({
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "x", refusal: null },
+            finish_reason:
+              reason as OpenAI.ChatCompletion["choices"][0]["finish_reason"],
+            logprobs: null,
+          },
+        ],
+      });
+    }
+
+    it("maps stop to STOP", () => {
+      expect(convertResponse(withFinish("stop")).finishReason).toBe(
+        FinishReason.STOP,
+      );
+    });
+
+    it("maps length to MAX_TOKENS", () => {
+      expect(convertResponse(withFinish("length")).finishReason).toBe(
+        FinishReason.MAX_TOKENS,
+      );
+    });
+
+    it("maps content_filter to SAFETY", () => {
+      expect(convertResponse(withFinish("content_filter")).finishReason).toBe(
+        FinishReason.SAFETY,
+      );
+    });
+
+    it("maps tool_calls to STOP", () => {
+      expect(convertResponse(withFinish("tool_calls")).finishReason).toBe(
+        FinishReason.STOP,
+      );
+    });
   });
 });
 
@@ -166,5 +248,304 @@ describe("convertStreamChunk", () => {
 
     expect(accumulated.text).toBe("");
     expect(accumulated.toolCalls.size).toBe(0);
+  });
+
+  it("attaches finishReason to the final response", () => {
+    const accumulated = createStreamAccumulator();
+    accumulated.text = "done";
+
+    const result = convertStreamChunk(createChunk({}, "length"), accumulated);
+
+    expect(result.response?.finishReason).toBe(FinishReason.MAX_TOKENS);
+  });
+
+  it("captures a usage chunk that arrives AFTER finish (real OpenAI ordering)", () => {
+    const accumulated = createStreamAccumulator();
+
+    // content delta
+    convertStreamChunk(createChunk({ content: "Hi" }), accumulated);
+
+    // finish chunk arrives FIRST (real OpenAI stream_options ordering).
+    const finalResult = convertStreamChunk(
+      createChunk({}, "stop"),
+      accumulated,
+    );
+    expect(finalResult.isComplete).toBe(true);
+    expect(finalResult.response?.finishReason).toBe(FinishReason.STOP);
+    // No usage yet — the usage chunk has not arrived.
+    expect(finalResult.response?.usageMetadata).toBeUndefined();
+    // Finish clears any prior accumulator usage.
+    expect(accumulated.usage).toBeUndefined();
+
+    // usage-only chunk (empty choices) arrives AFTER finish — it must be
+    // captured into the accumulator without completing again. The LLM stream
+    // loop then merges acc.usage into the held final response (see core tests).
+    const usageChunk = {
+      id: "chatcmpl-123",
+      object: "chat.completion.chunk",
+      created: Date.now(),
+      model: "test-model",
+      choices: [],
+      usage: { prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 },
+    } as ChatCompletionChunk;
+    const usageResult = convertStreamChunk(usageChunk, accumulated);
+    expect(usageResult.isComplete).toBe(false);
+    expect(usageResult.response).toBeUndefined();
+    expect(accumulated.usage).toEqual({
+      promptTokenCount: 12,
+      candidatesTokenCount: 8,
+      totalTokenCount: 20,
+    });
+  });
+
+  it("emits usage on the final response when usage arrives BEFORE finish", () => {
+    // Some OpenAI-compatible providers attach usage to the finish chunk or send
+    // it just before. In that ordering the converter's final response carries
+    // the usage directly.
+    const accumulated = createStreamAccumulator();
+    convertStreamChunk(createChunk({ content: "Hi" }), accumulated);
+
+    const usageChunk = {
+      id: "chatcmpl-123",
+      object: "chat.completion.chunk",
+      created: Date.now(),
+      model: "test-model",
+      choices: [],
+      usage: { prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 },
+    } as ChatCompletionChunk;
+    convertStreamChunk(usageChunk, accumulated);
+
+    const finalResult = convertStreamChunk(
+      createChunk({}, "stop"),
+      accumulated,
+    );
+    expect(finalResult.response?.usageMetadata).toEqual({
+      promptTokenCount: 12,
+      candidatesTokenCount: 8,
+      totalTokenCount: 20,
+    });
+    expect(accumulated.usage).toBeUndefined();
+  });
+
+  it("surfaces reasoning AND content co-located in one chunk", () => {
+    const accumulated = createStreamAccumulator();
+    const result = convertStreamChunk(
+      createChunk({
+        reasoning_content: "thinking",
+        content: "answer",
+      } as ChatCompletionChunk["choices"][0]["delta"]),
+      accumulated,
+    );
+
+    expect(result.isComplete).toBe(false);
+    expect(result.response?.partial).toBe(true);
+    expect(result.response?.content?.parts).toEqual([
+      { text: "thinking", thought: true },
+      { text: "answer" },
+    ]);
+    expect(accumulated.reasoning).toBe("thinking");
+    expect(accumulated.text).toBe("answer");
+  });
+
+  it("processes reasoning, content, tool_call, and finish all in one chunk", () => {
+    const accumulated = createStreamAccumulator();
+    const result = convertStreamChunk(
+      createChunk(
+        {
+          reasoning_content: "reason",
+          content: "say",
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_1",
+              type: "function",
+              function: { name: "do_it", arguments: '{"x":1}' },
+            },
+          ],
+        } as ChatCompletionChunk["choices"][0]["delta"],
+        "tool_calls",
+      ),
+      accumulated,
+    );
+
+    // finish_reason present -> final response, not a partial
+    expect(result.isComplete).toBe(true);
+    expect(result.response?.turnComplete).toBe(true);
+    const parts = result.response?.content?.parts ?? [];
+    expect(parts[0]).toEqual({ text: "reason", thought: true });
+    expect(parts[1]).toEqual({ text: "say" });
+    expect(parts[2]).toEqual({
+      functionCall: { id: "call_1", name: "do_it", args: { x: 1 } },
+    });
+  });
+});
+
+describe("reasoning passthrough", () => {
+  it("surfaces message.reasoning_content as a thought part before text", () => {
+    const response = createCompletion({
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "The answer is 4.",
+            reasoning_content: "2 + 2 = 4",
+            refusal: null,
+          },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+    } as Partial<ChatCompletion>);
+
+    const result = convertResponse(response);
+    const parts = result.content?.parts ?? [];
+    expect(parts[0]).toEqual({ text: "2 + 2 = 4", thought: true });
+    expect(parts[1]).toEqual({ text: "The answer is 4." });
+  });
+
+  it("surfaces message.reasoning (OpenAI/OpenRouter naming) as a thought part", () => {
+    const response = createCompletion({
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "Done.",
+            reasoning: "thinking hard",
+            refusal: null,
+          },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+    } as Partial<ChatCompletion>);
+
+    const parts = convertResponse(response).content?.parts ?? [];
+    expect(parts[0]).toEqual({ text: "thinking hard", thought: true });
+  });
+
+  it("yields no thought part when the provider omits reasoning", () => {
+    const response = createCompletion();
+    const parts = convertResponse(response).content?.parts ?? [];
+    expect(parts.some((p) => p.thought)).toBe(false);
+  });
+
+  it("maps completion_tokens_details.reasoning_tokens to thoughtsTokenCount", () => {
+    const response = createCompletion({
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 50,
+        total_tokens: 60,
+        completion_tokens_details: { reasoning_tokens: 32 },
+      },
+    } as Partial<ChatCompletion>);
+
+    expect(convertResponse(response).usageMetadata).toEqual({
+      promptTokenCount: 10,
+      candidatesTokenCount: 50,
+      totalTokenCount: 60,
+      thoughtsTokenCount: 32,
+    });
+  });
+
+  it("omits thoughtsTokenCount when reasoning_tokens is absent", () => {
+    const response = createCompletion({
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+    const usage = convertResponse(response).usageMetadata;
+    expect(usage?.thoughtsTokenCount).toBeUndefined();
+  });
+
+  it("streams reasoning_content delta as a partial thought part", () => {
+    const acc = createStreamAccumulator();
+
+    const result = convertStreamChunk(
+      createChunk({
+        reasoning_content: "step 1",
+      } as ChatCompletionChunk["choices"][0]["delta"]),
+      acc,
+    );
+
+    expect(result.isComplete).toBe(false);
+    expect(result.response?.partial).toBe(true);
+    expect(result.response?.content?.parts?.[0]).toEqual({
+      text: "step 1",
+      thought: true,
+    });
+    expect(acc.reasoning).toBe("step 1");
+  });
+
+  it("streams reasoning (OpenRouter naming) delta as a thought part", () => {
+    const acc = createStreamAccumulator();
+
+    const result = convertStreamChunk(
+      createChunk({
+        reasoning: "hmm",
+      } as ChatCompletionChunk["choices"][0]["delta"]),
+      acc,
+    );
+
+    expect(result.response?.content?.parts?.[0]).toEqual({
+      text: "hmm",
+      thought: true,
+    });
+  });
+
+  it("includes accumulated reasoning as a thought part in the final response", () => {
+    const acc = createStreamAccumulator();
+
+    convertStreamChunk(
+      createChunk({
+        reasoning_content: "think ",
+      } as ChatCompletionChunk["choices"][0]["delta"]),
+      acc,
+    );
+    convertStreamChunk(
+      createChunk({
+        reasoning_content: "more",
+      } as ChatCompletionChunk["choices"][0]["delta"]),
+      acc,
+    );
+    convertStreamChunk(createChunk({ content: "answer" }), acc);
+
+    const final = convertStreamChunk(createChunk({}, "stop"), acc);
+    const parts = final.response?.content?.parts ?? [];
+    expect(parts[0]).toEqual({ text: "think more", thought: true });
+    expect(parts[1]).toEqual({ text: "answer" });
+    // reasoning accumulator reset after completion
+    expect(acc.reasoning).toBe("");
+  });
+
+  it("captures reasoning_tokens into acc.usage from a usage chunk AFTER finish", () => {
+    const acc = createStreamAccumulator();
+    convertStreamChunk(createChunk({ content: "Hi" }), acc);
+
+    // finish first (real OpenAI ordering)
+    convertStreamChunk(createChunk({}, "stop"), acc);
+
+    const usageChunk = {
+      id: "chatcmpl-123",
+      object: "chat.completion.chunk",
+      created: Date.now(),
+      model: "test-model",
+      choices: [],
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 40,
+        total_tokens: 52,
+        completion_tokens_details: { reasoning_tokens: 25 },
+      },
+    } as ChatCompletionChunk;
+    convertStreamChunk(usageChunk, acc);
+
+    // The accumulator now holds the usage (with reasoning tokens) for the LLM
+    // stream loop to merge into the held final response.
+    expect(acc.usage).toEqual({
+      promptTokenCount: 12,
+      candidatesTokenCount: 40,
+      totalTokenCount: 52,
+      thoughtsTokenCount: 25,
+    });
   });
 });

--- a/tests/converters/schema.test.ts
+++ b/tests/converters/schema.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeSchema } from "../../src/converters/schema";
+
+describe("normalizeSchema", () => {
+  it("normalizes nested OBJECT/STRING/ARRAY types to lowercase", () => {
+    const result = normalizeSchema({
+      type: "OBJECT",
+      properties: {
+        name: { type: "STRING" },
+        tags: { type: "ARRAY", items: { type: "STRING" } },
+        count: { type: "INTEGER" },
+      },
+      required: ["name"],
+    });
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        tags: { type: "array", items: { type: "string" } },
+        count: { type: "integer" },
+      },
+      required: ["name"],
+    });
+  });
+
+  it("is idempotent on already-lowercase schemas", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+
+    expect(normalizeSchema(schema)).toEqual(schema);
+  });
+
+  it("returns undefined for non-object input", () => {
+    expect(normalizeSchema(null)).toBeUndefined();
+    expect(normalizeSchema("string")).toBeUndefined();
+    expect(normalizeSchema(42)).toBeUndefined();
+  });
+
+  it("preserves arrays of primitives (e.g. required, enum)", () => {
+    const result = normalizeSchema({
+      type: "STRING",
+      enum: ["a", "b", "c"],
+    });
+
+    expect(result).toEqual({ type: "string", enum: ["a", "b", "c"] });
+  });
+});

--- a/tests/core/openai-compatible-llm.request.test.ts
+++ b/tests/core/openai-compatible-llm.request.test.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Behavioral tests for OpenAICompatibleLlm that assert the actual request body
+ * sent to the OpenAI SDK and the streaming-usage merge — the COMBINATIONS that
+ * pure converter unit tests cannot observe.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { LlmRequest, LlmResponse } from "@google/adk";
+import type OpenAI from "openai";
+import { OpenAICompatibleLlm } from "../../src/core/openai-compatible-llm";
+import { OPENAI_DEFINITION } from "../../src/providers/openai/definition";
+
+type CreateParams = Parameters<
+  OpenAI["chat"]["completions"]["create"]
+>[0] & {
+  model: string;
+  messages: unknown[];
+  tools?: unknown[];
+  tool_choice?: unknown;
+  stream?: boolean;
+  stream_options?: { include_usage?: boolean };
+  max_tokens?: number;
+  max_completion_tokens?: number;
+  reasoning_effort?: string;
+};
+
+function makeLlm(model: string): OpenAICompatibleLlm {
+  return new OpenAICompatibleLlm(OPENAI_DEFINITION, {
+    model,
+    apiKey: "test-key",
+  });
+}
+
+/** Replaces the SDK call with a spy that records params and returns `result`. */
+function spyCreate(
+  llm: OpenAICompatibleLlm,
+  result: unknown,
+): { calls: CreateParams[] } {
+  const calls: CreateParams[] = [];
+  // biome-ignore lint/suspicious/noExplicitAny: test access to private client
+  (llm as any).client.chat.completions.create = async (params: CreateParams) => {
+    calls.push(params);
+    return result;
+  };
+  return { calls };
+}
+
+function userRequest(overrides: Partial<LlmRequest> = {}): LlmRequest {
+  return {
+    contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+    liveConnectConfig: {},
+    toolsDict: {},
+    ...overrides,
+  } as LlmRequest;
+}
+
+const SIMPLE_COMPLETION = {
+  id: "x",
+  object: "chat.completion",
+  created: 0,
+  model: "test",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "ok", refusal: null },
+      finish_reason: "stop",
+      logprobs: null,
+    },
+  ],
+} as OpenAI.ChatCompletion;
+
+async function drain(
+  gen: AsyncGenerator<LlmResponse, void>,
+): Promise<LlmResponse[]> {
+  const out: LlmResponse[] = [];
+  for await (const r of gen) out.push(r);
+  return out;
+}
+
+describe("OpenAICompatibleLlm request body", () => {
+  it("spreads params, sets stream_options.include_usage on stream", async () => {
+    const llm = makeLlm("gpt-4.1");
+    const { calls } = spyCreate(
+      llm,
+      (async function* () {
+        yield {
+          id: "x",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "test",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        } as OpenAI.ChatCompletionChunk;
+      })(),
+    );
+
+    await drain(
+      llm.generateContentAsync(
+        userRequest({ config: { temperature: 0.4, maxOutputTokens: 50 } }),
+        true,
+      ),
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0];
+    expect(body.model).toBe("gpt-4.1");
+    expect(body.stream).toBe(true);
+    expect(body.stream_options).toEqual({ include_usage: true });
+    expect(body.temperature).toBe(0.4);
+    expect(body.max_tokens).toBe(50);
+  });
+
+  it("does NOT send tool_choice when no tools are present", async () => {
+    const llm = makeLlm("gpt-4.1");
+    const { calls } = spyCreate(llm, SIMPLE_COMPLETION);
+
+    await drain(
+      llm.generateContentAsync(
+        userRequest({
+          config: {
+            toolConfig: {
+              // would map to tool_choice "auto" — but no tools, so it must be omitted
+              functionCallingConfig: { mode: "AUTO" },
+            },
+          } as unknown as LlmRequest["config"],
+        }),
+        false,
+      ),
+    );
+
+    expect(calls[0]).not.toHaveProperty("tool_choice");
+    expect(calls[0]).not.toHaveProperty("tools");
+  });
+
+  it("sends tool_choice only together with tools", async () => {
+    const llm = makeLlm("gpt-4.1");
+    const { calls } = spyCreate(llm, SIMPLE_COMPLETION);
+
+    await drain(
+      llm.generateContentAsync(
+        userRequest({
+          config: {
+            tools: [
+              {
+                functionDeclarations: [
+                  {
+                    name: "get_weather",
+                    description: "",
+                    parameters: { type: "object", properties: {} },
+                  },
+                ],
+              },
+            ],
+            toolConfig: {
+              functionCallingConfig: { mode: "AUTO" },
+            },
+          } as unknown as LlmRequest["config"],
+        }),
+        false,
+      ),
+    );
+
+    expect(calls[0].tools).toHaveLength(1);
+    expect(calls[0].tool_choice).toBe("auto");
+  });
+
+  it("uses max_completion_tokens (not max_tokens) for a gpt-5 reasoning model", async () => {
+    const llm = makeLlm("gpt-5");
+    const { calls } = spyCreate(llm, SIMPLE_COMPLETION);
+
+    await drain(
+      llm.generateContentAsync(
+        userRequest({
+          config: {
+            maxOutputTokens: 128,
+            thinkingConfig: { thinkingBudget: 1000 },
+          },
+        }),
+        false,
+      ),
+    );
+
+    expect(calls[0].max_completion_tokens).toBe(128);
+    expect(calls[0]).not.toHaveProperty("max_tokens");
+    expect(calls[0].reasoning_effort).toBe("low");
+  });
+
+  it("drops reasoning_effort for gpt-4.1 even when thinkingConfig is set", async () => {
+    const llm = makeLlm("gpt-4.1");
+    const { calls } = spyCreate(llm, SIMPLE_COMPLETION);
+
+    await drain(
+      llm.generateContentAsync(
+        userRequest({
+          config: {
+            maxOutputTokens: 128,
+            thinkingConfig: { thinkingBudget: 4096 },
+          },
+        }),
+        false,
+      ),
+    );
+
+    expect(calls[0]).not.toHaveProperty("reasoning_effort");
+    expect(calls[0].max_tokens).toBe(128);
+  });
+});
+
+describe("OpenAICompatibleLlm streaming usage merge", () => {
+  function chunk(
+    delta: OpenAI.ChatCompletionChunk["choices"][0]["delta"],
+    finish: string | null = null,
+  ): OpenAI.ChatCompletionChunk {
+    return {
+      id: "x",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "test",
+      choices: [{ index: 0, delta, finish_reason: finish }],
+    } as OpenAI.ChatCompletionChunk;
+  }
+
+  function usageChunk(): OpenAI.ChatCompletionChunk {
+    return {
+      id: "x",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "test",
+      choices: [],
+      usage: { prompt_tokens: 5, completion_tokens: 7, total_tokens: 12 },
+    } as OpenAI.ChatCompletionChunk;
+  }
+
+  it("captures usage from a chunk that arrives AFTER the finish chunk", async () => {
+    const llm = makeLlm("gpt-4.1");
+    spyCreate(
+      llm,
+      (async function* () {
+        yield chunk({ content: "Hello" });
+        // real OpenAI ordering: finish FIRST, then a usage-only chunk
+        yield chunk({}, "stop");
+        yield usageChunk();
+      })(),
+    );
+
+    const responses = await drain(
+      llm.generateContentAsync(userRequest(), true),
+    );
+
+    // The last yielded response is the final one and must carry the usage that
+    // arrived only AFTER the finish chunk.
+    const final = responses[responses.length - 1];
+    expect(final.turnComplete).toBe(true);
+    expect(final.usageMetadata).toEqual({
+      promptTokenCount: 5,
+      candidatesTokenCount: 7,
+      totalTokenCount: 12,
+    });
+  });
+
+  it("still emits the final response when no trailing usage chunk arrives", async () => {
+    const llm = makeLlm("gpt-4.1");
+    spyCreate(
+      llm,
+      (async function* () {
+        yield chunk({ content: "Hello" });
+        yield chunk({}, "stop");
+      })(),
+    );
+
+    const responses = await drain(
+      llm.generateContentAsync(userRequest(), true),
+    );
+    const final = responses[responses.length - 1];
+    expect(final.turnComplete).toBe(true);
+    expect(final.content?.parts?.[0]).toEqual({ text: "Hello" });
+  });
+});

--- a/tests/providers/anthropic/anthropic-llm.test.ts
+++ b/tests/providers/anthropic/anthropic-llm.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { resetAllConfigs } from "../../../src/config";
 import {
-  AnthropicLlm,
   ANTHROPIC_MODEL_PATTERNS,
+  AnthropicLlm,
 } from "../../../src/providers/anthropic";
 import {
-  describeModelPatterns,
   describeConnectError,
+  describeModelPatterns,
 } from "../../helpers/provider-test-helpers";
 
 describe("AnthropicLlm", () => {
@@ -26,12 +26,7 @@ describe("AnthropicLlm", () => {
       "claude-3-opus-20240229",
       "claude-3-haiku-20240307",
     ],
-    invalidModels: [
-      "gpt-4.1",
-      "grok-4",
-      "gemini-2.0-flash",
-      "llama-3.1",
-    ],
+    invalidModels: ["gpt-4.1", "grok-4", "gemini-2.0-flash", "llama-3.1"],
   });
 
   describe("constructor", () => {
@@ -89,6 +84,184 @@ describe("AnthropicLlm", () => {
         maxRetries: 5,
       });
       expect(llm.model).toBe("claude-sonnet-4-5-20250929");
+    });
+  });
+
+  describe("buildRequestParams (max_tokens override)", () => {
+    // Expose the private buildRequestParams for assertions.
+    type TestableParams = {
+      max_tokens?: number;
+      temperature?: number;
+      top_p?: number;
+      top_k?: number;
+      thinking?: { type: "enabled"; budget_tokens: number };
+    };
+    type ToolChoice =
+      | { type: "auto" }
+      | { type: "none" }
+      | { type: "any" }
+      | { type: "tool"; name: string };
+    type BuildResult = {
+      max_tokens: number;
+      thinking?: { type: "enabled"; budget_tokens: number };
+      tool_choice?: ToolChoice;
+      system?: unknown;
+      tools?: Array<{ name: string; cache_control?: unknown }>;
+    };
+    class TestableAnthropicLlm extends AnthropicLlm {
+      callBuild(
+        params?: TestableParams,
+        opts?: {
+          system?: string;
+          tools?: unknown;
+          toolChoice?: ToolChoice;
+        },
+      ): BuildResult {
+        return (
+          this as unknown as {
+            buildRequestParams: (
+              messages: unknown[],
+              system: string | undefined,
+              tools: unknown,
+              params?: TestableParams,
+              toolChoice?: ToolChoice,
+            ) => BuildResult;
+          }
+        ).buildRequestParams(
+          [],
+          opts?.system,
+          opts?.tools,
+          params,
+          opts?.toolChoice,
+        );
+      }
+    }
+
+    it("uses per-request max_tokens over the instance default", () => {
+      const llm = new TestableAnthropicLlm({
+        model: "claude-sonnet-4-5-20250929",
+        apiKey: "sk-ant-test",
+        maxTokens: 4096,
+      });
+
+      expect(llm.callBuild({ max_tokens: 256 }).max_tokens).toBe(256);
+    });
+
+    it("falls back to the instance default when no per-request value", () => {
+      const llm = new TestableAnthropicLlm({
+        model: "claude-sonnet-4-5-20250929",
+        apiKey: "sk-ant-test",
+        maxTokens: 8192,
+      });
+
+      expect(llm.callBuild().max_tokens).toBe(8192);
+    });
+
+    it("raises max_tokens above the thinking budget when too small", () => {
+      const llm = new TestableAnthropicLlm({
+        model: "claude-sonnet-4-5-20250929",
+        apiKey: "sk-ant-test",
+        maxTokens: 1024,
+      });
+
+      const result = llm.callBuild({
+        thinking: { type: "enabled", budget_tokens: 4096 },
+      });
+      expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 4096 });
+      expect(result.max_tokens).toBe(4097);
+    });
+
+    it("keeps max_tokens when already greater than the thinking budget", () => {
+      const llm = new TestableAnthropicLlm({
+        model: "claude-sonnet-4-5-20250929",
+        apiKey: "sk-ant-test",
+        maxTokens: 8192,
+      });
+
+      const result = llm.callBuild({
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        max_tokens: 8192,
+      });
+      expect(result.max_tokens).toBe(8192);
+    });
+
+    describe("thinking + forced tool_choice reconciliation", () => {
+      const tool = { name: "json_output", description: "", input_schema: {} };
+
+      function newLlm() {
+        return new TestableAnthropicLlm({
+          model: "claude-sonnet-4-5-20250929",
+          apiKey: "sk-ant-test",
+          maxTokens: 8192,
+        });
+      }
+
+      it("downgrades a forced {type:'tool'} choice to auto when thinking is on", () => {
+        const result = newLlm().callBuild(
+          { thinking: { type: "enabled", budget_tokens: 2048 } },
+          { tools: [tool], toolChoice: { type: "tool", name: "json_output" } },
+        );
+        expect(result.tool_choice).toEqual({ type: "auto" });
+      });
+
+      it("downgrades a forced {type:'any'} choice to auto when thinking is on", () => {
+        const result = newLlm().callBuild(
+          { thinking: { type: "enabled", budget_tokens: 2048 } },
+          { tools: [tool], toolChoice: { type: "any" } },
+        );
+        expect(result.tool_choice).toEqual({ type: "auto" });
+      });
+
+      it("preserves {type:'none'} when thinking is on", () => {
+        const result = newLlm().callBuild(
+          { thinking: { type: "enabled", budget_tokens: 2048 } },
+          { tools: [tool], toolChoice: { type: "none" } },
+        );
+        expect(result.tool_choice).toEqual({ type: "none" });
+      });
+
+      it("keeps a forced {type:'tool'} choice when thinking is OFF", () => {
+        const result = newLlm().callBuild(
+          {},
+          { tools: [tool], toolChoice: { type: "tool", name: "json_output" } },
+        );
+        expect(result.tool_choice).toEqual({
+          type: "tool",
+          name: "json_output",
+        });
+      });
+    });
+
+    describe("prompt caching wiring", () => {
+      const tool = { name: "get_weather", description: "", input_schema: {} };
+
+      it("applies cache_control only when promptCaching is enabled", () => {
+        const enabled = new TestableAnthropicLlm({
+          model: "claude-sonnet-4-5-20250929",
+          apiKey: "sk-ant-test",
+          promptCaching: true,
+        });
+
+        const result = enabled.callBuild({}, { system: "sys", tools: [tool] });
+        // System widened to a cacheable text-block array.
+        expect(result.system).toEqual([
+          { type: "text", text: "sys", cache_control: { type: "ephemeral" } },
+        ]);
+        // Last (only) tool carries cache_control.
+        expect(result.tools?.[0].cache_control).toEqual({ type: "ephemeral" });
+      });
+
+      it("does not apply cache_control when promptCaching is disabled (default)", () => {
+        const disabled = new TestableAnthropicLlm({
+          model: "claude-sonnet-4-5-20250929",
+          apiKey: "sk-ant-test",
+        });
+
+        const result = disabled.callBuild({}, { system: "sys", tools: [tool] });
+        // System stays a plain string; tool carries no cache_control.
+        expect(result.system).toBe("sys");
+        expect(result.tools?.[0].cache_control).toBeUndefined();
+      });
     });
   });
 

--- a/tests/providers/anthropic/converters/request.test.ts
+++ b/tests/providers/anthropic/converters/request.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "bun:test";
+import type Anthropic from "@anthropic-ai/sdk";
 import type { LlmRequest } from "@google/adk";
-import type { Schema } from "@google/genai";
-import { convertAnthropicRequest } from "../../../../src/providers/anthropic/converters/request";
+import { FunctionCallingConfigMode, type Schema } from "@google/genai";
+import {
+  applyAnthropicPromptCaching,
+  convertAnthropicGenerationConfig,
+  convertAnthropicRequest,
+  convertAnthropicStructuredOutput,
+  convertAnthropicToolChoice,
+} from "../../../../src/providers/anthropic/converters/request";
 
 function createLlmRequest(overrides: Partial<LlmRequest> = {}): LlmRequest {
   return {
@@ -284,6 +291,686 @@ describe("convertAnthropicRequest", () => {
       const result = convertAnthropicRequest(request);
 
       expect(result.tools).toBeUndefined();
+    });
+  });
+
+  describe("generation config", () => {
+    it("maps sampling fields and clamps temperature >1 to 1", () => {
+      // top_p is dropped because temperature is set (Anthropic rejects both
+      // together); top_k is preserved. See sampling-reconciliation tests below.
+      const request = createLlmRequest({
+        config: {
+          temperature: 1.5,
+          topP: 0.8,
+          topK: 40,
+          maxOutputTokens: 512,
+          stopSequences: ["STOP"],
+        },
+      });
+
+      expect(convertAnthropicGenerationConfig(request)).toEqual({
+        temperature: 1,
+        top_k: 40,
+        max_tokens: 512,
+        stop_sequences: ["STOP"],
+      });
+    });
+
+    it("does not clamp temperature <=1", () => {
+      const request = createLlmRequest({ config: { temperature: 0.6 } });
+      expect(convertAnthropicGenerationConfig(request)).toEqual({
+        temperature: 0.6,
+      });
+    });
+
+    it("drops seed/penalties/candidateCount", () => {
+      const request = createLlmRequest({
+        config: {
+          temperature: 0.5,
+          seed: 1,
+          presencePenalty: 0.2,
+          frequencyPenalty: 0.2,
+          candidateCount: 3,
+        },
+      });
+      expect(convertAnthropicGenerationConfig(request)).toEqual({
+        temperature: 0.5,
+      });
+    });
+
+    it("returns undefined when no sampling fields set", () => {
+      expect(
+        convertAnthropicGenerationConfig(createLlmRequest({ config: {} })),
+      ).toBeUndefined();
+    });
+
+    it("exposes params on the converted request", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
+        config: { maxOutputTokens: 128 },
+      });
+      expect(convertAnthropicRequest(request).params).toEqual({
+        max_tokens: 128,
+      });
+    });
+  });
+
+  describe("extended thinking", () => {
+    it("emits thinking param with the configured budget", () => {
+      const request = createLlmRequest({
+        config: {
+          thinkingConfig: { includeThoughts: true, thinkingBudget: 4096 },
+        },
+      });
+
+      expect(convertAnthropicGenerationConfig(request)?.thinking).toEqual({
+        type: "enabled",
+        budget_tokens: 4096,
+      });
+    });
+
+    it("falls back to the minimum budget (1024) when none/too-small is given", () => {
+      const noBudget = createLlmRequest({
+        config: { thinkingConfig: { includeThoughts: true } },
+      });
+      expect(convertAnthropicGenerationConfig(noBudget)?.thinking).toEqual({
+        type: "enabled",
+        budget_tokens: 1024,
+      });
+
+      const tooSmall = createLlmRequest({
+        config: { thinkingConfig: { thinkingBudget: 100 } },
+      });
+      expect(convertAnthropicGenerationConfig(tooSmall)?.thinking).toEqual({
+        type: "enabled",
+        budget_tokens: 1024,
+      });
+    });
+
+    it("does not emit thinking when thinkingConfig is absent", () => {
+      const request = createLlmRequest({ config: { temperature: 0.5 } });
+      expect(
+        convertAnthropicGenerationConfig(request)?.thinking,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("sampling reconciliation (combinations Anthropic rejects)", () => {
+    it("thinking on + temperature drops a non-1 temperature (omits it)", () => {
+      const request = createLlmRequest({
+        config: {
+          temperature: 0.5,
+          thinkingConfig: { includeThoughts: true, thinkingBudget: 2048 },
+        },
+      });
+      const params = convertAnthropicGenerationConfig(request);
+      expect(params?.thinking).toEqual({
+        type: "enabled",
+        budget_tokens: 2048,
+      });
+      expect(params).not.toHaveProperty("temperature");
+    });
+
+    it("thinking on + temperature===1 keeps temperature", () => {
+      const request = createLlmRequest({
+        config: {
+          temperature: 1,
+          thinkingConfig: { thinkingBudget: 2048 },
+        },
+      });
+      const params = convertAnthropicGenerationConfig(request);
+      expect(params?.temperature).toBe(1);
+    });
+
+    it("thinking on drops top_p and top_k entirely", () => {
+      const request = createLlmRequest({
+        config: {
+          topP: 0.9,
+          topK: 40,
+          thinkingConfig: { thinkingBudget: 2048 },
+        },
+      });
+      const params = convertAnthropicGenerationConfig(request);
+      expect(params).not.toHaveProperty("top_p");
+      expect(params).not.toHaveProperty("top_k");
+      expect(params?.thinking).toEqual({
+        type: "enabled",
+        budget_tokens: 2048,
+      });
+    });
+
+    it("temperature + top_p (no thinking): keeps temperature, drops top_p", () => {
+      const request = createLlmRequest({
+        config: { temperature: 0.7, topP: 0.9 },
+      });
+      const params = convertAnthropicGenerationConfig(request);
+      expect(params?.temperature).toBe(0.7);
+      expect(params).not.toHaveProperty("top_p");
+    });
+
+    it("top_p alone (no temperature, no thinking) is preserved", () => {
+      const request = createLlmRequest({ config: { topP: 0.9 } });
+      const params = convertAnthropicGenerationConfig(request);
+      expect(params?.top_p).toBe(0.9);
+      expect(params).not.toHaveProperty("temperature");
+    });
+
+    it("top_k alone (no thinking) is preserved", () => {
+      const request = createLlmRequest({ config: { topK: 40 } });
+      expect(convertAnthropicGenerationConfig(request)?.top_k).toBe(40);
+    });
+  });
+
+  describe("tool choice", () => {
+    it("maps AUTO to {type:'auto'}", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.AUTO },
+          },
+        },
+      });
+      expect(convertAnthropicToolChoice(request)).toEqual({ type: "auto" });
+    });
+
+    it("maps ANY to {type:'any'}", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.ANY },
+          },
+        },
+      });
+      expect(convertAnthropicToolChoice(request)).toEqual({ type: "any" });
+    });
+
+    it("maps NONE to {type:'none'}", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.NONE },
+          },
+        },
+      });
+      expect(convertAnthropicToolChoice(request)).toEqual({ type: "none" });
+    });
+
+    it("maps ANY with single allowedFunctionName to {type:'tool',name}", () => {
+      const request = createLlmRequest({
+        config: {
+          toolConfig: {
+            functionCallingConfig: {
+              mode: FunctionCallingConfigMode.ANY,
+              allowedFunctionNames: ["get_weather"],
+            },
+          },
+        },
+      });
+      expect(convertAnthropicToolChoice(request)).toEqual({
+        type: "tool",
+        name: "get_weather",
+      });
+    });
+
+    it("returns undefined when no toolConfig", () => {
+      expect(
+        convertAnthropicToolChoice(createLlmRequest({ config: {} })),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("structured output", () => {
+    it("injects a json_output tool + forces tool_choice for responseSchema", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "give json" }] }],
+        config: {
+          responseSchema: {
+            type: "OBJECT",
+            properties: { answer: { type: "STRING" } },
+          } as Schema,
+        },
+      });
+
+      const structured = convertAnthropicStructuredOutput(request);
+      expect(structured?.tool.name).toBe("json_output");
+      expect(structured?.tool.input_schema).toEqual({
+        type: "object",
+        properties: { answer: { type: "string" } },
+      });
+      expect(structured?.toolChoice).toEqual({
+        type: "tool",
+        name: "json_output",
+      });
+
+      const result = convertAnthropicRequest(request);
+      expect(result.tools?.some((t) => t.name === "json_output")).toBe(true);
+      expect(result.toolChoice).toEqual({ type: "tool", name: "json_output" });
+    });
+
+    it("returns undefined when no schema", () => {
+      expect(
+        convertAnthropicStructuredOutput(createLlmRequest({ config: {} })),
+      ).toBeUndefined();
+    });
+
+    it("respects an explicit tool_choice NONE — does not force json_output", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "give json" }] }],
+        config: {
+          responseSchema: {
+            type: "OBJECT",
+            properties: { answer: { type: "STRING" } },
+          } as Schema,
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.NONE },
+          },
+        },
+      });
+
+      const result = convertAnthropicRequest(request);
+      // tool_choice none is preserved; the json_output tool is NOT forced.
+      expect(result.toolChoice).toEqual({ type: "none" });
+      expect(result.tools?.some((t) => t.name === "json_output")).toBeFalsy();
+    });
+
+    it("still forces json_output when tool_choice is AUTO", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "give json" }] }],
+        config: {
+          responseSchema: {
+            type: "OBJECT",
+            properties: { answer: { type: "STRING" } },
+          } as Schema,
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.AUTO },
+          },
+        },
+      });
+
+      const result = convertAnthropicRequest(request);
+      expect(result.toolChoice).toEqual({ type: "tool", name: "json_output" });
+      expect(result.tools?.some((t) => t.name === "json_output")).toBe(true);
+    });
+  });
+
+  describe("extended-thinking round-trip (processContent re-emits thoughts)", () => {
+    it("re-emits a thought part as a thinking block carrying the signature", () => {
+      const request = createLlmRequest({
+        contents: [
+          { role: "user", parts: [{ text: "hi" }] },
+          {
+            role: "model",
+            parts: [
+              {
+                text: "let me reason about this",
+                thought: true,
+                thoughtSignature: "sig-abc123",
+              },
+              { text: "Here is the answer." },
+            ],
+          },
+        ],
+      });
+
+      const result = convertAnthropicRequest(request);
+      const assistant = result.messages[1];
+      expect(assistant.role).toBe("assistant");
+      expect(assistant.content).toEqual([
+        {
+          type: "thinking",
+          thinking: "let me reason about this",
+          signature: "sig-abc123",
+        },
+        { type: "text", text: "Here is the answer." },
+      ]);
+    });
+
+    it("re-emits a redacted thought part (no text) as redacted_thinking", () => {
+      const request = createLlmRequest({
+        contents: [
+          { role: "user", parts: [{ text: "hi" }] },
+          {
+            role: "model",
+            parts: [{ thought: true, thoughtSignature: "encrypted-blob" }],
+          },
+        ],
+      });
+
+      const result = convertAnthropicRequest(request);
+      expect(result.messages[1].content).toEqual([
+        { type: "redacted_thinking", data: "encrypted-blob" },
+      ]);
+    });
+
+    it("does not re-emit a thought part as plain text (signature preserved)", () => {
+      const request = createLlmRequest({
+        contents: [
+          { role: "user", parts: [{ text: "hi" }] },
+          {
+            role: "model",
+            parts: [
+              {
+                text: "reasoning",
+                thought: true,
+                thoughtSignature: "sig-xyz",
+              },
+            ],
+          },
+        ],
+      });
+
+      const blocks = convertAnthropicRequest(request).messages[1]
+        .content as Anthropic.ContentBlockParam[];
+      // The thinking text must not leak through as a plain text block.
+      expect(blocks.some((b) => b.type === "text")).toBe(false);
+      expect(blocks[0]).toEqual({
+        type: "thinking",
+        thinking: "reasoning",
+        signature: "sig-xyz",
+      });
+    });
+
+    it("drops a thought part with no signature (nothing replayable)", () => {
+      const request = createLlmRequest({
+        contents: [
+          { role: "user", parts: [{ text: "hi" }] },
+          {
+            role: "model",
+            parts: [
+              { text: "unsigned reasoning", thought: true },
+              { text: "the answer" },
+            ],
+          },
+        ],
+      });
+
+      const result = convertAnthropicRequest(request);
+      expect(result.messages[1].content).toEqual([
+        { type: "text", text: "the answer" },
+      ]);
+    });
+  });
+
+  describe("prompt caching (opt-in)", () => {
+    const tool = (name: string): Anthropic.Tool => ({
+      name,
+      description: `${name} tool`,
+      input_schema: { type: "object", properties: {} },
+    });
+
+    it("wraps system into a cacheable text block", () => {
+      const result = applyAnthropicPromptCaching("be helpful", undefined);
+      expect(result.system).toEqual([
+        {
+          type: "text",
+          text: "be helpful",
+          cache_control: { type: "ephemeral" },
+        },
+      ]);
+      expect(result.tools).toBeUndefined();
+    });
+
+    it("attaches cache_control only to the last tool", () => {
+      const result = applyAnthropicPromptCaching(undefined, [
+        tool("first"),
+        tool("second"),
+      ]);
+
+      expect(result.system).toBeUndefined();
+      expect(result.tools).toHaveLength(2);
+      // First tool: no cache_control.
+      expect(
+        (result.tools?.[0] as { cache_control?: unknown }).cache_control,
+      ).toBeUndefined();
+      // Last tool: cache_control present.
+      expect(
+        (result.tools?.[1] as { cache_control?: unknown }).cache_control,
+      ).toEqual({ type: "ephemeral" });
+    });
+
+    it("does not mutate the input tools", () => {
+      const tools = [tool("first"), tool("second")];
+      applyAnthropicPromptCaching("sys", tools);
+      // Original array entries remain untouched.
+      expect(
+        (tools[1] as { cache_control?: unknown }).cache_control,
+      ).toBeUndefined();
+    });
+
+    it("returns empty result when no system or tools", () => {
+      expect(applyAnthropicPromptCaching(undefined, undefined)).toEqual({});
+      expect(applyAnthropicPromptCaching("", [])).toEqual({});
+    });
+
+    it("base conversion never emits cache_control (caching is off by default)", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
+        config: {
+          systemInstruction: "be helpful",
+          tools: [
+            {
+              functionDeclarations: [
+                { name: "get_weather", description: "weather" },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = convertAnthropicRequest(request);
+      // System stays a plain string; tools carry no cache_control.
+      expect(typeof result.system).toBe("string");
+      expect(
+        (result.tools?.[0] as { cache_control?: unknown }).cache_control,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("multimodal input", () => {
+    it("maps inlineData image to a base64 image block", () => {
+      const request = createLlmRequest({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              { text: "what is this" },
+              { inlineData: { mimeType: "image/png", data: "AAAA" } },
+            ],
+          },
+        ],
+      });
+
+      const result = convertAnthropicRequest(request);
+      expect(result.messages[0].content).toEqual([
+        { type: "text", text: "what is this" },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "AAAA" },
+        },
+      ]);
+    });
+
+    it("maps inlineData application/pdf to a base64 document block", () => {
+      const request = createLlmRequest({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              { inlineData: { mimeType: "application/pdf", data: "JVBE" } },
+            ],
+          },
+        ],
+      });
+
+      const result = convertAnthropicRequest(request);
+      expect(result.messages[0].content).toEqual([
+        {
+          type: "document",
+          source: {
+            type: "base64",
+            media_type: "application/pdf",
+            data: "JVBE",
+          },
+        },
+      ]);
+    });
+
+    it("maps http fileData image to a url image block", () => {
+      const request = createLlmRequest({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              {
+                fileData: {
+                  mimeType: "image/jpeg",
+                  fileUri: "https://example.com/c.jpg",
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = convertAnthropicRequest(request);
+      expect(result.messages[0].content).toEqual([
+        {
+          type: "image",
+          source: { type: "url", url: "https://example.com/c.jpg" },
+        },
+      ]);
+    });
+
+    it("drops gs:// fileData URIs", () => {
+      const request = createLlmRequest({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              { text: "hi" },
+              {
+                fileData: {
+                  mimeType: "image/png",
+                  fileUri: "gs://bucket/img.png",
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = convertAnthropicRequest(request);
+      expect(result.messages[0].content).toEqual([
+        { type: "text", text: "hi" },
+      ]);
+    });
+  });
+
+  describe("Gemini-only built-in tools", () => {
+    function withConsoleWarn<T>(fn: () => T): { result: T; warns: string[] } {
+      const warns: string[] = [];
+      const original = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warns.push(args.map(String).join(" "));
+      };
+      try {
+        const result = fn();
+        return { result, warns };
+      } finally {
+        console.warn = original;
+      }
+    }
+
+    it("skips a googleSearch tool group and warns once", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        config: {
+          tools: [{ googleSearch: {} } as unknown as Record<string, unknown>],
+        },
+      });
+
+      const { result, warns } = withConsoleWarn(() =>
+        convertAnthropicRequest(request),
+      );
+
+      expect(result.tools).toBeUndefined();
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("googleSearch");
+    });
+
+    it("keeps functionDeclarations while dropping a built-in", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+        config: {
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: "get_weather",
+                  description: "Get weather",
+                  parameters: { type: "object", properties: {} } as Record<
+                    string,
+                    unknown
+                  >,
+                },
+              ],
+            },
+            { codeExecution: {} } as unknown as Record<string, unknown>,
+          ],
+        },
+      });
+
+      const { result, warns } = withConsoleWarn(() =>
+        convertAnthropicRequest(request),
+      );
+
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools?.[0].name).toBe("get_weather");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("codeExecution");
+    });
+  });
+
+  describe("Gemini-only config fields never leak into the body", () => {
+    it("never forwards safetySettings / responseModalities / cachedContent / labels / routingConfig", () => {
+      const request = createLlmRequest({
+        contents: [{ role: "user", parts: [{ text: "Hi" }] }],
+        config: {
+          temperature: 0.5,
+          maxOutputTokens: 100,
+          safetySettings: [
+            { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" },
+          ],
+          responseModalities: ["TEXT"],
+          cachedContent: "cachedContents/abc123",
+          labels: { team: "research" },
+          routingConfig: { autoMode: { modelRoutingPreference: "BALANCED" } },
+        } as unknown as LlmRequest["config"],
+      });
+
+      const result = convertAnthropicRequest(request);
+      const body = {
+        ...result.params,
+        ...(result.tools ? { tools: result.tools } : {}),
+        ...(result.system ? { system: result.system } : {}),
+      };
+
+      expect(result.params).toEqual({ temperature: 0.5, max_tokens: 100 });
+
+      for (const forbidden of [
+        "safetySettings",
+        "safety_settings",
+        "responseModalities",
+        "response_modalities",
+        "cachedContent",
+        "cached_content",
+        "labels",
+        "routingConfig",
+        "routing_config",
+      ]) {
+        expect(body).not.toHaveProperty(forbidden);
+        expect(result.params ?? {}).not.toHaveProperty(forbidden);
+      }
     });
   });
 });

--- a/tests/providers/anthropic/converters/response.test.ts
+++ b/tests/providers/anthropic/converters/response.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type Anthropic from "@anthropic-ai/sdk";
+import { FinishReason } from "@google/genai";
 import {
   convertAnthropicResponse,
   convertAnthropicStreamEvent,
@@ -127,6 +128,34 @@ describe("convertAnthropicResponse", () => {
 
       expect(result.content).toBeUndefined();
       expect(result.turnComplete).toBe(true);
+    });
+  });
+
+  describe("finishReason mapping (non-stream)", () => {
+    function withStop(reason: Anthropic.Message["stop_reason"]) {
+      return convertAnthropicResponse(
+        createMessage({
+          content: [{ type: "text", text: "x", citations: null }],
+          stop_reason: reason,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+      );
+    }
+
+    it("maps end_turn to STOP", () => {
+      expect(withStop("end_turn").finishReason).toBe(FinishReason.STOP);
+    });
+
+    it("maps max_tokens to MAX_TOKENS", () => {
+      expect(withStop("max_tokens").finishReason).toBe(FinishReason.MAX_TOKENS);
+    });
+
+    it("maps tool_use to STOP", () => {
+      expect(withStop("tool_use").finishReason).toBe(FinishReason.STOP);
+    });
+
+    it("maps refusal to SAFETY", () => {
+      expect(withStop("refusal").finishReason).toBe(FinishReason.SAFETY);
     });
   });
 });
@@ -384,6 +413,168 @@ describe("convertAnthropicStreamEvent", () => {
       const result = convertAnthropicStreamEvent(event, acc);
 
       expect(result.response?.usageMetadata).toBeUndefined();
+    });
+  });
+
+  describe("finishReason mapping (stream)", () => {
+    it("captures stop_reason from message_delta and emits it on message_stop", () => {
+      const acc = createAnthropicStreamAccumulator();
+      acc.text = "done";
+
+      convertAnthropicStreamEvent(
+        {
+          type: "message_delta",
+          delta: { stop_reason: "max_tokens", stop_sequence: null },
+          usage: {
+            output_tokens: 5,
+            input_tokens: null,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+            server_tool_use: null,
+          },
+        },
+        acc,
+      );
+
+      const result = convertAnthropicStreamEvent({ type: "message_stop" }, acc);
+
+      expect(result.response?.finishReason).toBe(FinishReason.MAX_TOKENS);
+      expect(acc.stopReason).toBeUndefined();
+    });
+
+    it("maps tool_use stop_reason to STOP", () => {
+      const acc = createAnthropicStreamAccumulator();
+      acc.toolUses.set(0, {
+        id: "c1",
+        name: "get_weather",
+        input: "{}",
+      });
+
+      convertAnthropicStreamEvent(
+        {
+          type: "message_delta",
+          delta: { stop_reason: "tool_use", stop_sequence: null },
+          usage: {
+            output_tokens: 5,
+            input_tokens: null,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+            server_tool_use: null,
+          },
+        },
+        acc,
+      );
+
+      const result = convertAnthropicStreamEvent({ type: "message_stop" }, acc);
+      expect(result.response?.finishReason).toBe(FinishReason.STOP);
+    });
+  });
+
+  describe("extended thinking (non-streaming)", () => {
+    it("converts a thinking block to a thought part with signature", () => {
+      const message = createMessage({
+        content: [
+          {
+            type: "thinking",
+            thinking: "Let me reason about this...",
+            signature: "sig-abc-123",
+          },
+          { type: "text", text: "The answer is 42.", citations: null },
+        ],
+        usage: { input_tokens: 10, output_tokens: 20 },
+      });
+
+      const result = convertAnthropicResponse(message);
+
+      expect(result.content?.parts).toHaveLength(2);
+      const thought = result.content?.parts?.[0];
+      expect(thought?.thought).toBe(true);
+      expect(thought?.text).toBe("Let me reason about this...");
+      expect(thought?.thoughtSignature).toBe("sig-abc-123");
+      expect(result.content?.parts?.[1].text).toBe("The answer is 42.");
+    });
+
+    it("converts a redacted_thinking block to a thought part carrying data", () => {
+      const message = createMessage({
+        content: [
+          { type: "redacted_thinking", data: "encrypted-blob" },
+          { type: "text", text: "Done.", citations: null },
+        ],
+        usage: { input_tokens: 5, output_tokens: 5 },
+      });
+
+      const result = convertAnthropicResponse(message);
+
+      const thought = result.content?.parts?.[0];
+      expect(thought?.thought).toBe(true);
+      expect(thought?.thoughtSignature).toBe("encrypted-blob");
+      expect(thought?.text).toBeUndefined();
+    });
+  });
+
+  describe("extended thinking (streaming)", () => {
+    it("emits a partial thought part for thinking_delta and assembles signature", () => {
+      const acc = createAnthropicStreamAccumulator();
+
+      convertAnthropicStreamEvent(
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: "", signature: "" },
+        },
+        acc,
+      );
+
+      const deltaResult = convertAnthropicStreamEvent(
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "thinking_delta", thinking: "Step 1..." },
+        },
+        acc,
+      );
+
+      const part = deltaResult.response?.content?.parts?.[0];
+      expect(deltaResult.response?.partial).toBe(true);
+      expect(part?.thought).toBe(true);
+      expect(part?.text).toBe("Step 1...");
+
+      convertAnthropicStreamEvent(
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "signature_delta", signature: "sig-xyz" },
+        },
+        acc,
+      );
+
+      expect(acc.thinkingBlocks.get(0)?.thinking).toBe("Step 1...");
+      expect(acc.thinkingBlocks.get(0)?.signature).toBe("sig-xyz");
+
+      const final = convertAnthropicStreamEvent({ type: "message_stop" }, acc);
+      const thought = final.response?.content?.parts?.[0];
+      expect(thought?.thought).toBe(true);
+      expect(thought?.text).toBe("Step 1...");
+      expect(thought?.thoughtSignature).toBe("sig-xyz");
+      expect(acc.thinkingBlocks.size).toBe(0);
+    });
+
+    it("emits a partial thought for a redacted_thinking content_block_start", () => {
+      const acc = createAnthropicStreamAccumulator();
+
+      const result = convertAnthropicStreamEvent(
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "redacted_thinking", data: "enc-blob" },
+        },
+        acc,
+      );
+
+      const part = result.response?.content?.parts?.[0];
+      expect(result.response?.partial).toBe(true);
+      expect(part?.thought).toBe(true);
+      expect(part?.thoughtSignature).toBe("enc-blob");
     });
   });
 });


### PR DESCRIPTION
## Summary

The bridge converters only forwarded `systemInstruction`, message `contents`, and tool `functionDeclarations` to providers — **every other field of ADK's `LlmRequest.config` (a `@google/genai` `GenerateContentConfig`) was silently dropped.** This wires the full model surface through to both converter families (OpenAI-compatible: OpenAI/xAI/OpenRouter/AI Gateway/Custom; and the Anthropic native provider).

## What's passed through now

| Capability | OpenAI-compat | Anthropic |
|---|---|---|
| Sampling config (temperature, topP, topK, maxOutputTokens, stop, seed, penalties, n, logprobs) | ✅ | ✅ |
| `tool_choice` (from `toolConfig.functionCallingConfig`) | ✅ | ✅ |
| `finishReason` (provider → ADK enum) | ✅ | ✅ |
| Streaming token usage | ✅ (`stream_options.include_usage`) | ✅ |
| Multimodal image input (`inlineData`/`fileData`) | ✅ `image_url` | ✅ image + document |
| Structured output (`responseSchema`) | ✅ `response_format json_schema` | ✅ forced `json_output` tool |
| Reasoning/thinking in+out (`thinkingConfig`) | ✅ `reasoning_effort` (model-gated) + thought parts | ✅ extended thinking + signed round-trip |
| Prompt caching | — | ✅ opt-in (instance config) |
| Gemini-only tools/config | filtered + warn | filtered + warn |

`src/` was previously dropping all of this; **no public API changed** (additions are additive). Strict allowlist preserved — config is never blind-spread into a provider body.

## Correctness: provider-API forbidden combinations reconciled

A dual code review (43 agents) found the unit tests covered field *shapes* but missed *combinations* the real APIs reject with `400`. All fixed and verified against the live APIs:
- **Streaming usage** is no longer lost (the loop drained on `finish_reason` before the trailing usage chunk).
- **OpenAI** reasoning models use `max_completion_tokens`; `reasoning_effort` is gated to reasoning-capable models (no more `400` on gpt-4.1/grok); structured output uses `strict:false`.
- **Anthropic** drops sampling params and forced `tool_choice` when extended thinking is enabled; respects `tool_choice: NONE`; replays the signed thinking block for multi-turn tool calls.

## Validation

- **388 unit tests / 0 fail**, typecheck/lint/build/publint/attw all green.
- **Real end-to-end calls across all 5 keyed providers**, including the forbidden combinations: `thinking+temperature`, `thinking+structured-output`, `multi-turn thinking+tool`, `reasoning+maxOutputTokens` (gpt-5.5), and **streaming usage present** — all pass with no `400`.

## Notes
- Reasoning/thinking is opt-in (only emitted when `config.thinkingConfig` is set).
- Anthropic prompt caching is an opt-in instance config (ADK's `cachedContent` is a non-portable Gemini resource).
- Deferred/non-portable: Gemini grounding, code execution, Vertex RAG, Live/bidi (filtered out cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)