### PR TITLE
Release v0.6.0 — external agents bridge (Claude / Codex / Gemini)

### DIFF
--- a/AGENTS_INTEGRATION_REMEDIATION_PLAN.md
+++ b/AGENTS_INTEGRATION_REMEDIATION_PLAN.md
@@ -1,0 +1,183 @@
+# External-Agent SDK Integration — Remediation Plan (Codex + Claude)
+
+_Date: 2026-06-20. Scope: `/home/alex/Projects/ADK/adk-llm-bridge-onmain`. Plan only — no source edits._
+
+## 1. Executive summary
+
+The Codex (`@openai/codex-sdk`) and Claude (`@anthropic-ai/claude-agent-sdk`) external-agent drivers are functionally working but carry several confirmed correctness and policy-fidelity defects, and both dependency pins are stale (Codex 0.130.0 vs 0.141.0; Claude 0.2.141 vs 0.3.183 — the caret pins can never reach the current line). The headline fixes: **Claude** maps a read-only policy to `permissionMode: "plan"` (interactive planning mode that refuses tool execution) and silently inherits host `~/.claude`/project settings because `settingSources` is never set — both undermine deterministic policy-driven execution; it also never wires an `abortController`, orphaning the spawned CLI on early break/error. **Codex** uses the wrong availability signal (the SDK ships its own bundled binary, so "codex on PATH" is meaningless), never persists the thread id from the `thread.started` event (losing resumability on mid-turn failure), and drops ambient proxy/`CODEX_ACCESS_TOKEN` vars from the replacement env. Both drivers blanket-label every error `recoverable: true`, so upstream retry loops spin on unfixable auth/billing failures. This plan bumps both SDKs to current, corrects auth/availability and permission-mode mapping per current docs, fixes lifecycle/error surfacing, and adds the tests/smoke checks to prove each fix.
+
+**Dropped / reclassified from the source audits** (do NOT action as written):
+- **ERR-1 (Claude permission-denied message)** — REFUTED (`isReal=false`). `SDKPermissionDeniedMessage.message` exists and `claude-agent-sdk.ts:349` already reads it via `stringValue(record.message)`. Only a minor enhancement remains (append `tool_name`/`decision_reason`); folded into ERR-2 as low.
+- **CODEX-2 "fall back to `OPENAI_API_KEY`"** — the premise that `OPENAI_API_KEY` is Codex's recommended programmatic auth is **NOT grounded**. Codex CLI auth precedence is `CODEX_API_KEY` > ephemeral store > `CODEX_ACCESS_TOKEN` > `auth.json`; `OPENAI_API_KEY` is not a Codex CLI credential variable. The driver's use of `CODEX_API_KEY` is correct. The only real defect is the example guard's `OPENAI_API_KEY` check (UX inconsistency, low).
+- **LIFECYCLE-1 "Codex abort"** — partially stale: the **Codex** driver already passes `signal: request.context?.abortSignal` (`codex-sdk.ts:203`). LIFECYCLE-1 applies to the **Claude** driver only.
+
+---
+
+## 2. Codex (`@openai/codex-sdk`)
+
+### Version & bump
+
+| | Current | Latest | Action |
+|---|---|---|---|
+| installed | `0.130.0` (pins `@openai/codex` 0.130.0) | `0.141.0` (npm, 2026-06-20) | bump |
+
+- **Root `package.json:63`** peer `">=0.130.0"` → keep `>=0.130.0` lower bound but widen to current line, e.g. `">=0.130.0 <0.142"` (optional peer; do not force a hard floor on consumers).
+- **Root `package.json:84`** dev `"^0.130.0"` → `"^0.141.0"`.
+- **`examples/basic-agent-codex/package.json:15`** dep `"^0.130.0"` → `"^0.141.0"`.
+- Re-run `bun install` and the suite against 0.141.0. TS API surface (`Codex`/`Thread`/`CodexOptions`/`ThreadOptions`/`ThreadEvent`, `ThreadStartedEvent`) is unchanged 0.130→current (verified against installed `node_modules/@openai/codex-sdk/dist/index.d.ts:106-164,218,229`), so this is a within-0.x minor bump with no expected API break. **Note** the upstream main-branch SDK README now describes env as merged "on top of" `process.env` rather than full replacement — re-verify env semantics after the bump (see CODEX-3).
+
+### Confirmed issues (severity-ordered)
+
+| id | sev | location | summary |
+|---|---|---|---|
+| CODEX-1 | medium | `examples/basic-agent-codex/agent.ts:79-87`; driver `codex-sdk.ts:289-297,742-777` | Availability detection keys on `codex` on PATH and never checks `~/.codex/auth.json`; the SDK ships a **bundled** binary (`node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex/codex` present), so PATH is the wrong signal. Worst case: a run starts with no usable credential and 401s. |
+| CODEX-3 | medium | driver `codex-sdk.ts:302-320`; allowlist `provider/codex.ts:9-16` | `buildEnv` builds a **replacement** env (SDK does not inherit `process.env` when `env` is supplied — `dist/index.d.ts:229`). Ambient proxy vars (`https_proxy`/`HTTPS_PROXY`/`NO_PROXY`) are not allowlisted at all, and `CODEX_ACCESS_TOKEN` is missing from `CODEX_ENV_ALLOWLIST`, so they are dropped. A custom shell `CODEX_HOME` is lost unless delivered via structured credential (it IS allowlisted; the gap is ambient delivery). |
+| CODEX-4 | medium | driver `codex-sdk.ts:216,322-365` | Thread id is read as `thread.id` only **after** the stream loop; `normalizeEvent` has no `thread.started` branch. `thread.id` is null until the first turn starts; if the stream throws mid-turn, the id is never captured and resumability is lost. (`ThreadStartedEvent {type:"thread.started", thread_id}` exists — `dist/index.d.ts:106-109,164`.) |
+| CODEX-5 | medium | driver `codex-sdk.ts:231-239,330-353,387-404` | All catch/stream errors yield `recoverable:true`; `describeError` only special-cases the literal "Unable to locate Codex CLI binaries". A 401/auth or missing-credential error passes through as recoverable, so retry loops spin. |
+| CODEX-2 | low | driver `codex-sdk.ts:257`; example `agent.ts:81` | Driver resolves `apiKey` from config then `CODEX_API_KEY` (correct). The example guard checks `OPENAI_API_KEY`, so a run can proceed and then 401 — internal inconsistency only. |
+| CODEX-6 | low | driver `codex-sdk.ts:742-816` | Manual bundled-binary candidate table duplicates SDK-internal resolution (hardcoded vendor triples, 8 ancestor dirs); brittle to future vendor-layout changes and can pick a binary from an unrelated parent workspace. Not broken today; only populates the optional `codexPathOverride`. |
+| CODEX-7 | low | driver `codex-sdk.ts:263-273,407-442` | `webSearchMode`/`webSearchEnabled` are forwarded independently of `networkAccessEnabled` (`policy.allowNetwork`); a driver with web search enabled under `allowNetwork:false` (example sets `allowNetwork:false`) requests web search in a no-network sandbox. |
+
+### Remediation steps
+
+1. **Correct auth + availability detection (CODEX-1, CODEX-2).**
+   - In `examples/basic-agent-codex/agent.ts:79-87` `codexCredentialsAvailable()`: stop treating "codex on PATH" as the availability signal (the SDK bundles its own binary). Replace the signal with: config/`CODEX_API_KEY` present **OR** a readable `auth.json` at `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) **OR** an explicit `CODEX_EXECUTABLE`/`CODEX_CLI_PATH`. Keep `OPENAI_API_KEY` only as an optional convenience signal (and, if kept, document that it is mapped onto `CODEX_API_KEY`, not used directly by the CLI). Update the printed hint accordingly. The guard must still skip cleanly (exit 0) when nothing is present.
+   - Optional, low-risk: have the example/driver, when `OPENAI_API_KEY` is set but `CODEX_API_KEY` is not, map it onto `CODEX_API_KEY` so the guard and the driver agree — or simply align the guard to check `CODEX_API_KEY`. Do not add an `OPENAI_API_KEY` fallback inside the driver's credential resolution.
+   - **Citation:** `developers.openai.com/codex/auth` (fetched 2026-06-20) — "We recommend API key authentication for programmatic Codex CLI workflows"; `developers.openai.com/codex/noninteractive` — `CODEX_API_KEY=<api-key> codex exec`. Auth precedence (`CODEX_API_KEY` > ephemeral > `CODEX_ACCESS_TOKEN` > `auth.json`, `$CODEX_HOME` default `~/.codex`) from `codex-rs/login/src/auth/manager.rs` via Context7 `/openai/codex` (2026-06-20). Bundled binary confirmed empirically (`node_modules/@openai/codex-linux-x64/vendor/.../codex` present; `@openai/codex-sdk` pins `@openai/codex` exactly). **Grounded.**
+
+2. **Deterministic no-credential behavior (CODEX-1, CODEX-5).**
+   - Ensure that when no credential is resolvable the run fails fast and **non-recoverable** rather than starting a turn that 401s with `recoverable:true`. In `codex-sdk.ts` `describeError`/`normalizeEvent`/catch (lines 231-239, 330-353, 387-404): classify errors — surface auth (401)/missing-credential and missing-binary as **non-recoverable** with a distinct code (e.g. `CODEX_AUTH_ERROR`); only mark transient transport errors `recoverable`. Inspect `ThreadErrorEvent {message}` and `TurnFailedEvent {error:{message}}` (the SDK exposes only a message string, so classification is heuristic on the message text + a 401/auth substring check).
+   - **Citation:** `ThreadErrorEvent`/`TurnFailedEvent` in installed `dist/index.d.ts`; `developers.openai.com/codex/auth` confirms 401 arises when valid credentials are unavailable (non-retryable). **Grounded.**
+
+3. **Forward proxy/cert/token vars through the replacement env (CODEX-3).**
+   - In `src/agents/provider/codex.ts:9-16` add `CODEX_ACCESS_TOKEN` to `CODEX_ENV_ALLOWLIST` (documented auth var).
+   - In `codex-sdk.ts:302-320` `buildEnv`, additionally copy ambient proxy/cert vars from `this.#env` when present: `HTTPS_PROXY`/`https_proxy`, `HTTP_PROXY`/`http_proxy`, `NO_PROXY`/`no_proxy`, `SSL_CERT_FILE`, `SSL_CERT_DIR`, `CODEX_HOME` (so a custom shell `CODEX_HOME` is not lost even when not delivered via credential). Do this via the same `copyIfPresent` mechanism used for `PATH`/`HOME`.
+   - After the version bump, re-verify whether 0.141.0 still fully replaces `process.env` (current main README suggests it may now merge on top); if it merges, the proxy-var copy becomes belt-and-suspenders rather than required.
+   - **Citation:** Installed `dist/index.d.ts:229` "will not inherit variables from `process.env`"; `CODEX_ACCESS_TOKEN` is a documented auth.json-precedence var (Context7 `/openai/codex`, 2026-06-20). **Grounded for 0.130.0; re-verify after bump.**
+
+4. **Capture thread id from `thread.started` (CODEX-4).**
+   - In `codex-sdk.ts` `normalizeEvent` (322-365) add a branch for `type === "thread.started"` that records `event.thread_id` immediately, and in `run()` emit the `state_delta` as soon as the id is known (do not wait for the post-loop `thread.id` read at line 216). This persists resumability even if the stream throws mid-turn.
+   - **Citation:** `ThreadStartedEvent {type:"thread.started", thread_id}` `dist/index.d.ts:106-109,164`; `get id()` "Populated after the first turn starts"; `resumeThread` persists to `~/.codex/sessions`. **Grounded.**
+
+5. **Reconcile web search with sandbox network (CODEX-7).**
+   - In `buildThreadOptions` (263-273): only forward `webSearchMode`/`webSearchEnabled` when the resolved `networkAccessEnabled` (from `policy.allowNetwork`) is true; otherwise omit/disable them.
+   - **Citation:** `ThreadOptions` exposes `networkAccessEnabled`/`webSearchMode`/`webSearchEnabled`/`sandboxMode` (`dist/index.d.ts:238-249`). Semantic (web search needs network egress) is logically sound; exact conflict behavior is not explicitly documented — safe, low-risk improvement. **Grounded on type surface; semantics inferred.**
+
+6. **Prefer SDK binary resolution (CODEX-6) — optional cleanup.**
+   - Leave `codexPathOverride` unset unless the user supplies `CODEX_EXECUTABLE`/`CODEX_CLI_PATH`; lean on the SDK's own bundled-binary resolution rather than the hardcoded candidate table (`742-816`). Keep the SDK and its pinned `@openai/codex` CLI on the same version (the SDK pins it exactly). The manual table can remain as a best-effort last resort but should not be the primary path.
+   - **Citation:** `@openai/codex-sdk` package.json pins `@openai/codex` exactly; SDK spawns the bundled CLI. **Grounded.**
+
+---
+
+## 3. Claude (`@anthropic-ai/claude-agent-sdk`)
+
+### Version & bump
+
+| | Current | Latest | Action |
+|---|---|---|---|
+| installed | `0.2.141` | `0.3.183` (npm, 2026-06-20) | bump |
+
+- **Root `package.json:61`** peer `">=0.2.138"` → widen to span the current line, e.g. `">=0.2.138 <0.4"` (optional peer).
+- **Root `package.json:79`** dev `"^0.2.138"` → `"^0.3.183"`.
+- **`examples/basic-agent-claude/package.json:14`** dep `"^0.2.138"` → `"^0.3.183"`.
+- Caret on `0.2.138` can never resolve `0.3.x` (npm 0.x caret semantics lock the minor), so the current line is unreachable today. No confirmed hard API break was found (`query` signature, `settingSources`, `permissionMode`, `systemPrompt` preset/append, `includePartialMessages`, `abortController`, `SDKAssistantMessageError`/`SDKResultError` all present in current docs + installed types), so this is stale-pin/untested-drift, not a known incompatibility. Re-run the suite against 0.3.183.
+
+### Confirmed issues (severity-ordered)
+
+| id | sev | location | summary |
+|---|---|---|---|
+| AUTH-1 | high | driver `claude-agent-sdk.ts:184,127`; example `basic-agent-claude/agent.ts` (never sets it) | `settingSources` defaults `undefined` and `removeUndefined` strips the key, so it is omitted — which loads **all** host sources (user `~/.claude` + project `.claude` + local): permission rules, MCP servers, hooks, CLAUDE.md. This can override the intended read-only policy. |
+| PERM-1 | high | driver `claude-agent-sdk.ts:470-471` | A read-only policy maps to `permissionMode: "plan"` — interactive planning mode that refuses tool execution and drives an `ExitPlanMode` workflow. A read-only Q&A run can stall or return a plan artifact instead of an answer. |
+| LIFECYCLE-1 | high | driver `claude-agent-sdk.ts:148-172,174-196`; `external-agent-driver.ts:15-28` | The `for await` over `sdk.query` sets no `abortController`, has no `try/finally`, and never calls `Query.interrupt()`/`return()`. On early consumer break/upstream error the SDK-owned `claude` subprocess is orphaned. No abort signal is threaded through `ExternalAgentRunRequest`. (Contrast: the Codex driver already passes `signal` at `codex-sdk.ts:203`.) |
+| VER-1 | medium | `package.json:61,79`; both example manifests | Caret pin can never reach 0.3.x; latest 0.3.183. Drift risk (covered by the bump above). |
+| ERR-2 | medium | driver `claude-agent-sdk.ts:158-167,300-311,318-336` | Catch and assistant/result error paths emit `recoverable:true` unconditionally, collapsing the typed `SDKAssistantMessageError` enum (`authentication_failed`/`oauth_org_not_allowed`/`billing_error`/`rate_limit`/`invalid_request`/`server_error`/`max_output_tokens`) and `SDKResultError` subtypes (`error_max_turns`/`error_max_budget_usd`/…). Non-recoverable conditions are mislabeled recoverable. |
+| STREAM-1 | low | driver `claude-agent-sdk.ts:174-196,296-362`; `claude-agent.ts:20` | `includePartialMessages` is never set and there is no `stream_event` branch, yet `capabilities.streaming:true` is advertised. Output is emitted at full-assistant-message granularity, not token deltas. |
+| ERR-3 | low | driver `claude-agent-sdk.ts:318-321` | `result` subtype `success` ignores `record.result` (the final aggregated answer). Normally redundant (assistant text already arrived); edge case where the answer is delivered only on the result message yields silent-empty output. |
+| AUTH-2 | low | driver `claude-agent-sdk.ts:187-189,43` | `systemPrompt` is unconditionally the `claude_code` preset; the type allows a plain string but `buildOptions` never uses it. The SDK no longer defaults to the `claude_code` preset (minimal default since v0.1.0), so forcing the full coding-agent prompt changes persona/token cost for plain Q&A with no opt-out. |
+| ERR-1 | DROP | `claude-agent-sdk.ts:349`; `sdk.d.ts:3202-3225` | **Refuted** — message field exists and is already surfaced. Only a minor enrichment remains (append `tool_name`/`decision_reason`), folded into ERR-2. |
+
+### Remediation steps
+
+1. **Isolate from host settings (AUTH-1).**
+   - In `ClaudeAgentSdkDriver` default `settingSources` to `[]` (SDK isolation mode) instead of leaving it `undefined`, OR have the example pass an intentional allowlist. Because the constructor (`:127`) leaves it `undefined` and `removeUndefined` (`:195,670-674`) strips it, the fix is to provide an explicit default (`[]`) so the key is sent. Allow consumers to opt into specific sources via `ClaudeAgentSdkDriverConfig.settingSources`.
+   - **Citation:** `code.claude.com/docs/en/agent-sdk/typescript` ("Programmatic Configuration for SDK-Only Applications": pass `[]` to opt out) and `.../claude-code-features` ("Omitting `settingSources` defaults to loading all three: user, project, and local"); installed `sdk.d.ts:1659-1669`. Context7, 2026-06-20. **Grounded.**
+
+2. **Correct read-only permission-mode mapping (PERM-1).**
+   - In `mapPolicyToClaudeSdkPermission` (`:461-480`): map a read-only policy to `permissionMode: "default"` (with read-only/no-edit rules) or `"dontAsk"` — NOT `"plan"`. `"plan"` is interactive planning mode that explores without executing and uses `ExitPlanMode`; it is wrong for plain Q&A. Reserve `"acceptEdits"`/`"bypassPermissions"` for write/full-access as today.
+   - **Citation:** `code.claude.com/docs/en/agent-sdk` PermissionMode literal — `"plan"` = "Planning mode - explore without editing", `"dontAsk"` = "Deny anything not pre-approved"; `ExitPlanMode` tool docs; installed `sdk.d.ts:1834`. Context7, 2026-06-20. **Grounded.**
+
+3. **Lifecycle / cancellation (LIFECYCLE-1).**
+   - Thread an abort signal through `ExternalAgentRunRequest` (`external-agent-driver.ts:15-28`) — mirror how Codex reads `request.context?.abortSignal`.
+   - In `buildOptions` (`:174-196`) set `abortController` from that signal, and/or capture the `Query` object from `sdk.query(...)` and call `interrupt()`/`return()` inside a `try/finally` around the `for await` loop (`:148-172`) so the spawned `claude` subprocess is cleaned up on early break or error.
+   - **Citation:** installed `sdk.d.ts:1160` `Options.abortController` ("When aborted, the query will stop and clean up resources") and `:2023-2033` `Query.interrupt()`; query control/abort at `code.claude.com/docs/en/agent-sdk/typescript`. Context7, 2026-06-20. **Grounded.**
+
+4. **Auth precedence — verify, do not rewrite (AUTH-2 context / best practice).**
+   - The driver's `buildEnv` (`:273-294`) replacement-env + `envAllowlist` approach is **correct** and already includes API key, OAuth token, Bedrock/Vertex/Foundry switches (`provider/schema.ts:30-41`). Credentials resolve **inside** the spawned CLI: `ANTHROPIC_API_KEY` (API key) → existing Claude Code OAuth/subscription (`CLAUDE_CODE_OAUTH_TOKEN`) → native CLI auth. Because env **replaces** `process.env`, keep copying `PATH`/`HOME`/`CLAUDE_CONFIG_DIR`/`XDG_CONFIG_HOME` (already done).
+   - Enhancement (not currently implemented): read the init `SDKSystemMessage.apiKeySource` to fail fast / report which auth path is in use. Do not change the precedence — only add observability.
+   - Keep the example guard (`basic-agent-claude/agent.ts:71-79`) as is (it already checks `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`/`CLAUDE_CODE_OAUTH_TOKEN`/executable) — it is consistent with the driver, unlike the Codex guard.
+   - **Citation:** `buildEnv` env semantics + `apiKeySource` on `SDKSystemMessage` (installed `sdk.d.ts`); auth/env guidance at `code.claude.com/docs/en/agent-sdk/typescript`. Context7, 2026-06-20. **Grounded.**
+
+5. **Error classification (ERR-2, + ERR-1 enrichment).**
+   - In `normalizeMessage` (`:296-362`) and the `run` catch (`:158-167`): set `recoverable` from the typed enums instead of blanket `true`. Treat `authentication_failed`/`oauth_org_not_allowed`/`billing_error`/`invalid_request` and result subtypes `error_max_turns`/`error_max_budget_usd`/`error_max_structured_output_retries` as **non-recoverable**; `rate_limit`/`server_error`/transient transport as recoverable. Use a meaningful `code` from the subtype.
+   - For permission-denied (`:345-355`), additionally append `record.tool_name` and `record.decision_reason`/`decision_reason_type` to the surfaced message (the rejection text itself is already surfaced — ERR-1 refuted).
+   - **Citation:** installed `sdk.d.ts:2465-2470` `SDKAssistantMessageError` enum, `:3292-3322` `SDKResultError` subtypes/`errors[]`, `:3202-3225` `SDKPermissionDeniedMessage` (`tool_name`/`decision_reason`/`message`); result/message types at `code.claude.com/docs/en/agent-sdk/typescript`. Context7, 2026-06-20. **Grounded.**
+
+6. **Streaming fidelity (STREAM-1) — choose one.**
+   - Either set `includePartialMessages: true` in `buildOptions` and add a `stream_event` branch in `normalizeMessage` that handles `content_block_delta`/`text_delta` to emit incremental output; **or** drop the `streaming:true` claim from `claude-agent.ts:20` capabilities to match actual behavior.
+   - **Citation:** `code.claude.com/docs/en/agent-sdk/streaming-output` (TS example sets `includePartialMessages:true` and reads `message.type==='stream_event'` → `content_block_delta` → `text_delta`); installed `sdk.d.ts:1392`. Context7, 2026-06-20. **Grounded.**
+
+7. **Result fallback (ERR-3) — optional.**
+   - In the `result` `success` branch (`:318-321`), if no assistant text was emitted during the turn, fall back to `record.result` (the final aggregated answer) before emitting `completed`, to avoid silent-empty output on that edge.
+   - **Citation:** `SDKResultSuccess.result:string` installed `sdk.d.ts:3314-3322`. **Grounded.**
+
+8. **Plain-string system prompt (AUTH-2) — optional.**
+   - In `buildOptions` (`:187-189`) honor a configured plain-string `systemPrompt` (the type at `:43` already allows it) so non-coding agents are not forced into the `claude_code` preset; keep preset+append as the opt-in default.
+   - **Citation:** `code.claude.com/docs/en/agent-sdk/modifying-system-prompts` (plain-string `systemPrompt`) + migration-guide (minimal default since v0.1.0). Context7, 2026-06-20. **Grounded.**
+
+---
+
+## 4. Cross-cutting items
+
+- **Shared abort plumbing.** Add an abort/cancellation signal to `ExternalAgentRunRequest` (`src/agents/external-agent-driver.ts:15-28`) as a first-class field. Codex already consumes `request.context?.abortSignal` (`codex-sdk.ts:203`); make Claude consume the same so both drivers share one cancellation contract (supports LIFECYCLE-1).
+- **Shared error-classification helper.** Both drivers blanket-set `recoverable:true` (CODEX-5, ERR-2). Factor a small `classifyRecoverable(message|subtype)` helper (in `src/agents/runtime/` or `events.ts`) that maps auth/billing/missing-binary/quota-exhausted → non-recoverable and transport/rate-limit → recoverable, and use it in both `normalizeEvent`/`normalizeMessage` and the catch blocks. Add distinct codes (`CODEX_AUTH_ERROR`, reuse `CLAUDE_AUTH_STATUS`/subtype codes).
+- **Example guard consistency.** Codex example guard (`basic-agent-codex/agent.ts:79-87`) must align with the driver's `CODEX_API_KEY` + `auth.json` reality (CODEX-1/2). Claude example guard is already consistent; leave it. Both must continue to exit 0 with a clear hint when no credential is present.
+- **Env-passthrough audit.** Reconcile `CODEX_ENV_ALLOWLIST` (`provider/codex.ts`) and the Claude allowlist (`provider/schema.ts:30-41`) with the ambient vars each `buildEnv` copies, since both drivers use replacement-env semantics; add proxy/cert vars (CODEX-3) and `CODEX_ACCESS_TOKEN`.
+
+### Tests to add (Bun, under `tests/agents/`)
+
+- **Codex auth/availability:** unit test that `codexCredentialsAvailable()` returns true for `auth.json` present + no PATH binary, and false for none; that the driver does not add an `OPENAI_API_KEY` fallback to credential resolution.
+- **Codex `thread.started`:** feed a fake event stream emitting `thread.started` then a mid-turn throw; assert the `state_delta` carrying the thread id is emitted (resumability preserved) even on failure (`codex-sdk.test.ts`).
+- **Codex env:** assert `buildEnv` forwards `CODEX_HOME`/proxy/cert/`CODEX_ACCESS_TOKEN` when present in `this.#env`/credential, and that the allowlist includes `CODEX_ACCESS_TOKEN`.
+- **Codex web-search reconciliation:** assert `webSearchEnabled` is dropped when `allowNetwork:false`.
+- **Codex/Claude error classification:** table-driven test mapping auth/billing/rate-limit/transport → expected `recoverable` and `code` for both drivers.
+- **Claude `settingSources`:** assert the driver sends `settingSources: []` by default (not omitted) (`claude-agent-sdk.test.ts`).
+- **Claude permission mode:** assert read-only policy → `permissionMode` `"default"`/`"dontAsk"` (NOT `"plan"`); keep existing write/full-access assertions.
+- **Claude lifecycle:** assert an `abortController` is set on options and that `interrupt()`/`return()` is invoked on early break (spy on a fake `Query`).
+- **Claude permission-denied enrichment:** assert `tool_name`/`decision_reason` are appended (guard against the ERR-1 over-correction — the base message must still be surfaced).
+
+---
+
+## 5. Ordered execution checklist
+
+1. **Bumps first (low risk, unblocks testing against current APIs).** Update both SDK pins in root `package.json` (peer + dev) and both example manifests; `bun install`; run `bun run typecheck:all` and `bun test` to establish a green baseline on 0.141.0 / 0.3.183.
+2. **Claude PERM-1** (read-only → `"default"`/`"dontAsk"`) — highest behavioral impact, smallest change.
+3. **Claude AUTH-1** (`settingSources: []` default).
+4. **Claude LIFECYCLE-1 + shared abort plumbing** (add abort field to `ExternalAgentRunRequest`; wire `abortController`/`interrupt` in Claude; confirm Codex already consumes it).
+5. **Shared error-classification helper → apply to Claude ERR-2 and Codex CODEX-5** (incl. Codex deterministic no-credential non-recoverable failure).
+6. **Codex CODEX-4** (`thread.started` capture).
+7. **Codex CODEX-1/CODEX-2** (auth/availability detection in example guard; align `CODEX_API_KEY`).
+8. **Codex CODEX-3** (allowlist `CODEX_ACCESS_TOKEN`; forward proxy/cert/`CODEX_HOME`) — re-verify env replacement semantics on 0.141.0.
+9. **Codex CODEX-7** (web-search ↔ network reconciliation).
+10. **Low-priority polish:** Claude STREAM-1 (enable partials or drop the claim), ERR-3 (result fallback), AUTH-2 (plain-string prompt), permission-denied enrichment; Codex CODEX-6 (prefer SDK binary resolution).
+11. Add tests alongside each fix (section 4).
+
+### Risks / verification
+
+- **API drift from the bumps (VER-1 / Codex minor).** Mitigate: bump first (step 1) and rely on `bun run typecheck:all` to catch any 0.3.x / 0.141.0 type breaks before behavioral changes. No hard break is expected (surfaces verified in installed `.d.ts` and current docs), but the Claude minor jump (0.2→0.3) and the Codex env-merge README change warrant a fresh typecheck + full test run.
+- **Prove permission/setting fixes (PERM-1, AUTH-1).** Unit tests on `mapPolicyToClaudeSdkPermission` and `buildOptions` output (`settingSources`, `permissionMode`); plus a no-cred smoke (`SMOKE_PROMPT` with no `ANTHROPIC_API_KEY`) must still exit 0, and a credentialed read-only smoke must return a direct answer (not a plan artifact / not stalling on `ExitPlanMode`).
+- **Prove lifecycle (LIFECYCLE-1).** Test with a fake `Query` that records `interrupt()`/`return()` calls; assert they fire on early `break` and on thrown error; assert `abortController` present in options.
+- **Prove Codex resumability (CODEX-4).** Fake event stream emitting `thread.started` then throwing; assert `state_delta` with the thread id is yielded.
+- **Prove error classification (CODEX-5, ERR-2).** Table-driven tests; assert non-recoverable for auth/billing/missing-binary, recoverable for transport/rate-limit.
+- **Prove env passthrough (CODEX-3).** Unit-assert forwarded keys; for runtime, a behind-proxy smoke (set `HTTPS_PROXY`) reaching the model proves egress survives the replacement env.
+- **No-credential smoke (both providers).** `bun run` each example with all credential env vars unset → must print the hint and exit 0; with `CODEX_API_KEY`/`ANTHROPIC_API_KEY` set → must produce a response. Re-run the Codex smoke with only `auth.json` present (no PATH binary) to prove the corrected availability detection.
+- **Gate:** `bun run ci` (typecheck:all + lint + test + build + lint:publish) must pass before and after the change set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-06-20
+
+### Added
+
+- **External agents bridge** (`adk-llm-bridge/agents`). A new subsystem that wraps
+  full external coding agents as native ADK agents, preserving multi-agent
+  orchestration, tool calling, and streaming:
+  - Anthropic Claude via the Claude Agent SDK (`ClaudeAgent`).
+  - OpenAI Codex via the Codex SDK/CLI (`CodexAgent`).
+  - Google Gemini via the Gemini CLI (`GeminiCliAgent`).
+  - A driver abstraction (SDK / CLI / subprocess modes), credential providers,
+    permission-policy mapping, runtime sessions, a tool gateway, and a native
+    ADK event stream (`ExternalAgentEvent`).
+- Examples: `basic-agent-claude`, `basic-agent-codex`, `basic-agent-gemini`, and
+  the combined `external-agents` showcase.
+
+### Changed
+
+- SDK pins: `@openai/codex-sdk` `^0.141.0` and
+  `@anthropic-ai/claude-agent-sdk` `^0.3.183`.
+
+### Fixed
+
+- **Codex driver:** availability detection now keys on `CODEX_API_KEY` /
+  `$CODEX_HOME/auth.json` instead of a `codex` binary on `PATH` (the SDK bundles
+  its own); errors are classified (auth/billing/missing-binary non-recoverable,
+  transport/rate-limit recoverable); the thread id is captured from
+  `thread.started` so resumability survives a mid-turn failure; and proxy/cert/
+  `CODEX_HOME`/`CODEX_ACCESS_TOKEN` vars are forwarded through the replacement env.
+- **Claude driver:** a read-only policy maps to `permissionMode: "default"`
+  (no longer the interactive `"plan"` mode); `settingSources` defaults to `[]`
+  (SDK isolation) so host `~/.claude`/project settings no longer leak in; the
+  spawned CLI is cancelled via `abortController` + `interrupt()`/`return()` on
+  early break or error; and errors are classified from the SDK's typed subtypes.
+
 ## [0.5.3] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,6 +95,50 @@ const agent = new LlmAgent({
 });
 ```
 
+## External Agent Runtimes (Opt-in)
+
+`adk-llm-bridge` keeps its root import focused on LLM providers. Existing code that imports from `adk-llm-bridge` is unchanged. External agent runtime helpers are available from the explicit `/agents` subpath:
+
+```typescript
+import { CodexAgent, ClaudeAgent, GeminiCliAgent } from "adk-llm-bridge/agents";
+```
+
+Use this API when you want an ADK agent graph to include provider-owned coding CLIs/runtimes as `BaseAgent`-compatible sub-agents. The agent layer exposes shared configuration, credential, permission, provider registry, and runtime drivers while keeping provider auth/configuration owned by each external runtime. `CodexAgent` uses the official `@openai/codex-sdk` driver by default; pass `new CodexCliDriver()` explicitly when you need the lower-level CLI fallback.
+
+```typescript
+import { LlmAgent } from "@google/adk";
+import { AIGateway } from "adk-llm-bridge";
+import { ClaudeAgent, EnvCredentialProvider } from "adk-llm-bridge/agents";
+
+const reviewer = new ClaudeAgent({
+  name: "CodeReviewer",
+  credentialProvider: new EnvCredentialProvider(),
+  workingDirectory: process.cwd(),
+  permissions: {
+    mode: "ask",
+    allowNetwork: false,
+    allowedPaths: [process.cwd()],
+  },
+  instruction: "Review this change for correctness and safety.",
+});
+
+export const rootAgent = new LlmAgent({
+  name: "Coordinator",
+  model: AIGateway("anthropic/claude-sonnet-4"),
+  instruction: "Route code review tasks to the reviewer sub-agent.",
+  subAgents: [reviewer],
+});
+```
+
+### External Agent Auth and Permissions
+
+- **Provider-owned auth** — Codex, Claude Code, Gemini CLI, or a custom runtime should continue to own its normal authentication flow.
+- **No default secret persistence** — the default credential provider stores nothing. Use `EnvCredentialProvider` to pass only provider-allowlisted environment variables, or provide your own `ExternalAgentCredentialProvider` for a secret manager.
+- **Optional runtime dependencies** — importing `adk-llm-bridge/agents` does not install or execute provider CLIs. Wire a driver/runtime explicitly in applications that need one.
+- **Permission presets** — use `read-only`, `ask`, `workspace-write`, or `full-access` policies, plus optional `allowNetwork` and `allowedPaths`, so provider drivers can map ADK intent to provider-specific sandbox flags.
+
+See [examples/external-agents](./examples/external-agents) for a shape-only example.
+
 ## Configuration
 
 ### Environment Variables
@@ -300,6 +344,7 @@ See the [examples](./examples) directory:
 - **[basic-agent-lmstudio](./examples/basic-agent-lmstudio)** - Multi-agent HelpDesk with LM Studio
 - **[native-features](./examples/native-features)** - Showcase of native model capabilities (sampling, reasoning, structured output, multimodal, tool_choice, streaming) across all 5 providers
 - **[express-server](./examples/express-server)** - Production HTTP API with sessions, streaming, tools
+- **[external-agents](./examples/external-agents)** - Opt-in `/agents` API shape for external runtime sub-agents
 
 ## Requirements
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,21 +10,21 @@
         "openai": "^6.37.0",
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.138",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.183",
         "@arethetypeswrong/cli": "^0.18.3",
         "@biomejs/biome": "^2.3.10",
         "@google/adk": "^1.2.0",
         "@google/genai": "^2.0.1",
-        "@openai/codex-sdk": "^0.130.0",
+        "@openai/codex-sdk": "^0.141.0",
         "@types/bun": "latest",
         "bunup": "^0.16.32",
         "publint": "^0.3.21",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "@anthropic-ai/claude-agent-sdk": ">=0.2.138",
+        "@anthropic-ai/claude-agent-sdk": ">=0.2.138 <0.4",
         "@google/adk": ">=0.6.1 <2",
-        "@openai/codex-sdk": ">=0.130.0",
+        "@openai/codex-sdk": ">=0.130.0 <0.142",
       },
       "optionalPeers": [
         "@anthropic-ai/claude-agent-sdk",
@@ -37,23 +37,23 @@
 
     "@andrewbranch/untar.js": ["@andrewbranch/untar.js@1.0.3", "", {}, "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.141", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.183", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.183", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.183", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.183", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.183", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.183", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.183", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.183", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.183" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-rAKws76RKdFu+DK5q9wYN0AGLRdPrw0vGd+TMzSFynFdxwUAehYc9vUKJoK27j2xRoHFdNt+JDsih5BzsUzi+Q=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.183", "", { "os": "darwin", "cpu": "arm64" }, "sha512-o/+sxwKgXuw6RG5cERWjvcvL1CDSPe/TaXMhax+dq+V4lDOI5iTqg3y5Wfb6dL3xlWoTA2OhWowDQllKbE04LQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141", "", { "os": "darwin", "cpu": "x64" }, "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.183", "", { "os": "darwin", "cpu": "x64" }, "sha512-V7Cf8JeD5EPf4MPomFUlEblCIQI0wg+aWdOSqvfMsDmCBEHljd52CQ3a7W263oVt6I7QUfRTpX2KNvdma56rDA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.183", "", { "os": "linux", "cpu": "arm64" }, "sha512-qqnSf85D3uBH7kRHLGOMhr7aQrREUZ4hUlCztrkJe/twUT4bmJsO86zamnAf7vOYeCul/sHYwBMmXtOfI+cHZg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.183", "", { "os": "linux", "cpu": "arm64" }, "sha512-ua6XaiCcYYKfd0CY9cjoyYnTQWI2GocpbP7Gwvmr+9taW/lTpQGVQH3FrF2VFKXVSt7AaVE6Z7WN9oPxcxl3VA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.183", "", { "os": "linux", "cpu": "x64" }, "sha512-GvfNp9XsKWFvr0EH3NgX2pqzHPYhFeqhOmVc4A+2e+GdxBMYUEa0ylfPLJItahQU9FkTJAw2oQNnzTHPPm1GxA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.183", "", { "os": "linux", "cpu": "x64" }, "sha512-wp+p+4xeZOW+h4InMKR7nIdGlgYftXyR+ErOVz7i2tMRcKuYMoc5jRIYjdJkuETMSr5nsRj0rDeO5gG7M6MGZQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141", "", { "os": "win32", "cpu": "arm64" }, "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.183", "", { "os": "win32", "cpu": "arm64" }, "sha512-cGyMC9YDsrCQ4av74dMVa2liOb5oLFX4+1SxwJGRCW7mBVBazcM6rg7ifWbd9XfkDhNPKOIfyiloipyMfoaE4g=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141", "", { "os": "win32", "cpu": "x64" }, "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.183", "", { "os": "win32", "cpu": "x64" }, "sha512-h/XzbrSmXGroTk/FYKR6J4/8G9vDb1HUUUeNXeBGqGW1kppIiWPJKLRzjtSe0brVjADOKOT6tE5IHK0mV/1gBw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.95.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ=="],
 
@@ -211,21 +211,21 @@
 
     "@npmcli/move-file": ["@npmcli/move-file@1.1.2", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg=="],
 
-    "@openai/codex": ["@openai/codex@0.130.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w=="],
+    "@openai/codex": ["@openai/codex@0.141.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-ACpAn/Z7JwBg431040zKOLpBtNdP024ixqwC/R2YM5tPrLG0wfSmrd/AVHPUExt6hOO6fEHwxM/ixAyzFleQXw=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.130.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.141.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BuroZvQQLJYLfQEG7MKMdxHtggDDlxeJCTot//MwEnbW8ga7P319EPos/FyOK9r/gh+E/KGxk+YAzEoHZPRGEg=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.130.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.141.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-kDP+egfjp3cuao1r9AdD8/skBxM7saT007VE82DB9mRUcqgKaxYHoPaHmKhlYOlFwPam0zsD6ORT6GJJhvGAKg=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.130.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.141.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-jXAOSjMqAUUgfMo9ciAkioJKKAYDwOE40bLx4/2jR7Tfu4u9409X5fQlLuNLMgnlfuzUEk/UiibQE62a70bQaw=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.130.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.141.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-q3xv538DT/Sb8rRq8apdKgrgA/isqs1fDfE5JhRDMmojYFA3zwDldlmdWWGdS3APtjf5UrDsqljSE9JHxnlWNA=="],
 
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.130.0", "", { "dependencies": { "@openai/codex": "0.130.0" } }, "sha512-ICKaZ5zrIDg71AiQcsUToVoe5Icmrc3LwSM5+2z7Cf8F1x6nOaY7/ucpFlr4aH8oDe7t3dangc+MsWZTkdvDFw=="],
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.141.0", "", { "dependencies": { "@openai/codex": "0.141.0" } }, "sha512-VCLsSJGSoOHcVAC/2+NrhtiBiCP/XF8YmCzzGocm8qNkAPN3a/+CcrvwUmvNSH53dU3TVi5Hp5zddov16BXLHw=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.130.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.141.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-87X5tvH1RmKQOHbgO5Cv+S0aXJ+saHTSSHEasJjbB1FtUoLbao29NTnkpkB2dAV3xtUJ/dmE8NgvbFEeWuMqUQ=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.130.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.141.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-4gur4DgFQIOc+DopNOI90IpNA66qBIyc5Lb5QYy66OOCXOvXpbOCpScuEFmT1xpaTzNUYhlRGA2NFWqSHQrKUQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
@@ -1316,8 +1316,6 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
-
-    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,22 +5,31 @@
     "": {
       "name": "adk-llm-bridge",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.78.0",
-        "openai": "^6.27.0",
+        "@anthropic-ai/sdk": "^0.95.1",
+        "@opentelemetry/api": "^1.9.1",
+        "openai": "^6.37.0",
       },
       "devDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.138",
         "@arethetypeswrong/cli": "^0.18.3",
         "@biomejs/biome": "^2.3.10",
         "@google/adk": "^1.2.0",
-        "@google/genai": "^1.40.0",
+        "@google/genai": "^2.0.1",
+        "@openai/codex-sdk": "^0.130.0",
         "@types/bun": "latest",
         "bunup": "^0.16.32",
         "publint": "^0.3.21",
-        "typescript": "^5.3.0",
+        "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "@google/adk": ">=0.5.0 <2",
+        "@anthropic-ai/claude-agent-sdk": ">=0.2.138",
+        "@google/adk": ">=0.6.1 <2",
+        "@openai/codex-sdk": ">=0.130.0",
       },
+      "optionalPeers": [
+        "@anthropic-ai/claude-agent-sdk",
+        "@openai/codex-sdk",
+      ],
     },
   },
   "packages": {
@@ -28,7 +37,25 @@
 
     "@andrewbranch/untar.js": ["@andrewbranch/untar.js@1.0.3", "", {}, "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.141", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141", "", { "os": "darwin", "cpu": "x64" }, "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141", "", { "os": "win32", "cpu": "arm64" }, "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141", "", { "os": "win32", "cpu": "x64" }, "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.95.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ=="],
 
     "@arethetypeswrong/cli": ["@arethetypeswrong/cli@0.18.3", "", { "dependencies": { "@arethetypeswrong/core": "0.18.3", "chalk": "^4.1.2", "cli-table3": "^0.6.3", "commander": "^10.0.1", "marked": "^9.1.2", "marked-terminal": "^7.1.0", "semver": "^7.5.4" }, "bin": { "attw": "./dist/index.js" } }, "sha512-GeAlc+lUD4gKHD/LDQNvQY30FfQ+xAXg2inbQKUjFZgTOdI5ygEweaOnGHGBPSKXSLGQC7VLhpXu9zMnYk/4sQ=="],
 
@@ -134,7 +161,7 @@
 
     "@google/adk": ["@google/adk@1.2.0", "", { "dependencies": { "@a2a-js/sdk": "^0.3.10", "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0", "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0", "@google-cloud/storage": "^7.17.1", "@google-cloud/vertexai": "^1.12.0", "@google/genai": "^1.37.0", "@mikro-orm/core": "^6.6.10", "@mikro-orm/reflection": "^6.6.6", "@modelcontextprotocol/sdk": "^1.26.0", "@opentelemetry/api": "1.9.0", "@opentelemetry/api-logs": "^0.205.0", "@opentelemetry/exporter-logs-otlp-http": "^0.205.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.205.0", "@opentelemetry/exporter-trace-otlp-http": "^0.205.0", "@opentelemetry/resource-detector-gcp": "^0.40.0", "@opentelemetry/resources": "^2.1.0", "@opentelemetry/sdk-logs": "^0.205.0", "@opentelemetry/sdk-metrics": "^2.1.0", "@opentelemetry/sdk-trace-base": "^2.1.0", "@opentelemetry/sdk-trace-node": "^2.1.0", "express": "^4.22.1", "google-auth-library": "^10.3.0", "js-yaml": "^4.1.1", "jsonpath-plus": "^10.4.0", "lodash-es": "^4.18.1", "winston": "^3.19.0", "zod": "^4.2.1", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@mikro-orm/mariadb": "^6.6.6", "@mikro-orm/mssql": "^6.6.6", "@mikro-orm/mysql": "^6.6.6", "@mikro-orm/postgresql": "^6.6.6", "@mikro-orm/sqlite": "^6.6.6" } }, "sha512-EIDd9eb7AIwWmvt6wnKs688mPVxhjqUEmYQisiCbmo37Rk9jeyTLRYnBXSXFEXzUm0GvOUvWBWutqP0r+E7XDA=="],
 
-    "@google/genai": ["@google/genai@1.44.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A=="],
+    "@google/genai": ["@google/genai@2.9.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
@@ -170,7 +197,7 @@
 
     "@mikro-orm/sqlite": ["@mikro-orm/sqlite@6.6.9", "", { "dependencies": { "@mikro-orm/knex": "6.6.9", "fs-extra": "11.3.3", "sqlite3": "5.1.7", "sqlstring-sqlite": "0.1.1" }, "peerDependencies": { "@mikro-orm/core": "^6.0.0" } }, "sha512-kl9rHS0DH7hWg7Qz6rNzcmsHQmzmmxsl1u3luwPuGTvez7dTM0f3Z+36NxFyQA1gcyHagyZO4pxIn0ZyiU+E4Q=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
@@ -184,7 +211,23 @@
 
     "@npmcli/move-file": ["@npmcli/move-file@1.1.2", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg=="],
 
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+    "@openai/codex": ["@openai/codex@0.130.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.130.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.130.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.130.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.130.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA=="],
+
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.130.0", "", { "dependencies": { "@openai/codex": "0.130.0" } }, "sha512-ICKaZ5zrIDg71AiQcsUToVoe5Icmrc3LwSM5+2z7Cf8F1x6nOaY7/ucpFlr4aH8oDe7t3dangc+MsWZTkdvDFw=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.130.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.130.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.205.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg=="],
 
@@ -341,6 +384,8 @@
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
 
@@ -597,6 +642,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -936,7 +983,7 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
-    "openai": ["openai@6.27.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ=="],
+    "openai": ["openai@6.44.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA=="],
 
     "oxc-minify": ["oxc-minify@0.93.0", "", { "optionalDependencies": { "@oxc-minify/binding-android-arm64": "0.93.0", "@oxc-minify/binding-darwin-arm64": "0.93.0", "@oxc-minify/binding-darwin-x64": "0.93.0", "@oxc-minify/binding-freebsd-x64": "0.93.0", "@oxc-minify/binding-linux-arm-gnueabihf": "0.93.0", "@oxc-minify/binding-linux-arm-musleabihf": "0.93.0", "@oxc-minify/binding-linux-arm64-gnu": "0.93.0", "@oxc-minify/binding-linux-arm64-musl": "0.93.0", "@oxc-minify/binding-linux-riscv64-gnu": "0.93.0", "@oxc-minify/binding-linux-s390x-gnu": "0.93.0", "@oxc-minify/binding-linux-x64-gnu": "0.93.0", "@oxc-minify/binding-linux-x64-musl": "0.93.0", "@oxc-minify/binding-wasm32-wasi": "0.93.0", "@oxc-minify/binding-win32-arm64-msvc": "0.93.0", "@oxc-minify/binding-win32-x64-msvc": "0.93.0" } }, "sha512-pwMjOGN/I+cfLVkSmECcVHROKwECNVAXCT5h/29S4f0aArIUh3CQnix1yYy7MTQ3yThNuGANjjE9jWJyT43Vbw=="],
 
@@ -1122,6 +1169,8 @@
 
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
@@ -1268,6 +1317,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
+    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
+
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 
     "@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
@@ -1284,6 +1335,12 @@
 
     "@google-cloud/vertexai/google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
 
+    "@google/adk/@google/genai": ["@google/genai@1.44.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A=="],
+
+    "@google/adk/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
+    "@google/adk/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
     "@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
@@ -1295,6 +1352,8 @@
     "@modelcontextprotocol/sdk/express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "@npmcli/move-file/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "@opentelemetry/api-logs/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.1.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw=="],
 
@@ -1484,6 +1543,8 @@
 
     "@google-cloud/vertexai/google-auth-library/gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
+    "@google/adk/@modelcontextprotocol/sdk/express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
     "@grpc/proto-loader/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "@grpc/proto-loader/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
@@ -1574,6 +1635,30 @@
 
     "@google-cloud/vertexai/@google/genai/google-auth-library/gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
+    "@google/adk/@modelcontextprotocol/sdk/express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/body-parser": ["body-parser@2.2.1", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "@modelcontextprotocol/sdk/express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "@modelcontextprotocol/sdk/express/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -1599,6 +1684,14 @@
     "teeny-request/https-proxy-agent/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "@google-cloud/vertexai/@google/genai/google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "@google/adk/@modelcontextprotocol/sdk/express/type-is/media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "@npmcli/move-file/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -1,10 +1,18 @@
 import { defineConfig } from "bunup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/agents/index.ts"],
   format: ["esm"],
   target: "node",
-  external: ["@google/adk", "@google/genai", "openai", "@anthropic-ai/sdk"],
+  external: [
+    "@google/adk",
+    "@google/genai",
+    "openai",
+    "@anthropic-ai/sdk",
+    "@anthropic-ai/claude-agent-sdk",
+    "@openai/codex-sdk",
+    "@opentelemetry/api",
+  ],
   dts: { inferTypes: true },
   sourcemap: "linked",
   clean: true,

--- a/examples/basic-agent-claude/.env.example
+++ b/examples/basic-agent-claude/.env.example
@@ -1,0 +1,17 @@
+# Claude credentials are optional when native Claude Code auth/OAuth is already
+# configured on this machine. The ClaudeAgent uses the official
+# @anthropic-ai/claude-agent-sdk TypeScript package. Set ANTHROPIC_API_KEY for
+# env-based auth (CI/scripts), or rely on the local Claude Code CLI.
+# ANTHROPIC_API_KEY=sk-ant-your-api-key-here # Takes precedence over subscription OAuth when present
+# ANTHROPIC_AUTH_TOKEN=your-anthropic-auth-token-here
+# CLAUDE_CODE_OAUTH_TOKEN=your-claude-code-oauth-token-here
+# CLAUDE_CONFIG_DIR=/path/to/claude/config
+
+# Optional: point the SDK at an existing Claude Code executable when your package
+# manager blocked the SDK's native binary postinstall. The driver also autodetects
+# common locations such as ~/.local/bin/claude.
+# CLAUDE_CODE_EXECUTABLE=/Users/you/.local/bin/claude
+# CLAUDE_CODE_PATH=/Users/you/.local/bin/claude
+
+# Optional: override the smoke-test prompt.
+# SMOKE_PROMPT=In one sentence, what is the Google Agent Development Kit (ADK)?

--- a/examples/basic-agent-claude/.gitignore
+++ b/examples/basic-agent-claude/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+bun.lock
+.env

--- a/examples/basic-agent-claude/README.md
+++ b/examples/basic-agent-claude/README.md
@@ -1,0 +1,59 @@
+# Basic Agent with Claude (Claude Agent SDK)
+
+A minimal example running [Anthropic](https://anthropic.com/) Claude as an
+external ADK agent through the official
+[`@anthropic-ai/claude-agent-sdk`](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk)
+driver. The `ClaudeAgent` is the root ADK agent, wrapped in an ADK `Runner`.
+
+## Architecture
+
+```mermaid
+graph TD
+    User([User]) --> Runner[ADK Runner]
+    Runner --> Claude[ClaudeAssistant<br/>ClaudeAgent + Claude Agent SDK driver]
+```
+
+## Setup
+
+1. Copy the environment file. Credentials are optional if the local Claude Code
+   CLI is already authenticated on this machine:
+   ```bash
+   cp .env.example .env
+   # Optionally edit .env and add your ANTHROPIC_API_KEY
+   ```
+
+2. Install dependencies:
+   ```bash
+   bun install
+   ```
+
+3. Run the smoke script (sends one prompt):
+   ```bash
+   bun run smoke
+   ```
+
+   If no credential and no local Claude Code CLI are available, the script
+   prints a setup hint and exits cleanly without crashing.
+
+4. Or run the agent with DevTools:
+   ```bash
+   bun run web
+   ```
+
+## Authentication
+
+The `ClaudeAgent` resolves credentials via the environment or the native Claude
+Code CLI auth/OAuth already configured on this machine. Provide one of:
+
+- `ANTHROPIC_API_KEY` (takes precedence over subscription OAuth)
+- `ANTHROPIC_AUTH_TOKEN`
+- `CLAUDE_CODE_OAUTH_TOKEN`
+- A local, authenticated Claude Code CLI
+
+To change the smoke prompt, set `SMOKE_PROMPT` in `.env` or edit `agent.ts`.
+
+## Example Questions
+
+- "In one sentence, what is the Google Agent Development Kit (ADK)?"
+- "Explain the difference between an LLM agent and an external agent."
+- "What providers does adk-llm-bridge support?"

--- a/examples/basic-agent-claude/agent.ts
+++ b/examples/basic-agent-claude/agent.ts
@@ -1,0 +1,122 @@
+import type * as Adk from "@google/adk";
+import {
+  ClaudeAgent,
+  ClaudeAgentSdkDriver,
+  EnvCredentialProvider,
+  mapPermissionModeToPolicy,
+} from "adk-llm-bridge/agents";
+
+// This example maps @google/adk to declaration files for local type-checking.
+// Import the runtime ESM build directly so Bun does not execute a .d.ts file.
+const adkRuntime = await import(
+  new URL(
+    [
+      "..",
+      "..",
+      "node_modules",
+      "@google",
+      "adk",
+      "dist",
+      "esm",
+      "index.js",
+    ].join("/"),
+    import.meta.url,
+  ).href
+);
+const { InMemorySessionService, Runner } = adkRuntime as typeof Adk;
+
+// =============================================================================
+// Claude (Claude Agent SDK) as an external ADK agent
+// =============================================================================
+//
+// The ClaudeAgent runs Anthropic Claude through the official
+// @anthropic-ai/claude-agent-sdk driver as the root ADK agent. Credentials come
+// from the environment (ANTHROPIC_API_KEY) or from the native Claude Code CLI
+// auth/OAuth already configured on this machine.
+
+const credentialProvider = new EnvCredentialProvider();
+const workingDirectory = process.cwd();
+
+const claudeDriver = new ClaudeAgentSdkDriver({
+  // Optional fallback when package-manager postinstall scripts did not install
+  // the SDK's bundled native binary. Leave unset to use driver autodetection
+  // and the SDK default.
+  pathToClaudeCodeExecutable:
+    process.env.CLAUDE_CODE_EXECUTABLE ?? process.env.CLAUDE_CODE_PATH,
+});
+
+export const rootAgent = new ClaudeAgent({
+  name: "ClaudeAssistant",
+  description: "A simple Claude assistant running as the root ADK agent.",
+  credentialProvider,
+  driver: claudeDriver,
+  workingDirectory,
+  permissions: {
+    ...mapPermissionModeToPolicy("read-only"),
+    allowNetwork: false,
+    allowedPaths: [workingDirectory],
+  },
+  instruction: `You are a friendly assistant running as a Claude ADK agent.
+
+Answer the user's question clearly and concisely. Do not modify files.`,
+});
+
+// =============================================================================
+// Smoke script: send ONE simple prompt
+// =============================================================================
+//
+// Typechecks and builds without credentials. At runtime, if no credential or
+// Claude Code CLI is available, print a clear message and exit 0.
+
+function hasClaudeCredential(): boolean {
+  return Boolean(
+    process.env.ANTHROPIC_API_KEY ||
+      process.env.ANTHROPIC_AUTH_TOKEN ||
+      process.env.CLAUDE_CODE_OAUTH_TOKEN ||
+      process.env.CLAUDE_CODE_EXECUTABLE ||
+      process.env.CLAUDE_CODE_PATH,
+  );
+}
+
+export async function main(): Promise<void> {
+  if (!hasClaudeCredential()) {
+    console.log(
+      "set ANTHROPIC_API_KEY (or local Claude Code CLI) to run this example",
+    );
+    process.exit(0);
+  }
+
+  const prompt =
+    process.env.SMOKE_PROMPT ??
+    "In one sentence, what is the Google Agent Development Kit (ADK)?";
+
+  const sessionService = new InMemorySessionService();
+  const session = await sessionService.createSession({
+    appName: "agent",
+    userId: "user",
+  });
+  const runner = new Runner({
+    appName: "agent",
+    agent: rootAgent,
+    sessionService,
+  });
+
+  let text = "";
+  for await (const event of runner.runAsync({
+    userId: "user",
+    sessionId: session.id,
+    newMessage: { role: "user", parts: [{ text: prompt }] },
+  })) {
+    for (const part of event.content?.parts ?? []) {
+      if (part.text) {
+        text += part.text;
+      }
+    }
+  }
+
+  console.log(text.trim());
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/examples/basic-agent-claude/package.json
+++ b/examples/basic-agent-claude/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "basic-agent-claude",
+  "private": true,
+  "type": "module",
+  "main": "agent.ts",
+  "scripts": {
+    "dev": "bunx @google/adk-devtools run agent.ts",
+    "web": "bunx @google/adk-devtools web",
+    "start": "bun agent.ts",
+    "smoke": "bun agent.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
+    "@google/adk": "^1.1.0",
+    "adk-llm-bridge": "file:../.."
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/basic-agent-claude/package.json
+++ b/examples/basic-agent-claude/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.183",
     "@google/adk": "^1.1.0",
     "adk-llm-bridge": "file:../.."
   },

--- a/examples/basic-agent-claude/tsconfig.json
+++ b/examples/basic-agent-claude/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "paths": {
+      "@google/adk": ["node_modules/@google/adk/dist/types/index.d.ts"],
+      "adk-llm-bridge": ["../../src/index.ts"],
+      "adk-llm-bridge/agents": ["../../src/agents/index.ts"]
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"],
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/basic-agent-codex/.env.example
+++ b/examples/basic-agent-codex/.env.example
@@ -1,0 +1,23 @@
+# Codex runtime credentials/config.
+#
+# The CodexAgent uses the bundled Codex SDK driver (@openai/codex-sdk). At
+# runtime it needs ONE of the following:
+#   1. An API key, OR
+#   2. A local `codex` CLI binary with native Codex auth already configured.
+#
+# If none is available, the smoke script prints a hint and exits 0 (no crash).
+
+# API key auth (either variable works; OPENAI_API_KEY is the OpenAI default).
+# OPENAI_API_KEY=your-openai-api-key-here
+# CODEX_API_KEY=your-codex-api-key-here
+
+# Optional Codex configuration.
+# CODEX_HOME=/path/to/codex/home
+
+# Optional: point the Codex SDK at an existing Codex executable if its optional
+# binary dependencies are not discovered automatically.
+# CODEX_EXECUTABLE=/Users/you/.nvm/versions/node/v24.14.1/bin/codex
+# CODEX_CLI_PATH=/Users/you/.nvm/versions/node/v24.14.1/bin/codex
+
+# Optional: override the single smoke prompt sent by `bun run smoke`.
+# SMOKE_PROMPT=In one sentence, what is OpenAI Codex?

--- a/examples/basic-agent-codex/.gitignore
+++ b/examples/basic-agent-codex/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+bun.lock
+.env

--- a/examples/basic-agent-codex/README.md
+++ b/examples/basic-agent-codex/README.md
@@ -1,0 +1,69 @@
+# Basic Agent with OpenAI Codex (external ADK agent)
+
+A single-agent example running [OpenAI Codex](https://developers.openai.com/codex/sdk/)
+as an external ADK agent via the bundled Codex SDK driver.
+
+## Architecture
+
+```mermaid
+graph TD
+    User([User]) --> Codex[CodexAssistant]
+    Codex --> Driver[CodexSdkDriver]
+    Driver --> SDK[("@openai/codex-sdk")]
+    SDK --> Runtime[OpenAI Codex]
+```
+
+Unlike the LLM-provider examples, `CodexAgent` does not use a `model` from the
+bridge. It is an external agent: the `CodexSdkDriver` (the default driver for
+`CODEX_AGENT_DEFINITION`) launches Codex through `@openai/codex-sdk` and streams
+its events back into the ADK runner.
+
+## Setup
+
+1. Copy the environment file and add your credential:
+   ```bash
+   cp .env.example .env
+   # Edit .env and add OPENAI_API_KEY (or CODEX_API_KEY), or skip this and rely
+   # on a local `codex` CLI that already has native Codex auth configured.
+   ```
+
+2. Install dependencies:
+   ```bash
+   bun install
+   ```
+
+3. Run the one-prompt smoke script:
+   ```bash
+   bun run smoke
+   ```
+
+   Or explore interactively with DevTools:
+   ```bash
+   bun run web
+   ```
+
+## Credentials
+
+The Codex SDK driver needs ONE of the following at runtime:
+
+- `OPENAI_API_KEY` or `CODEX_API_KEY` set in the environment, or
+- a local `codex` CLI binary on your `PATH` with native Codex auth configured.
+
+If none is available, `bun run smoke` prints
+`set OPENAI_API_KEY (or local codex CLI) to run this example` and exits 0 without
+crashing, so the example always type-checks and builds.
+
+## Example Questions
+
+- "In one sentence, what is OpenAI Codex?" (default smoke prompt)
+- "List three things a coding assistant is good at."
+- "Explain what an ADK external agent is in two sentences."
+
+To change the smoke prompt without editing `agent.ts`, set `SMOKE_PROMPT`:
+
+```bash
+SMOKE_PROMPT="Summarize what this example does." bun run smoke
+```
+
+To change the agent's behavior or permissions, edit `agent.ts` and update the
+`CodexAgent` config (`instruction`, `permissions`, `workingDirectory`).

--- a/examples/basic-agent-codex/agent.ts
+++ b/examples/basic-agent-codex/agent.ts
@@ -1,0 +1,130 @@
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import type * as Adk from "@google/adk";
+import {
+  CodexAgent,
+  EnvCredentialProvider,
+  mapPermissionModeToPolicy,
+} from "adk-llm-bridge/agents";
+
+// This example maps @google/adk to declaration files for local type-checking.
+// Import the runtime ESM build directly so Bun does not execute a .d.ts file.
+const adkRuntime = await import(
+  new URL(
+    [
+      "..",
+      "..",
+      "node_modules",
+      "@google",
+      "adk",
+      "dist",
+      "esm",
+      "index.js",
+    ].join("/"),
+    import.meta.url,
+  ).href
+);
+
+// =============================================================================
+// Codex External Agent (via the Codex SDK driver)
+// =============================================================================
+//
+// CodexAgent runs OpenAI Codex as an external ADK agent. It uses the bundled
+// CodexSdkDriver (the default for CODEX_AGENT_DEFINITION), which talks to the
+// @openai/codex-sdk package and, at runtime, either an OPENAI_API_KEY /
+// CODEX_API_KEY credential or a local `codex` CLI binary with native auth.
+
+const credentialProvider = new EnvCredentialProvider();
+const workingDirectory = process.cwd();
+
+export const rootAgent = new CodexAgent({
+  name: "CodexAssistant",
+  description:
+    "A general-purpose assistant running OpenAI Codex as an external ADK agent.",
+  credentialProvider,
+  workingDirectory,
+  permissions: {
+    // Read-only keeps the smoke run from modifying files. Restrict reachable
+    // paths to this example directory.
+    ...mapPermissionModeToPolicy("read-only"),
+    allowNetwork: false,
+    allowedPaths: [workingDirectory],
+  },
+  instruction: `You are a concise, friendly assistant running as a Codex ADK agent.
+
+Answer the user's question directly. Do not modify files. Keep responses short.`,
+});
+
+// =============================================================================
+// Smoke script: send ONE simple prompt through an ADK runner.
+//
+// Typechecks and builds with no credentials. At runtime, if neither an API key
+// nor a local codex CLI is available, it prints a clear hint and exits 0 instead
+// of crashing.
+// =============================================================================
+
+const SMOKE_PROMPT =
+  process.env.SMOKE_PROMPT ?? "In one sentence, what is OpenAI Codex?";
+
+function hasCodexCliOnPath(): boolean {
+  const executable = process.platform === "win32" ? "codex.exe" : "codex";
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (dir.length > 0 && existsSync(join(dir, executable))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function codexCredentialsAvailable(): boolean {
+  return Boolean(
+    process.env.OPENAI_API_KEY ||
+      process.env.CODEX_API_KEY ||
+      process.env.CODEX_EXECUTABLE ||
+      process.env.CODEX_CLI_PATH ||
+      hasCodexCliOnPath(),
+  );
+}
+
+export async function main(): Promise<void> {
+  if (!codexCredentialsAvailable()) {
+    console.log("set OPENAI_API_KEY (or local codex CLI) to run this example");
+    process.exit(0);
+  }
+
+  const { InMemorySessionService, Runner } = adkRuntime as typeof Adk;
+
+  const sessionService = new InMemorySessionService();
+  const session = await sessionService.createSession({
+    appName: "agent",
+    userId: "user",
+  });
+  const runner = new Runner({
+    appName: "agent",
+    agent: rootAgent,
+    sessionService,
+  });
+
+  let text = "";
+  for await (const event of runner.runAsync({
+    userId: "user",
+    sessionId: session.id,
+    newMessage: { role: "user", parts: [{ text: SMOKE_PROMPT }] },
+  })) {
+    if (event.errorMessage) {
+      console.error(`Codex error: ${event.errorMessage}`);
+    }
+    for (const part of event.content?.parts ?? []) {
+      if (part.text) {
+        text += part.text;
+      }
+    }
+  }
+
+  console.log(`Prompt: ${SMOKE_PROMPT}`);
+  console.log(`Response: ${text.trim() || "(no text response)"}`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/examples/basic-agent-codex/agent.ts
+++ b/examples/basic-agent-codex/agent.ts
@@ -1,5 +1,6 @@
-import { existsSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import { accessSync, constants } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type * as Adk from "@google/adk";
 import {
   CodexAgent,
@@ -31,8 +32,10 @@ const adkRuntime = await import(
 //
 // CodexAgent runs OpenAI Codex as an external ADK agent. It uses the bundled
 // CodexSdkDriver (the default for CODEX_AGENT_DEFINITION), which talks to the
-// @openai/codex-sdk package and, at runtime, either an OPENAI_API_KEY /
-// CODEX_API_KEY credential or a local `codex` CLI binary with native auth.
+// @openai/codex-sdk package. The SDK ships its OWN bundled `codex` binary, so a
+// `codex` on PATH is NOT the availability signal — what matters is a usable
+// credential: a CODEX_API_KEY, a readable ~/.codex/auth.json, or an explicit
+// CODEX_EXECUTABLE/CODEX_CLI_PATH.
 
 const credentialProvider = new EnvCredentialProvider();
 const workingDirectory = process.cwd();
@@ -58,38 +61,56 @@ Answer the user's question directly. Do not modify files. Keep responses short.`
 // =============================================================================
 // Smoke script: send ONE simple prompt through an ADK runner.
 //
-// Typechecks and builds with no credentials. At runtime, if neither an API key
-// nor a local codex CLI is available, it prints a clear hint and exits 0 instead
-// of crashing.
+// Typechecks and builds with no credentials. At runtime, if no usable Codex
+// credential is available, it prints a clear hint and exits 0 instead of
+// crashing.
 // =============================================================================
 
 const SMOKE_PROMPT =
   process.env.SMOKE_PROMPT ?? "In one sentence, what is OpenAI Codex?";
 
-function hasCodexCliOnPath(): boolean {
-  const executable = process.platform === "win32" ? "codex.exe" : "codex";
-  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
-    if (dir.length > 0 && existsSync(join(dir, executable))) {
-      return true;
-    }
+/**
+ * Resolve `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) and report
+ * whether it is readable. The SDK reads this file for native CLI auth, so its
+ * presence is a valid availability signal even without a `codex` on PATH.
+ */
+function hasReadableCodexAuthJson(): boolean {
+  const home = process.env.CODEX_HOME || join(homedir(), ".codex");
+  try {
+    accessSync(join(home, "auth.json"), constants.R_OK);
+    return true;
+  } catch {
+    return false;
   }
-  return false;
 }
 
-function codexCredentialsAvailable(): boolean {
+export function codexCredentialsAvailable(): boolean {
+  // Note: OPENAI_API_KEY is accepted only as a convenience signal — it is NOT a
+  // Codex CLI credential variable, so when set (without CODEX_API_KEY) it is
+  // mapped onto CODEX_API_KEY below so the guard and the driver agree.
   return Boolean(
-    process.env.OPENAI_API_KEY ||
-      process.env.CODEX_API_KEY ||
+    process.env.CODEX_API_KEY ||
+      process.env.OPENAI_API_KEY ||
       process.env.CODEX_EXECUTABLE ||
       process.env.CODEX_CLI_PATH ||
-      hasCodexCliOnPath(),
+      hasReadableCodexAuthJson(),
   );
 }
 
 export async function main(): Promise<void> {
   if (!codexCredentialsAvailable()) {
-    console.log("set OPENAI_API_KEY (or local codex CLI) to run this example");
+    console.log(
+      "set CODEX_API_KEY, or sign in so ~/.codex/auth.json exists " +
+        "(or set CODEX_EXECUTABLE/CODEX_CLI_PATH) to run this example",
+    );
     process.exit(0);
+  }
+
+  // OPENAI_API_KEY is not a Codex CLI credential variable; map it onto
+  // CODEX_API_KEY so the guard above and the driver's credential resolution
+  // agree. The driver itself does NOT add an OPENAI_API_KEY fallback.
+  if (process.env.OPENAI_API_KEY && !process.env.CODEX_API_KEY) {
+    process.env.CODEX_API_KEY = process.env.OPENAI_API_KEY;
   }
 
   const { InMemorySessionService, Runner } = adkRuntime as typeof Adk;

--- a/examples/basic-agent-codex/package.json
+++ b/examples/basic-agent-codex/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@google/adk": "^1.1.0",
-    "@openai/codex-sdk": "^0.130.0",
+    "@openai/codex-sdk": "^0.141.0",
     "adk-llm-bridge": "file:../.."
   },
   "devDependencies": {

--- a/examples/basic-agent-codex/package.json
+++ b/examples/basic-agent-codex/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "basic-agent-codex",
+  "private": true,
+  "type": "module",
+  "main": "agent.ts",
+  "scripts": {
+    "dev": "bunx @google/adk-devtools run agent.ts",
+    "web": "bunx @google/adk-devtools web",
+    "smoke": "bun agent.ts",
+    "start": "bun agent.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@google/adk": "^1.1.0",
+    "@openai/codex-sdk": "^0.130.0",
+    "adk-llm-bridge": "file:../.."
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/basic-agent-codex/tsconfig.json
+++ b/examples/basic-agent-codex/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "paths": {
+      "@google/adk": ["node_modules/@google/adk/dist/types/index.d.ts"],
+      "adk-llm-bridge": ["../../src/index.ts"],
+      "adk-llm-bridge/agents": ["../../src/agents/index.ts"]
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"],
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/basic-agent-gemini/.env.example
+++ b/examples/basic-agent-gemini/.env.example
@@ -1,0 +1,15 @@
+# Gemini CLI external agent credentials/config.
+# Provide an API key, or rely on a local `gemini` CLI that is already
+# authenticated on this machine (e.g. via `gemini auth login`).
+# GEMINI_API_KEY takes precedence; GOOGLE_API_KEY is also accepted.
+# GEMINI_API_KEY=your-gemini-api-key-here
+# GOOGLE_API_KEY=your-google-api-key-here
+
+# Vertex AI mode (optional). When enabled, configure the project/location below.
+# GOOGLE_GENAI_USE_VERTEXAI=true
+# GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+# GOOGLE_CLOUD_LOCATION=us-central1
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# Optional: prompt sent by the smoke script (bun run smoke).
+# SMOKE_PROMPT=In one sentence, what is the Google ADK?

--- a/examples/basic-agent-gemini/.gitignore
+++ b/examples/basic-agent-gemini/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+bun.lock
+.env

--- a/examples/basic-agent-gemini/README.md
+++ b/examples/basic-agent-gemini/README.md
@@ -1,0 +1,58 @@
+# Basic Agent with Gemini (Gemini CLI)
+
+A single external ADK agent that runs [Google Gemini](https://ai.google.dev/) via
+the Gemini CLI driver (`GeminiCliAgent` from `adk-llm-bridge/agents`).
+
+## Architecture
+
+```mermaid
+graph TD
+    User([User]) --> Gemini[GeminiAssistant]
+    Gemini --> CLI[gemini CLI driver]
+```
+
+## Setup
+
+1. Copy the environment file and add your Gemini credential:
+   ```bash
+   cp .env.example .env
+   # Edit .env and set GEMINI_API_KEY (or rely on a local, authenticated gemini CLI)
+   ```
+
+2. Install dependencies:
+   ```bash
+   bun install
+   ```
+
+3. Run a one-shot smoke prompt:
+   ```bash
+   bun run smoke
+   ```
+
+   Or explore the agent in DevTools:
+   ```bash
+   bun run web
+   ```
+
+## Credentials
+
+The Gemini CLI driver resolves credentials from the environment or a local
+`gemini` CLI that is already authenticated on this machine:
+
+- `GEMINI_API_KEY` (preferred) or `GOOGLE_API_KEY`
+- a local, authenticated `gemini` CLI (e.g. `gemini auth login`)
+- Vertex AI mode via `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`,
+  `GOOGLE_CLOUD_LOCATION`, and `GOOGLE_APPLICATION_CREDENTIALS`
+
+If neither a credential nor a local `gemini` CLI is available, `bun run smoke`
+prints `set GEMINI_API_KEY (or local gemini CLI) to run this example` and exits
+cleanly instead of crashing.
+
+## Example Questions
+
+- "In one sentence, what is the Google ADK?"
+- "Summarize the difference between an LLM agent and an external agent."
+- "List three things the Gemini CLI driver can do."
+
+To change the smoke prompt, set `SMOKE_PROMPT` in `.env`, or edit the config in
+`agent.ts`.

--- a/examples/basic-agent-gemini/agent.ts
+++ b/examples/basic-agent-gemini/agent.ts
@@ -1,0 +1,117 @@
+import type * as Adk from "@google/adk";
+import {
+  EnvCredentialProvider,
+  GEMINI_CLI_AGENT_DEFINITION,
+  GeminiCliAgent,
+  type GeminiCliAgentConfig,
+  mapPermissionModeToPolicy,
+} from "adk-llm-bridge/agents";
+
+// This example maps @google/adk to declaration files for local type-checking.
+// Import the runtime ESM build directly so Bun does not execute a .d.ts file.
+const adkRuntime = await import(
+  new URL(
+    [
+      "..",
+      "..",
+      "node_modules",
+      "@google",
+      "adk",
+      "dist",
+      "esm",
+      "index.js",
+    ].join("/"),
+    import.meta.url,
+  ).href
+);
+const { InMemorySessionService, Runner } = adkRuntime as typeof Adk;
+
+// =============================================================================
+// Gemini external agent (Gemini CLI driver)
+// =============================================================================
+//
+// GeminiCliAgent runs Google Gemini as an external ADK agent by driving the
+// local `gemini` CLI. Credentials resolve from the environment (GEMINI_API_KEY
+// or GOOGLE_API_KEY), or from a `gemini` CLI that is already authenticated on
+// this machine. The agent definition wires up the default credential provider
+// and the GeminiCliDriver for you; pass only the agent-specific config.
+
+const geminiConfig: GeminiCliAgentConfig = {
+  name: "GeminiAssistant",
+  description: "A helpful assistant running Google Gemini via the Gemini CLI.",
+  credentialProvider: new EnvCredentialProvider(),
+  workingDirectory: process.cwd(),
+  permissions: mapPermissionModeToPolicy("read-only"),
+  instruction: `You are a concise, helpful assistant running as a Gemini ADK agent.
+
+Answer the user's question directly and briefly. Do not modify files.`,
+};
+
+export const rootAgent = new GeminiCliAgent(geminiConfig);
+
+// =============================================================================
+// Smoke script: send ONE simple prompt
+// =============================================================================
+//
+// Run with `bun run smoke`. This typechecks and builds even when no credentials
+// are configured; at runtime it prints a clear hint and exits 0 if neither a
+// credential nor a local `gemini` CLI is available, instead of crashing.
+
+function hasGeminiCredential(): boolean {
+  return Boolean(process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY);
+}
+
+function hasGeminiCli(): boolean {
+  const command = GEMINI_CLI_AGENT_DEFINITION.provider.command ?? "gemini";
+  try {
+    const proc = Bun.spawnSync(["which", command]);
+    return proc.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function main(): Promise<void> {
+  if (!hasGeminiCredential() && !hasGeminiCli()) {
+    console.log(
+      "set GEMINI_API_KEY (or local gemini CLI) to run this example",
+    );
+    process.exit(0);
+  }
+
+  const prompt =
+    process.env.SMOKE_PROMPT ?? "In one sentence, what is the Google ADK?";
+
+  const sessionService = new InMemorySessionService();
+  const session = await sessionService.createSession({
+    appName: "agent",
+    userId: "user",
+  });
+  const runner = new Runner({
+    appName: "agent",
+    agent: rootAgent,
+    sessionService,
+  });
+
+  let text = "";
+  for await (const event of runner.runAsync({
+    userId: "user",
+    sessionId: session.id,
+    newMessage: { role: "user", parts: [{ text: prompt }] },
+  })) {
+    if (event.errorMessage) {
+      console.error(`Gemini agent error: ${event.errorMessage}`);
+    }
+    for (const part of event.content?.parts ?? []) {
+      if (part.text) {
+        text += part.text;
+      }
+    }
+  }
+
+  console.log(JSON.stringify({ prompt, response: text.trim() }, null, 2));
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/examples/basic-agent-gemini/package.json
+++ b/examples/basic-agent-gemini/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "basic-agent-gemini",
+  "private": true,
+  "type": "module",
+  "main": "agent.ts",
+  "scripts": {
+    "dev": "bunx @google/adk-devtools run agent.ts",
+    "web": "bunx @google/adk-devtools web",
+    "smoke": "bun agent.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@google/adk": "^1.1.0",
+    "adk-llm-bridge": "file:../.."
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/basic-agent-gemini/tsconfig.json
+++ b/examples/basic-agent-gemini/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "paths": {
+      "@google/adk": ["node_modules/@google/adk/dist/types/index.d.ts"],
+      "adk-llm-bridge": ["../../src/index.ts"],
+      "adk-llm-bridge/agents": ["../../src/agents/index.ts"]
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"],
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/external-agents/.env.example
+++ b/examples/external-agents/.env.example
@@ -1,0 +1,37 @@
+# Claude Code root agent credentials are optional when native Claude Code auth/OAuth
+# is already configured on this machine. The default driver uses the official
+# @anthropic-ai/claude-agent-sdk TypeScript package. Uncomment only if you want
+# env-based auth or CI/script auth.
+# ANTHROPIC_API_KEY=your-anthropic-api-key-here # Takes precedence over subscription OAuth when present
+# ANTHROPIC_AUTH_TOKEN=your-anthropic-auth-token-here
+# CLAUDE_CODE_OAUTH_TOKEN=your-claude-code-oauth-token-here
+# CLAUDE_CONFIG_DIR=/path/to/claude/config
+
+# Optional: point the SDK at an existing Claude Code executable when your package
+# manager blocked the SDK's native binary postinstall. The driver also autodetects
+# common locations such as ~/.local/bin/claude and local optional SDK packages.
+# CLAUDE_CODE_EXECUTABLE=/Users/you/.local/bin/claude
+# CLAUDE_CODE_PATH=/Users/you/.local/bin/claude
+
+# Claude cloud-provider modes (optional)
+# CLAUDE_CODE_USE_BEDROCK=false
+# CLAUDE_CODE_USE_VERTEX=false
+# CLAUDE_CODE_USE_FOUNDRY=false
+
+# Codex runtime credentials/config (optional; native Codex auth may also be used)
+# CODEX_API_KEY=your-codex-api-key-here
+# CODEX_HOME=/path/to/codex/home
+# Optional: point Codex SDK at an existing Codex executable if optional binary dependencies are not discovered.
+# CODEX_EXECUTABLE=/Users/you/.nvm/versions/node/v24.14.1/bin/codex
+# CODEX_CLI_PATH=/Users/you/.nvm/versions/node/v24.14.1/bin/codex
+
+# OpenRouter-backed LlmAgent subagent credentials/config.
+# OPENROUTER_API_KEY=your-openrouter-api-key-here
+# OPENROUTER_MODEL=google/gemini-2.0-flash-001
+
+# Smoke target for the hybrid HelpDesk example. billing delegates to Codex;
+# support delegates to an OpenRouter-backed ADK LlmAgent.
+# SMOKE_HELPDESK_TARGET=billing
+
+# Comma-separated absolute paths the example is allowed to analyze outside this example directory.
+# ARCHITECTURE_ANALYSIS_PATHS=/Users/you/Projects/my-repo,/Users/you/Projects/another-repo

--- a/examples/external-agents/.gitignore
+++ b/examples/external-agents/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+bun.lock
+.env

--- a/examples/external-agents/README.md
+++ b/examples/external-agents/README.md
@@ -1,0 +1,131 @@
+# External Agents HelpDesk Example
+
+This example mirrors the OpenRouter HelpDesk example, but makes Claude Code the root ADK agent and mixes external runtime subagents with a normal OpenRouter-backed `LlmAgent`.
+
+```txt
+ClaudeCodeRoot: ClaudeAgent
+  -> CodexBillingSpecialist: CodexAgent
+  -> OpenRouterSupportSpecialist: LlmAgent + OpenRouter(...)
+```
+
+## What This Demonstrates
+
+- `ClaudeAgent` can be the ADK `rootAgent`.
+- `CodexAgent` can be a normal ADK subagent even though it is an external runtime.
+- `LlmAgent` using `OpenRouter(...)` from `adk-llm-bridge` can be a subagent of Claude Code.
+- Claude Code delegates to both subagents through the runtime MCP bridge tool `run_adk_subagent`.
+- `run_adk_subagent` remains bounded RPC semantics: Claude calls a tool, the bridge runs a subagent, then Claude receives the result.
+- External runtime APIs stay opt-in through `adk-llm-bridge/agents`, while model providers stay in the root `adk-llm-bridge` import.
+
+## Quick Start
+
+First make sure Claude Code and Codex are authenticated with their native tooling.
+
+```bash
+claude --version
+codex --version
+# If needed, run each runtime's native login/auth flow first.
+```
+
+Then run the example:
+
+```bash
+cd examples/external-agents
+cp .env.example .env
+# Edit .env with OPENROUTER_API_KEY for the OpenRouterSupportSpecialist.
+# Env-based Claude/Codex auth is optional when native runtime auth is already configured.
+bun install
+bun run smoke:helpdesk
+bun run web
+```
+
+You can also type-check the example directly:
+
+```bash
+bun run typecheck
+```
+
+## Smoke Tests
+
+Billing smoke delegates from Claude Code to Codex:
+
+```bash
+bun run smoke:helpdesk
+```
+
+Support smoke delegates from Claude Code to the OpenRouter-backed `LlmAgent`:
+
+```bash
+bun run smoke:helpdesk:support
+```
+
+Both smoke tests execute the exported `rootAgent` through ADK `Runner` and fail if Claude Code does not call `run_adk_subagent`, if the expected subagent does not emit visible events, or if the bridge does not emit the matching function response.
+
+## Example Prompts
+
+Billing, routed to `CodexBillingSpecialist`:
+
+```txt
+Can you check the status of invoice INV-001?
+```
+
+```txt
+I need to request a refund for invoice INV-002 because I forgot to cancel.
+```
+
+Support, routed to `OpenRouterSupportSpecialist`:
+
+```txt
+What's the current status of the auth service?
+```
+
+```txt
+I need to reset my password for user@example.com.
+```
+
+For lower-level bridge diagnostics, you can force the tool call explicitly:
+
+```txt
+Use run_adk_subagent to delegate to OpenRouterSupportSpecialist. Ask it to check auth status and reset user@example.com.
+```
+
+## Runtime Setup
+
+The exported `rootAgent` is a `ClaudeAgent`, so normal chat in ADK DevTools is handled by Claude Code through the official `@anthropic-ai/claude-agent-sdk` TypeScript path.
+
+The example constructs two specialist ADK subagents:
+
+- `CodexBillingSpecialist` — a read-only `CodexAgent` that answers billing, invoice, payment, refund, and subscription questions from fixed demo data.
+- `OpenRouterSupportSpecialist` — a standard ADK `LlmAgent` using `OpenRouter(...)`, with `check_system_status` and `reset_password` tools.
+
+`CodexAgent` uses `@openai/codex-sdk` by default. The SDK controls the local Codex runtime and reuses Codex native authentication/configuration. Use `codex login` for local auth or provide `CODEX_API_KEY` for API-key automation. If optional Codex binary discovery fails, set `CODEX_EXECUTABLE` or `CODEX_CLI_PATH` to an existing `codex` executable.
+
+For local usage, Claude Code can use the credentials already configured on your machine. The SDK driver passes the minimal native-auth environment (`HOME`, `PATH`, `USER`, `SHELL`, `CLAUDE_CONFIG_DIR`, and `XDG_CONFIG_HOME`) so Claude can find its native config/cache. If needed, set `CLAUDE_CODE_EXECUTABLE` or `CLAUDE_CODE_PATH` in `.env`.
+
+The OpenRouter subagent requires `OPENROUTER_API_KEY` unless your environment already provides it. You can change the model with:
+
+```bash
+OPENROUTER_MODEL=google/gemini-2.0-flash-001
+```
+
+The default is `google/gemini-2.0-flash-001` because the free DeepSeek route can return intermittent OpenRouter provider `429` errors during tool-heavy support flows.
+
+The bridge does not persist provider secrets. Install and authenticate each runtime using its native documentation when you want that runtime to execute real work.
+
+## Important Runtime Note
+
+The `/agents` API is intentionally separate from the root LLM provider API. Normal LLM usage remains under:
+
+```ts
+import { OpenRouter } from "adk-llm-bridge";
+```
+
+External runtime usage is opt-in:
+
+```ts
+import { CodexAgent, ClaudeAgent } from "adk-llm-bridge/agents";
+```
+
+Claude Agent SDK execution is side-effectful and uses the permissions configured on the `ClaudeAgent`; this example defaults to `ask` mode and limits allowed paths to the current working directory plus any paths in `ARCHITECTURE_ANALYSIS_PATHS`. Subagent permissions are inherited conservatively, so `CodexBillingSpecialist` cannot expand beyond the root agent restrictions.
+
+The example `tsconfig.json` maps `adk-llm-bridge`, `adk-llm-bridge/agents`, and `@google/adk` for local type-checking, avoiding duplicate nominal ADK symbols while using a file dependency. The agent imports the ADK runtime ESM build directly so Bun does not execute declaration files at runtime.

--- a/examples/external-agents/agent.ts
+++ b/examples/external-agents/agent.ts
@@ -1,0 +1,223 @@
+import type * as Adk from "@google/adk";
+import { OpenRouter } from "adk-llm-bridge";
+import {
+  ClaudeAgent,
+  ClaudeAgentSdkDriver,
+  CodexAgent,
+  EnvCredentialProvider,
+  mapPermissionModeToPolicy,
+} from "adk-llm-bridge/agents";
+import {
+  normalizeAllowedDirectory,
+  parseArchitectureAnalysisPaths,
+} from "./config.js";
+
+// This example maps @google/adk to declaration files for local type-checking.
+// Import the runtime ESM build directly so Bun does not execute a .d.ts file.
+const adkRuntime = await import(
+  new URL(
+    [
+      "..",
+      "..",
+      "node_modules",
+      "@google",
+      "adk",
+      "dist",
+      "esm",
+      "index.js",
+    ].join("/"),
+    import.meta.url,
+  ).href
+);
+const { FunctionTool, LlmAgent } = adkRuntime as typeof Adk;
+
+const openRouterModel = process.env.OPENROUTER_MODEL ?? "openrouter/auto";
+const hasOpenRouterApiKey = Boolean(process.env.OPENROUTER_API_KEY);
+
+// =============================================================================
+// Billing Agent Tools / Reference Data
+// =============================================================================
+
+const billingReference = `Reference billing data:
+- INV-001: $99.00, paid, 2024-01-15, Monthly subscription.
+- INV-002: $99.00, pending, 2024-02-15, Monthly subscription.
+- user@example.com owns INV-001 and INV-002.
+Refund policy: verify invoice and reason before telling the user a refund can be initiated.`;
+
+// =============================================================================
+// Support Agent Tools
+// =============================================================================
+
+const checkSystemStatus = new FunctionTool({
+  name: "check_system_status",
+  description: "Check the current status of system services.",
+  parameters: {
+    type: "OBJECT",
+    properties: {
+      service: {
+        type: "STRING",
+        enum: ["api", "web", "database", "auth", "all"],
+        description: "Specific service to check, or 'all' for complete status",
+      },
+    },
+  } as never,
+  execute: (input: unknown) => {
+    const service = readService(input) ?? "all";
+    const services = {
+      api: { status: "operational", latency: "45ms" },
+      web: { status: "operational", latency: "120ms" },
+      database: { status: "operational", latency: "12ms" },
+      auth: {
+        status: "degraded",
+        latency: "250ms",
+        note: "Investigating slowness",
+      },
+    };
+
+    if (service === "all") {
+      return { result: "success", services };
+    }
+    const serviceData = services[service as keyof typeof services];
+    return {
+      result: "success",
+      service,
+      serviceStatus: serviceData.status,
+      latency: serviceData.latency,
+      ...("note" in serviceData ? { note: serviceData.note } : {}),
+    };
+  },
+});
+
+const resetPassword = new FunctionTool({
+  name: "reset_password",
+  description: "Send a password reset link to a user's email.",
+  parameters: {
+    type: "OBJECT",
+    properties: {
+      email: {
+        type: "STRING",
+        description: "User's email address",
+      },
+    },
+    required: ["email"],
+  } as never,
+  execute: (input: unknown) => {
+    const email = readString(input, "email") ?? "unknown@example.com";
+    return {
+      status: "success",
+      message: `Password reset link sent to ${email}. Link expires in 1 hour.`,
+    };
+  },
+});
+
+// External agent runtimes are opt-in and live under the /agents subpath. This
+// HelpDesk mirrors examples/basic-agent-openrouter while proving Claude Code can
+// be the root ADK agent and orchestrate both external and LLM-backed subagents.
+const credentialProvider = new EnvCredentialProvider();
+const workingDirectory = normalizeAllowedDirectory(process.cwd());
+const architectureAnalysisPaths = parseArchitectureAnalysisPaths(
+  process.env.ARCHITECTURE_ANALYSIS_PATHS,
+);
+const allowedPaths = [
+  ...new Set([workingDirectory, ...architectureAnalysisPaths]),
+];
+
+const codexBillingSpecialist = new CodexAgent({
+  name: "CodexBillingSpecialist",
+  description:
+    "Handles billing inquiries, invoice lookups, and refund request analysis using the Codex runtime.",
+  credentialProvider,
+  workingDirectory,
+  permissions: {
+    ...mapPermissionModeToPolicy("read-only"),
+    allowedPaths,
+  },
+  instruction: `You are a billing specialist assistant running as a Codex ADK subagent.
+
+Help customers with invoice lookups, refund request analysis, billing questions, and payment status. Use this fixed demo data instead of modifying files or calling external services.
+
+${billingReference}
+
+Be professional, empathetic, and efficient. Always verify the invoice/account before saying a refund can be initiated. Do not modify files.`,
+});
+
+const openRouterSupportSpecialist = hasOpenRouterApiKey
+  ? new LlmAgent({
+      name: "OpenRouterSupportSpecialist",
+      model: OpenRouter(openRouterModel),
+      description:
+        "Handles technical support requests, login issues, password resets, and system status through OpenRouter.",
+      instruction: `You are a technical support specialist. Help customers with:
+- Login and authentication issues
+- Password resets
+- System status inquiries
+- Technical troubleshooting
+
+Use your tools when checking system status or sending password reset links. Be patient and guide users step by step.`,
+      tools: [checkSystemStatus, resetPassword],
+    })
+  : undefined;
+
+const claudeDriver = new ClaudeAgentSdkDriver({
+  // Optional fallback when package-manager postinstall scripts did not install
+  // the SDK's bundled native binary. Leave these unset to use driver autodetection
+  // and the SDK default.
+  pathToClaudeCodeExecutable:
+    process.env.CLAUDE_CODE_EXECUTABLE ?? process.env.CLAUDE_CODE_PATH,
+});
+
+export const rootAgent = new ClaudeAgent({
+  name: "ClaudeCodeRoot",
+  description:
+    "Main HelpDesk coordinator running Claude Code as the root ADK agent.",
+  credentialProvider,
+  driver: claudeDriver,
+  workingDirectory,
+  permissions: {
+    ...mapPermissionModeToPolicy("ask"),
+    allowNetwork: false,
+    allowedPaths,
+  },
+  instruction: `You are the root Claude Code HelpDesk coordinator for this example.
+
+Use the native Claude Code authentication already configured on this machine. Your job is to greet the user, understand their issue, and delegate to the correct ADK subagent by calling the MCP tool named run_adk_subagent.
+
+Routing rules:
+- Billing, invoice lookup, payment status, refunds, and subscription questions: delegate to CodexBillingSpecialist.
+${
+  openRouterSupportSpecialist
+    ? "- Technical support, login issues, password reset, system status, auth status, API status, and troubleshooting: delegate to OpenRouterSupportSpecialist."
+    : "- Technical support via OpenRouterSupportSpecialist is disabled because OPENROUTER_API_KEY is not configured. If asked for support, explain that OPENROUTER_API_KEY is required for that subagent."
+}
+
+When delegating, call run_adk_subagent immediately before producing explanatory text. Do not narrate that you are about to delegate before the tool call. After the tool returns, summarize or relay the specialist result to the user.
+
+If the request is unclear, ask one concise clarifying question. Ask before broad or destructive changes. Do not modify files for HelpDesk requests.
+
+Allowed paths for runtime access: ${allowedPaths.join(", ")}.`,
+  subAgents: [
+    codexBillingSpecialist,
+    ...(openRouterSupportSpecialist ? [openRouterSupportSpecialist] : []),
+  ],
+});
+
+function readService(
+  input: unknown,
+): "api" | "web" | "database" | "auth" | "all" | undefined {
+  const service = readString(input, "service");
+  return service === "api" ||
+    service === "web" ||
+    service === "database" ||
+    service === "auth" ||
+    service === "all"
+    ? service
+    : undefined;
+}
+
+function readString(input: unknown, key: string): string | undefined {
+  if (!input || typeof input !== "object") {
+    return undefined;
+  }
+  const value = (input as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/examples/external-agents/config.ts
+++ b/examples/external-agents/config.ts
@@ -1,0 +1,44 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, relative } from "node:path";
+
+export function parseArchitectureAnalysisPaths(value: string | undefined): string[] {
+  const paths = (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+  const normalized = paths.map((path) => normalizeAllowedDirectory(path));
+  return [...new Set(normalized)];
+}
+
+export function normalizeAllowedDirectory(path: string): string {
+  if (!isAbsolute(path)) {
+    throw new Error(
+      `ARCHITECTURE_ANALYSIS_PATHS entries must be absolute paths. Invalid entry: ${path}`,
+    );
+  }
+
+  if (!existsSync(path)) {
+    throw new Error(
+      `ARCHITECTURE_ANALYSIS_PATHS entry does not exist: ${path}`,
+    );
+  }
+
+  const realPath = realpathSync(path);
+  if (!statSync(realPath).isDirectory()) {
+    throw new Error(
+      `ARCHITECTURE_ANALYSIS_PATHS entries must be directories. Invalid entry: ${path}`,
+    );
+  }
+
+  return realPath;
+}
+
+export function isPathAllowed(requestedPath: string, allowedPaths: readonly string[]): boolean {
+  const requested = normalizeAllowedDirectory(requestedPath);
+  return allowedPaths.some((allowedPath) => {
+    const allowed = normalizeAllowedDirectory(allowedPath);
+    const rel = relative(allowed, requested);
+    return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  });
+}

--- a/examples/external-agents/package.json
+++ b/examples/external-agents/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "external-agents",
+  "private": true,
+  "type": "module",
+  "main": "agent.ts",
+  "scripts": {
+    "dev": "bunx @google/adk-devtools run agent.ts",
+    "web": "bunx @google/adk-devtools web",
+    "smoke:architecture": "bun smoke-helpdesk.ts",
+    "smoke:helpdesk": "bun smoke-helpdesk.ts",
+    "smoke:helpdesk:support": "SMOKE_HELPDESK_TARGET=support bun smoke-helpdesk.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
+    "@google/adk": "^1.1.0",
+    "@openai/codex-sdk": "^0.130.0",
+    "adk-llm-bridge": "file:../.."
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/external-agents/smoke-architecture.ts
+++ b/examples/external-agents/smoke-architecture.ts
@@ -1,0 +1,7 @@
+// Backward-compatible alias for the previous smoke script name.
+// The external-agents example now demonstrates a hybrid HelpDesk.
+import { main } from "./smoke-helpdesk.js";
+
+if (import.meta.main) {
+  await main();
+}

--- a/examples/external-agents/smoke-helpdesk.ts
+++ b/examples/external-agents/smoke-helpdesk.ts
@@ -1,0 +1,145 @@
+import type * as Adk from "@google/adk";
+
+type HelpDeskTarget = "billing" | "support";
+
+const prompts: Record<HelpDeskTarget, { agentName: string; prompt: string }> = {
+  billing: {
+    agentName: "CodexBillingSpecialist",
+    prompt:
+      "I have a billing question. Check the status of invoice INV-001 and explain whether a refund can be considered. Use CodexBillingSpecialist.",
+  },
+  support: {
+    agentName: "OpenRouterSupportSpecialist",
+    prompt:
+      "I cannot log in. Check the auth service status and send a password reset link to user@example.com. Use OpenRouterSupportSpecialist.",
+  },
+};
+
+export async function main(): Promise<void> {
+  // Use the runtime ESM build directly because this example's tsconfig maps
+  // @google/adk to declaration files to avoid duplicate nominal ADK symbols during
+  // type-checking. Bun applies paths at runtime too, so a normal value import from
+  // @google/adk would try to execute a .d.ts file.
+  const adkRuntime = await import(
+    new URL(
+      ["..", "..", "node_modules", "@google", "adk", "dist", "esm", "index.js"].join("/"),
+      import.meta.url,
+    ).href,
+  );
+  const { InMemorySessionService, Runner } = adkRuntime as typeof Adk;
+
+  const target = readTarget();
+  if (target === "support" && !process.env.OPENROUTER_API_KEY) {
+    throw new Error(
+      "SMOKE_HELPDESK_TARGET=support requires OPENROUTER_API_KEY for OpenRouterSupportSpecialist.",
+    );
+  }
+  const scenario = prompts[target];
+  const prompt = process.env.SMOKE_HELPDESK_PROMPT ?? scenario.prompt;
+  const { rootAgent } = await import("./agent.js");
+
+  const sessionService = new InMemorySessionService();
+  const session = await sessionService.createSession({
+    appName: "agent",
+    userId: "user",
+  });
+  const runner = new Runner({
+    appName: "agent",
+    agent: rootAgent,
+    sessionService,
+  });
+
+  let streamedEvents = 0;
+  let partials = 0;
+  let targetFunctionCalls = 0;
+  let targetFunctionResponses = 0;
+  let visibleTargetEvents = 0;
+  const errors: string[] = [];
+  let text = "";
+
+  for await (const event of runner.runAsync({
+    userId: "user",
+    sessionId: session.id,
+    newMessage: { role: "user", parts: [{ text: prompt }] },
+  })) {
+    streamedEvents++;
+    if (event.partial) {
+      partials++;
+    }
+    if (event.errorMessage) {
+      errors.push(event.errorMessage);
+    }
+    if (event.author === scenario.agentName) {
+      visibleTargetEvents++;
+    }
+    for (const part of event.content?.parts ?? []) {
+      if (
+        part.functionCall?.name === "run_adk_subagent" &&
+        readAgentName(part.functionCall.args) === scenario.agentName
+      ) {
+        targetFunctionCalls++;
+      }
+      if (part.functionResponse?.name === "run_adk_subagent") {
+        const response = part.functionResponse.response as { agentName?: unknown; error?: unknown } | undefined;
+        if (response?.agentName === scenario.agentName) {
+          targetFunctionResponses++;
+        }
+        if (typeof response?.error === "string") {
+          errors.push(response.error);
+        }
+      }
+      if (part.text) {
+        text += `${part.text}\n`;
+      }
+    }
+  }
+
+  const persisted = await sessionService.getSession({
+    appName: "agent",
+    userId: "user",
+    sessionId: session.id,
+  });
+  const summary = {
+    target,
+    expectedAgent: scenario.agentName,
+    streamedEvents,
+    persistedEvents: persisted?.events.length ?? 0,
+    partials,
+    targetFunctionCalls,
+    targetFunctionResponses,
+    visibleTargetEvents,
+    errors,
+    sample: text.slice(0, 1200),
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (
+    errors.length > 0 ||
+    targetFunctionCalls < 1 ||
+    targetFunctionResponses < 1 ||
+    visibleTargetEvents < 1
+  ) {
+    process.exit(1);
+  }
+}
+
+function readTarget(): HelpDeskTarget {
+  const value = process.env.SMOKE_HELPDESK_TARGET ?? "billing";
+  if (value === "billing" || value === "support") {
+    return value;
+  }
+  throw new Error(`SMOKE_HELPDESK_TARGET must be billing or support. Received: ${value}`);
+}
+
+function readAgentName(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const agentName = (value as { agentName?: unknown }).agentName;
+  return typeof agentName === "string" ? agentName : undefined;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/examples/external-agents/tsconfig.json
+++ b/examples/external-agents/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "paths": {
+      "@google/adk": ["node_modules/@google/adk/dist/types/index.d.ts"],
+      "adk-llm-bridge": ["../../src/index.ts"],
+      "adk-llm-bridge/agents": ["../../src/agents/index.ts"]
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"],
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adk-llm-bridge",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Use any LLM with Google ADK TypeScript - supports AI Gateway, OpenRouter, and 100+ models",
   "keywords": [
     "adk",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "typecheck:compat:nodenext": "bun run build && bunx tsc -p tests/compat/nodenext-consumer/tsconfig.json"
   },
   "peerDependencies": {
-    "@anthropic-ai/claude-agent-sdk": ">=0.2.138",
+    "@anthropic-ai/claude-agent-sdk": ">=0.2.138 <0.4",
     "@google/adk": ">=0.6.1 <2",
-    "@openai/codex-sdk": ">=0.130.0"
+    "@openai/codex-sdk": ">=0.130.0 <0.142"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {
@@ -76,12 +76,12 @@
     "openai": "^6.37.0"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.183",
     "@arethetypeswrong/cli": "^0.18.3",
     "@biomejs/biome": "^2.3.10",
     "@google/adk": "^1.2.0",
     "@google/genai": "^2.0.1",
-    "@openai/codex-sdk": "^0.130.0",
+    "@openai/codex-sdk": "^0.141.0",
     "@types/bun": "latest",
     "bunup": "^0.16.32",
     "publint": "^0.3.21",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,17 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./agents": {
+      "types": "./dist/agents/index.d.ts",
+      "import": "./dist/agents/index.js"
     }
   },
   "files": [
     "dist"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "bunup",
@@ -50,23 +54,37 @@
     "check:fix": "biome check --write ./src ./tests",
     "lint:publish": "publint --strict && attw --pack --profile esm-only",
     "ci": "bun run typecheck:all && bun run lint && bun test && bun run build && bun run lint:publish",
-    "prepublishOnly": "bun run build && bun run lint:publish"
+    "prepublishOnly": "bun run build && bun run lint:publish",
+    "typecheck:compat:nodenext": "bun run build && bunx tsc -p tests/compat/nodenext-consumer/tsconfig.json"
   },
   "peerDependencies": {
-    "@google/adk": ">=0.5.0 <2"
+    "@anthropic-ai/claude-agent-sdk": ">=0.2.138",
+    "@google/adk": ">=0.6.1 <2",
+    "@openai/codex-sdk": ">=0.130.0"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    },
+    "@openai/codex-sdk": {
+      "optional": true
+    }
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.78.0",
-    "openai": "^6.27.0"
+    "@anthropic-ai/sdk": "^0.95.1",
+    "@opentelemetry/api": "^1.9.1",
+    "openai": "^6.37.0"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
     "@arethetypeswrong/cli": "^0.18.3",
     "@biomejs/biome": "^2.3.10",
     "@google/adk": "^1.2.0",
-    "@google/genai": "^1.40.0",
+    "@google/genai": "^2.0.1",
+    "@openai/codex-sdk": "^0.130.0",
     "@types/bun": "latest",
     "bunup": "^0.16.32",
     "publint": "^0.3.21",
-    "typescript": "^5.3.0"
+    "typescript": "^5.9.3"
   }
 }

--- a/scripts/check-dts-extensions.ts
+++ b/scripts/check-dts-extensions.ts
@@ -1,0 +1,55 @@
+import { readdir, readFile } from "node:fs/promises";
+import { relative } from "node:path";
+
+const distDir = new URL("../dist/", import.meta.url);
+const specifierPattern = /(?:import|export)\s+(?:type\s+)?(?:[^"']*?\s+from\s+)?["'](\.{1,2}\/[^"']+)["']/g;
+const sideEffectImportPattern = /import\s+["'](\.{1,2}\/[^"']+)["']/g;
+const allowedExtensions = new Set([".js", ".json"]);
+
+function hasAllowedExtension(specifier: string): boolean {
+  const withoutQuery = specifier.split(/[?#]/, 1)[0] ?? specifier;
+  const lastSegment = withoutQuery.split("/").pop() ?? "";
+  return [...allowedExtensions].some((extension) => lastSegment.endsWith(extension));
+}
+
+async function findDtsFiles(directory: URL): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = new URL(`${entry.name}${entry.isDirectory() ? "/" : ""}`, directory);
+      if (entry.isDirectory()) {
+        return findDtsFiles(entryPath);
+      }
+      return entry.name.endsWith(".d.ts") ? [entryPath.pathname] : [];
+    }),
+  );
+
+  return files.flat();
+}
+
+const failures: string[] = [];
+
+for (const file of await findDtsFiles(distDir)) {
+  const text = await readFile(file, "utf8");
+  const patterns = [specifierPattern, sideEffectImportPattern];
+
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const specifier = match[1];
+      if (specifier && !hasAllowedExtension(specifier)) {
+        failures.push(`${relative(process.cwd(), file)}: extensionless relative specifier "${specifier}"`);
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Declaration files contain extensionless relative ESM specifiers:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("✓ Declaration relative ESM specifiers include explicit file extensions");

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+  createExternalAgent,
+  type ExternalAgentDefinition,
+  type ExternalAgentDefinitionConfig,
+} from "./agent-schema.js";
+import { CLAUDE_AGENT_DEFINITION } from "./claude-agent.js";
+import { CODEX_AGENT_DEFINITION } from "./codex-agent.js";
+import type { ExternalAgent } from "./external-agent.js";
+import { GEMINI_CLI_AGENT_DEFINITION } from "./gemini-cli-agent.js";
+
+export class ExternalAgentDefinitionRegistry {
+  readonly #definitions = new Map<string, ExternalAgentDefinition>();
+
+  constructor(definitions: readonly ExternalAgentDefinition[] = []) {
+    for (const definition of definitions) {
+      this.register(definition);
+    }
+  }
+
+  register(definition: ExternalAgentDefinition): void {
+    const providerId = definition.provider.id;
+    if (!providerId) {
+      throw new Error("External agent provider id is required");
+    }
+    this.#definitions.set(providerId, definition);
+  }
+
+  get(id: string): ExternalAgentDefinition | undefined {
+    return this.#definitions.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.#definitions.has(id);
+  }
+
+  list(): ExternalAgentDefinition[] {
+    return [...this.#definitions.values()];
+  }
+
+  create(id: string, config: ExternalAgentDefinitionConfig): ExternalAgent {
+    const definition = this.get(id);
+    if (!definition) {
+      throw new Error(`Unknown external agent provider: ${id}`);
+    }
+    return createExternalAgent(definition, config);
+  }
+}
+
+export function createDefaultExternalAgentDefinitionRegistry(): ExternalAgentDefinitionRegistry {
+  return new ExternalAgentDefinitionRegistry([
+    CODEX_AGENT_DEFINITION,
+    CLAUDE_AGENT_DEFINITION,
+    GEMINI_CLI_AGENT_DEFINITION,
+  ]);
+}
+
+export const externalAgentDefinitionRegistry =
+  createDefaultExternalAgentDefinitionRegistry();

--- a/src/agents/agent-schema.ts
+++ b/src/agents/agent-schema.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ExternalAgentCredentialProvider } from "./auth/credential-provider.js";
+import { ExternalAgent, type ExternalAgentConfig } from "./external-agent.js";
+import type { ExternalAgentDriver } from "./external-agent-driver.js";
+import type { ExternalAgentProviderDefinition } from "./provider/schema.js";
+import type { AgentRuntimeCapabilities } from "./runtime/capabilities.js";
+
+export type ExternalAgentRuntimeKind = "sdk" | "cli" | "jsonl" | (string & {});
+
+export interface ExternalAgentDefinition {
+  /** Provider metadata used in events, auth, and registry lookups. */
+  provider: ExternalAgentProviderDefinition;
+  /** Runtime integration style. Useful for docs, diagnostics, and future factories. */
+  runtime?: ExternalAgentRuntimeKind;
+  /** Capabilities exposed by the default runtime driver. */
+  capabilities?: AgentRuntimeCapabilities;
+  /** Creates the default driver for this runtime. */
+  createDriver?: () => ExternalAgentDriver;
+  /** Creates the default credential provider for this runtime. */
+  createCredentialProvider?: () => ExternalAgentCredentialProvider;
+}
+
+export type ExternalAgentDefinitionConfig = Omit<ExternalAgentConfig, "provider">;
+
+export function createExternalAgentConfig(
+  definition: ExternalAgentDefinition,
+  config: ExternalAgentDefinitionConfig,
+): ExternalAgentConfig {
+  const driver = config.driver ?? definition.createDriver?.();
+  const credentialProvider =
+    config.credentialProvider ?? definition.createCredentialProvider?.();
+
+  return {
+    ...config,
+    provider: definition.provider,
+    ...(driver ? { driver } : {}),
+    ...(credentialProvider ? { credentialProvider } : {}),
+  };
+}
+
+export function createExternalAgent(
+  definition: ExternalAgentDefinition,
+  config: ExternalAgentDefinitionConfig,
+): ExternalAgent {
+  return new ExternalAgent(createExternalAgentConfig(definition, config));
+}

--- a/src/agents/auth/credential-provider.ts
+++ b/src/agents/auth/credential-provider.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { CredentialRequest, ExternalAgentCredential } from "./schema.js";
+
+export interface ExternalAgentCredentialProvider {
+  getCredential(request: CredentialRequest): Promise<ExternalAgentCredential | undefined>;
+}
+
+export class NoopCredentialProvider implements ExternalAgentCredentialProvider {
+  async getCredential(): Promise<ExternalAgentCredential | undefined> {
+    return undefined;
+  }
+}

--- a/src/agents/auth/env.ts
+++ b/src/agents/auth/env.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { CredentialRequest, ExternalAgentCredential } from "./schema.js";
+import type { ExternalAgentCredentialProvider } from "./credential-provider.js";
+
+export type EnvSource = Record<string, string | undefined>;
+
+export function readAllowedEnv(
+  env: EnvSource,
+  allowlist: readonly string[] = [],
+): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const key of allowlist) {
+    const value = env[key];
+    if (typeof value === "string" && value.length > 0) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+export class EnvCredentialProvider implements ExternalAgentCredentialProvider {
+  constructor(private readonly env: EnvSource = process.env) {}
+
+  async getCredential(
+    request: CredentialRequest,
+  ): Promise<ExternalAgentCredential | undefined> {
+    const env = readAllowedEnv(this.env, request.envAllowlist);
+    if (Object.keys(env).length === 0) {
+      return undefined;
+    }
+
+    return {
+      kind: "env",
+      label: `${request.providerId}:env`,
+      env,
+    };
+  }
+}

--- a/src/agents/auth/schema.ts
+++ b/src/agents/auth/schema.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+export type ExternalAgentAuthKind = "none" | "env" | "custom";
+
+export interface ExternalAgentCredential {
+  kind: ExternalAgentAuthKind;
+  /** Redacted identifier for diagnostics; never store raw secrets here. */
+  label?: string;
+  env?: Record<string, string>;
+}
+
+export interface CredentialRequest {
+  providerId: string;
+  envAllowlist?: readonly string[];
+}

--- a/src/agents/claude-agent.ts
+++ b/src/agents/claude-agent.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+  createExternalAgentConfig,
+  type ExternalAgentDefinition,
+  type ExternalAgentDefinitionConfig,
+} from "./agent-schema.js";
+import { EnvCredentialProvider } from "./auth/env.js";
+import { ClaudeAgentSdkDriver } from "./driver/claude-agent-sdk.js";
+import { ExternalAgent } from "./external-agent.js";
+import { CLAUDE_PROVIDER } from "./provider/schema.js";
+
+export const CLAUDE_AGENT_DEFINITION: ExternalAgentDefinition = {
+  provider: CLAUDE_PROVIDER,
+  runtime: "sdk",
+  capabilities: {
+    streaming: true,
+    permissions: true,
+    tools: true,
+    subagents: true,
+    mcpServers: true,
+  },
+  createCredentialProvider: () => new EnvCredentialProvider(),
+  createDriver: () => new ClaudeAgentSdkDriver(),
+};
+
+export type ClaudeAgentConfig = ExternalAgentDefinitionConfig;
+
+export class ClaudeAgent extends ExternalAgent {
+  static readonly definition = CLAUDE_AGENT_DEFINITION;
+
+  constructor(config: ClaudeAgentConfig) {
+    super(createExternalAgentConfig(CLAUDE_AGENT_DEFINITION, config));
+  }
+}

--- a/src/agents/claude-agent.ts
+++ b/src/agents/claude-agent.ts
@@ -18,7 +18,12 @@ export const CLAUDE_AGENT_DEFINITION: ExternalAgentDefinition = {
   provider: CLAUDE_PROVIDER,
   runtime: "sdk",
   capabilities: {
-    streaming: true,
+    // STREAM-1: the SDK driver emits output at full-assistant-message
+    // granularity (it does not set `includePartialMessages` / handle
+    // `stream_event` token deltas), so it does not advertise token-level
+    // streaming. Flip this back to `true` only alongside a `stream_event`
+    // delta branch in the driver's `normalizeMessage`.
+    streaming: false,
     permissions: true,
     tools: true,
     subagents: true,

--- a/src/agents/codex-agent.ts
+++ b/src/agents/codex-agent.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+  createExternalAgentConfig,
+  type ExternalAgentDefinition,
+  type ExternalAgentDefinitionConfig,
+} from "./agent-schema.js";
+import { CodexSdkDriver } from "./driver/codex-sdk.js";
+import { ExternalAgent } from "./external-agent.js";
+import { CODEX_PROVIDER } from "./provider/codex.js";
+
+export const CODEX_AGENT_DEFINITION: ExternalAgentDefinition = {
+  provider: CODEX_PROVIDER,
+  runtime: "sdk",
+  capabilities: {
+    streaming: true,
+    sessions: true,
+    permissions: true,
+    tools: true,
+    mcpServers: true,
+  },
+  createDriver: () => new CodexSdkDriver(),
+};
+
+export type CodexAgentConfig = ExternalAgentDefinitionConfig;
+
+export class CodexAgent extends ExternalAgent {
+  static readonly definition = CODEX_AGENT_DEFINITION;
+
+  constructor(config: CodexAgentConfig) {
+    super(createExternalAgentConfig(CODEX_AGENT_DEFINITION, config));
+  }
+}

--- a/src/agents/driver/claude-agent-sdk.ts
+++ b/src/agents/driver/claude-agent-sdk.ts
@@ -1,0 +1,684 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { existsSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExternalAgentEvent } from "../events.js";
+import type { ExternalAgentRunRequest } from "../external-agent-driver.js";
+import { mapPermissionPolicyToFlags } from "../permissions/mapper.js";
+import type { ExternalAgentPermissionPolicy } from "../permissions/schema.js";
+import { CLAUDE_PROVIDER } from "../provider/schema.js";
+import {
+  collectContents,
+  flattenContentsToPrompt,
+} from "../runtime/content-collector.js";
+import {
+  contentsToSdkMessages,
+  type SDKUserMessage,
+} from "./claude-message-mapper.js";
+
+type ClaudeAgentSdkPermissionMode =
+  | "default"
+  | "acceptEdits"
+  | "bypassPermissions"
+  | "plan"
+  | "dontAsk"
+  | "auto";
+
+type ClaudeAgentSdkSettingSource = "user" | "project" | "local";
+
+type ClaudeAgentSdkOptions = {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  permissionMode?: ClaudeAgentSdkPermissionMode;
+  additionalDirectories?: string[];
+  pathToClaudeCodeExecutable?: string;
+  settingSources?: ClaudeAgentSdkSettingSource[];
+  maxTurns?: number;
+  model?: string;
+  systemPrompt?: string | { type: "preset"; preset: "claude_code"; append?: string };
+  allowDangerouslySkipPermissions?: true;
+  mcpServers?: Record<string, unknown>;
+  allowedTools?: string[];
+  resume?: string;
+  forkSession?: boolean;
+};
+
+type ClaudeAgentSdkMessage = Record<string, unknown>;
+type ClaudeAgentSdkToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+type ClaudeAgentSdkToolDefinition = unknown;
+
+type ClaudeAgentSdkLike = {
+  query(params: {
+    prompt: string | AsyncIterable<unknown>;
+    options?: ClaudeAgentSdkOptions;
+  }): AsyncIterable<ClaudeAgentSdkMessage>;
+  createSdkMcpServer?(options: {
+    name: string;
+    version?: string;
+    tools?: ClaudeAgentSdkToolDefinition[];
+    alwaysLoad?: boolean;
+  }): unknown;
+  tool?(
+    name: string,
+    description: string,
+    inputSchema: Record<string, unknown>,
+    handler: (args: Record<string, unknown>, extra: unknown) => Promise<ClaudeAgentSdkToolResult>,
+    extras?: Record<string, unknown>,
+  ): ClaudeAgentSdkToolDefinition;
+};
+
+export interface ClaudeExecutableResolution {
+  path?: string;
+  checked: string[];
+}
+
+export interface ClaudeAgentSdkDriverConfig {
+  sdk?: ClaudeAgentSdkLike;
+  importSdk?: () => Promise<ClaudeAgentSdkLike>;
+  pathToClaudeCodeExecutable?: string;
+  executableSearchPaths?: string[];
+  env?: Record<string, string | undefined>;
+  settingSources?: ClaudeAgentSdkSettingSource[];
+  maxTurns?: number;
+  model?: string;
+  debugEvents?: boolean;
+  /**
+   * If set, the driver passes this session id to the Claude SDK
+   * `options.resume` field and sends only the current user turn (not the full
+   * ADK history) so the SDK appends to the resumed session instead of
+   * re-feeding history that the SDK already has on disk.
+   */
+  resumeSessionId?: string;
+  /**
+   * Pass-through for the Claude SDK `options.forkSession` flag. Use with
+   * `resumeSessionId` to fork rather than continue the previous session.
+   */
+  forkSession?: boolean;
+}
+
+export class ClaudeAgentSdkDriver {
+  readonly providerId = CLAUDE_PROVIDER.id;
+  readonly #sdk?: ClaudeAgentSdkLike;
+  readonly #importSdk: () => Promise<ClaudeAgentSdkLike>;
+  readonly #env: Record<string, string | undefined>;
+  readonly #pathToClaudeCodeExecutable?: string;
+  readonly #executableSearchPaths: string[];
+  readonly #settingSources?: ClaudeAgentSdkSettingSource[];
+  readonly #maxTurns?: number;
+  readonly #model?: string;
+  readonly #debugEvents: boolean;
+  readonly #resumeSessionId?: string;
+  readonly #forkSession?: boolean;
+
+  constructor(config: ClaudeAgentSdkDriverConfig = {}) {
+    this.#sdk = config.sdk;
+    this.#importSdk = config.importSdk ?? importClaudeAgentSdk;
+    this.#env = config.env ?? process.env;
+    this.#pathToClaudeCodeExecutable = config.pathToClaudeCodeExecutable;
+    this.#executableSearchPaths = config.executableSearchPaths ?? [];
+    this.#settingSources = config.settingSources;
+    this.#maxTurns = config.maxTurns;
+    this.#model = config.model;
+    this.#debugEvents = config.debugEvents ?? false;
+    this.#resumeSessionId = config.resumeSessionId;
+    this.#forkSession = config.forkSession;
+  }
+
+  async *run(request: ExternalAgentRunRequest): AsyncIterable<ExternalAgentEvent> {
+    const sdk = await this.loadSdk();
+    const prompt = this.buildPromptInput(request);
+    const options = await this.buildOptionsForRun(request, sdk);
+
+    yield {
+      type: "started",
+      providerId: this.providerId,
+      timestamp: Date.now(),
+    };
+
+    let completed = false;
+    let failed = false;
+    try {
+      for await (const message of sdk.query({ prompt, options })) {
+        const events = this.normalizeMessage(message);
+        for (const event of events) {
+          if (event.type === "completed") {
+            completed = true;
+          }
+          yield event;
+        }
+      }
+    } catch (error) {
+      failed = true;
+      yield {
+        type: "error",
+        message: this.describeError(error, request),
+        code: "CLAUDE_AGENT_SDK_ERROR",
+        recoverable: true,
+        timestamp: Date.now(),
+      };
+    }
+
+    if (!completed) {
+      yield { type: "completed", exitCode: failed ? 1 : 0, timestamp: Date.now() };
+    }
+  }
+
+  buildOptions(request: ExternalAgentRunRequest): ClaudeAgentSdkOptions {
+    const permission = mapPolicyToClaudeSdkPermission(request.permissions);
+    const options: ClaudeAgentSdkOptions = {
+      cwd: request.workingDirectory,
+      env: this.buildEnv(request),
+      permissionMode: permission.permissionMode,
+      additionalDirectories: request.permissions?.allowedPaths
+        ? [...request.permissions.allowedPaths]
+        : undefined,
+      pathToClaudeCodeExecutable: this.resolveClaudeExecutable(request).path,
+      settingSources: this.#settingSources,
+      maxTurns: this.#maxTurns,
+      model: this.#model,
+      systemPrompt: request.instruction
+        ? { type: "preset", preset: "claude_code", append: request.instruction }
+        : { type: "preset", preset: "claude_code" },
+      allowDangerouslySkipPermissions: permission.allowDangerouslySkipPermissions,
+      resume: this.#resumeSessionId,
+      forkSession: this.#forkSession,
+    };
+
+    return removeUndefined(options) as ClaudeAgentSdkOptions;
+  }
+
+  /**
+   * Build the SDK `prompt` input from a run request. Returns:
+   * - a plain string for text-only single-turn invocations (fast path);
+   * - an `AsyncIterable<SDKUserMessage>` carrying lossless multimodal blocks
+   *   for multi-turn or multimodal history;
+   * - an empty string when no content can be collected (defensive fallback).
+   *
+   * When `resumeSessionId` is configured, only the last collected `Content`
+   * is sent so the resumed session continues from existing transcript on disk
+   * rather than re-feeding history.
+   */
+  buildPromptInput(
+    request: ExternalAgentRunRequest,
+  ): string | AsyncIterable<SDKUserMessage> {
+    let contents: ReturnType<typeof collectContents>;
+    try {
+      contents = collectContents(request.context);
+    } catch {
+      contents = [];
+    }
+
+    if (contents.length === 0) {
+      return extractContextText(request.context) ?? "";
+    }
+
+    if (this.#resumeSessionId) {
+      const last = contents[contents.length - 1];
+      const messages = contentsToSdkMessages([last]);
+      return asyncIterable(messages);
+    }
+
+    if (contents.length === 1) {
+      const onlyTextParts = (contents[0].parts ?? []).every(
+        (part) => typeof part.text === "string" && !part.thought,
+      );
+      if (onlyTextParts) {
+        return buildPrompt(request);
+      }
+    }
+
+    const messages = contentsToSdkMessages(contents);
+    if (messages.length === 0) {
+      return buildPrompt(request);
+    }
+    return asyncIterable(messages);
+  }
+
+  resolveClaudeExecutable(request: ExternalAgentRunRequest): ClaudeExecutableResolution {
+    const checked: string[] = [];
+    const explicit = firstNonEmpty(
+      this.#pathToClaudeCodeExecutable,
+      this.#env.CLAUDE_CODE_EXECUTABLE,
+      this.#env.CLAUDE_CODE_PATH,
+      readCredentialEnv(request, "CLAUDE_CODE_EXECUTABLE"),
+      readCredentialEnv(request, "CLAUDE_CODE_PATH"),
+    );
+    if (explicit) {
+      checked.push(explicit);
+      return { path: explicit, checked };
+    }
+
+    for (const candidate of claudeExecutableCandidates({
+      env: this.#env,
+      workingDirectory: request.workingDirectory,
+      executableSearchPaths: this.#executableSearchPaths,
+    })) {
+      checked.push(candidate);
+      if (existsSync(candidate)) {
+        return { path: candidate, checked };
+      }
+    }
+
+    return { checked };
+  }
+
+  buildEnv(request: ExternalAgentRunRequest): Record<string, string | undefined> {
+    const env: Record<string, string | undefined> = {};
+
+    copyIfPresent(this.#env, env, "PATH");
+    copyIfPresent(this.#env, env, "HOME");
+    copyIfPresent(this.#env, env, "USER");
+    copyIfPresent(this.#env, env, "SHELL");
+    copyIfPresent(this.#env, env, "CLAUDE_CONFIG_DIR");
+    copyIfPresent(this.#env, env, "XDG_CONFIG_HOME");
+    env.CLAUDE_AGENT_SDK_CLIENT_APP = "adk-llm-bridge";
+
+    if (request.credential?.kind === "env") {
+      for (const key of request.provider.envAllowlist ?? []) {
+        const value = request.credential.env?.[key];
+        if (typeof value === "string" && value.length > 0) {
+          env[key] = value;
+        }
+      }
+    }
+
+    return env;
+  }
+
+  normalizeMessage(message: ClaudeAgentSdkMessage): ExternalAgentEvent[] {
+    const record = asRecord(message);
+    const type = stringValue(record.type);
+
+    if (type === "assistant") {
+      const error = stringValue(record.error);
+      if (error) {
+        return [
+          {
+            type: "error",
+            message: error,
+            code: error,
+            recoverable: true,
+            timestamp: Date.now(),
+          },
+        ];
+      }
+
+      const text = extractText(asRecord(record.message).content);
+      return text ? [{ type: "output", content: text, timestamp: Date.now() }] : [];
+    }
+
+    if (type === "result") {
+      if (record.subtype === "success") {
+        return [{ type: "completed" as const, exitCode: 0, timestamp: Date.now() }];
+      }
+
+      const errors = Array.isArray(record.errors)
+        ? record.errors.filter((item): item is string => typeof item === "string")
+        : [];
+      return [
+        {
+          type: "error",
+          message: errors.join("\n") || `Claude Agent SDK result: ${String(record.subtype ?? "error")}`,
+          code: stringValue(record.subtype),
+          recoverable: true,
+          timestamp: Date.now(),
+        },
+        { type: "completed", exitCode: 1, timestamp: Date.now() },
+      ];
+    }
+
+    if (type === "auth_status") {
+      const error = stringValue(record.error);
+      return error
+        ? [{ type: "error", message: error, code: "CLAUDE_AUTH_STATUS", recoverable: true, timestamp: Date.now() }]
+        : [];
+    }
+
+    if (type === "system" && record.subtype === "permission_denied") {
+      return [
+        {
+          type: "error",
+          message: stringValue(record.message) ?? "Claude permission denied",
+          code: "CLAUDE_PERMISSION_DENIED",
+          recoverable: true,
+          timestamp: Date.now(),
+        },
+      ];
+    }
+
+    if (this.#debugEvents) {
+      return [{ type: "output", content: JSON.stringify(message), timestamp: Date.now() }];
+    }
+
+    return [];
+  }
+
+  async buildOptionsForRun(
+    request: ExternalAgentRunRequest,
+    sdk: ClaudeAgentSdkLike,
+  ): Promise<ClaudeAgentSdkOptions> {
+    const options = this.buildOptions(request);
+    if (!request.toolGateway || !request.subAgents || request.subAgents.length === 0) {
+      return options;
+    }
+
+    const mcpServer = await this.buildSubAgentMcpServer(request, sdk);
+    return removeUndefined({
+      ...options,
+      mcpServers: {
+        ...(options.mcpServers ?? {}),
+        adk_bridge: mcpServer,
+      },
+      allowedTools: [
+        ...(options.allowedTools ?? []),
+        "mcp__adk_bridge__run_adk_subagent",
+      ],
+    }) as ClaudeAgentSdkOptions;
+  }
+
+  private async buildSubAgentMcpServer(
+    request: ExternalAgentRunRequest,
+    sdk: ClaudeAgentSdkLike,
+  ): Promise<unknown> {
+    if (!sdk.createSdkMcpServer || !sdk.tool) {
+      throw new Error(
+        "Claude Agent SDK MCP support is required to expose ADK subagents. Update @anthropic-ai/claude-agent-sdk or run without subAgents.",
+      );
+    }
+
+    const schema = await createRunSubAgentSchema();
+    const available = request.subAgents?.map((agent) => agent.name).join(", ") ?? "";
+    const runSubAgentTool = sdk.tool(
+      "run_adk_subagent",
+      `Run one of the ADK subagents by name. Available subagents: ${available}`,
+      schema,
+      async (args) => {
+        const agentName = stringValue(args.agentName) ?? "";
+        const task = stringValue(args.task) ?? "";
+        const result = await request.toolGateway?.runSubAgent({ agentName, task });
+        if (!result) {
+          return toolTextResult("ADK ToolGateway is not available.", true);
+        }
+        if (result.error) {
+          return toolTextResult(result.error, true);
+        }
+        return toolTextResult(result.output || `Subagent ${result.agentName} completed with ${result.events} events.`);
+      },
+      { alwaysLoad: true },
+    );
+
+    return sdk.createSdkMcpServer({
+      name: "adk_bridge",
+      version: "0.1.0",
+      tools: [runSubAgentTool],
+      alwaysLoad: true,
+    });
+  }
+
+  private describeError(error: unknown, request: ExternalAgentRunRequest): string {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Native CLI binary") && !message.includes("pathToClaudeCodeExecutable")) {
+      return message;
+    }
+
+    const resolution = this.resolveClaudeExecutable(request);
+    const checked = resolution.checked.length > 0
+      ? resolution.checked.map((item) => `  - ${item}`).join("\n")
+      : "  - <no candidates>";
+    return [
+      "Claude Agent SDK could not locate a Claude Code executable.",
+      "Set CLAUDE_CODE_EXECUTABLE=/absolute/path/to/claude or CLAUDE_CODE_PATH=/absolute/path/to/claude, add the executable directory to PATH, pass executableSearchPaths, or reinstall @anthropic-ai/claude-agent-sdk with optional dependencies.",
+      `Original error: ${message}`,
+      "Checked paths:",
+      checked,
+    ].join("\n");
+  }
+
+  private async loadSdk(): Promise<ClaudeAgentSdkLike> {
+    if (this.#sdk) {
+      return this.#sdk;
+    }
+
+    try {
+      return await this.#importSdk();
+    } catch (error) {
+      throw new Error(
+        "ClaudeAgent requires @anthropic-ai/claude-agent-sdk. Install it or pass driver: new ClaudeCliDriver(...).",
+        { cause: error },
+      );
+    }
+  }
+}
+
+export function mapPolicyToClaudeSdkPermission(
+  permissions?: ExternalAgentPermissionPolicy,
+): {
+  permissionMode: ClaudeAgentSdkPermissionMode;
+  allowDangerouslySkipPermissions?: true;
+} {
+  const policy = permissions ?? { mode: "ask" as const };
+  const flags = mapPermissionPolicyToFlags(policy);
+
+  if (flags.readOnly) {
+    return { permissionMode: "plan" };
+  }
+  if (flags.workspaceWrite) {
+    return { permissionMode: "acceptEdits" };
+  }
+  if (flags.fullAccess) {
+    return { permissionMode: "bypassPermissions", allowDangerouslySkipPermissions: true };
+  }
+  return { permissionMode: "default" };
+}
+
+function claudeExecutableCandidates({
+  env,
+  workingDirectory,
+  executableSearchPaths,
+}: {
+  env: Record<string, string | undefined>;
+  workingDirectory?: string;
+  executableSearchPaths?: string[];
+}): string[] {
+  const executable = process.platform === "win32" ? "claude.exe" : "claude";
+  const candidates = new Set<string>();
+
+  for (const dir of (env.PATH ?? "").split(delimiter)) {
+    if (dir.length > 0) {
+      candidates.add(join(dir, executable));
+    }
+  }
+
+  const home = env.HOME;
+  if (home) {
+    candidates.add(join(home, ".local", "bin", executable));
+    candidates.add(join(home, ".claude", "local", executable));
+  }
+
+  for (const dir of executableSearchPaths ?? []) {
+    if (dir.length > 0) {
+      candidates.add(join(dir, executable));
+    }
+  }
+
+  for (const base of candidateBaseDirectories(workingDirectory)) {
+    candidates.add(join(base, "node_modules", ".bin", executable));
+    for (const platformPackage of platformClaudePackages()) {
+      candidates.add(join(base, "node_modules", "@anthropic-ai", platformPackage, executable));
+    }
+  }
+
+  return [...candidates];
+}
+
+function candidateBaseDirectories(workingDirectory?: string): string[] {
+  const roots = new Set<string>();
+  if (workingDirectory) {
+    roots.add(resolve(workingDirectory));
+  }
+  roots.add(process.cwd());
+
+  let current = dirname(fileURLToPath(import.meta.url));
+  for (let index = 0; index < 8; index++) {
+    roots.add(current);
+    const next = dirname(current);
+    if (next === current) {
+      break;
+    }
+    current = next;
+  }
+
+  return [...roots].filter((item) => isAbsolute(item));
+}
+
+function platformClaudePackages(): string[] {
+  switch (`${process.platform}:${process.arch}`) {
+    case "darwin:arm64":
+      return ["claude-agent-sdk-darwin-arm64"];
+    case "darwin:x64":
+      return ["claude-agent-sdk-darwin-x64"];
+    case "linux:arm64":
+      return ["claude-agent-sdk-linux-arm64"];
+    case "linux:x64":
+      return ["claude-agent-sdk-linux-x64"];
+    case "win32:arm64":
+      return ["claude-agent-sdk-win32-arm64"];
+    case "win32:x64":
+      return ["claude-agent-sdk-win32-x64"];
+    default:
+      return [];
+  }
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+function readCredentialEnv(
+  request: ExternalAgentRunRequest,
+  key: string,
+): string | undefined {
+  return request.credential?.kind === "env" ? request.credential.env?.[key] : undefined;
+}
+
+function importClaudeAgentSdk(): Promise<ClaudeAgentSdkLike> {
+  return import("@anthropic-ai/claude-agent-sdk") as Promise<ClaudeAgentSdkLike>;
+}
+
+async function createRunSubAgentSchema(): Promise<Record<string, unknown>> {
+  try {
+    const { z } = await import("zod/v4");
+    return {
+      agentName: z.string().describe("Name of the ADK subagent to run"),
+      task: z.string().describe("Task or prompt for the subagent"),
+    };
+  } catch (error) {
+    throw new Error(
+      "Claude Agent SDK MCP subagent tooling requires zod/v4. Install zod or update @anthropic-ai/claude-agent-sdk dependencies.",
+      { cause: error },
+    );
+  }
+}
+
+function toolTextResult(text: string, isError?: boolean): ClaudeAgentSdkToolResult {
+  return {
+    content: [{ type: "text", text }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function asyncIterable(
+  messages: ReadonlyArray<SDKUserMessage>,
+): AsyncIterable<SDKUserMessage> {
+  return (async function* () {
+    for (const message of messages) {
+      yield message;
+    }
+  })();
+}
+
+function buildPrompt(request: ExternalAgentRunRequest): string {
+  try {
+    const contents = collectContents(request.context);
+    if (contents.length > 0) {
+      return flattenContentsToPrompt(contents);
+    }
+  } catch {
+    // fall through to legacy extractor
+  }
+  return extractContextText(request.context) ?? "";
+}
+
+function extractContextText(context: unknown): string | undefined {
+  const record = asRecord(context);
+  return (
+    extractText(record.userContent ?? record.user_content) ??
+    stringValue(record.input) ??
+    stringValue(record.prompt)
+  );
+}
+
+function extractText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((part) => extractText(part))
+      .filter((part): part is string => typeof part === "string");
+    return parts.length > 0 ? parts.join("") : undefined;
+  }
+
+  const record = asRecord(value);
+  const direct =
+    stringValue(record.text) ??
+    stringValue(record.content) ??
+    stringValue(record.result) ??
+    stringValue(record.message);
+  if (direct) {
+    return direct;
+  }
+
+  const arrayContent = Array.isArray(record.content)
+    ? record.content
+    : Array.isArray(record.parts)
+      ? record.parts
+      : undefined;
+  return arrayContent ? extractText(arrayContent) : undefined;
+}
+
+function copyIfPresent(
+  source: Record<string, string | undefined>,
+  target: Record<string, string | undefined>,
+  key: string,
+): void {
+  const value = source[key];
+  if (typeof value === "string" && value.length > 0) {
+    target[key] = value;
+  }
+}
+
+function removeUndefined(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/agents/driver/claude-agent-sdk.ts
+++ b/src/agents/driver/claude-agent-sdk.ts
@@ -8,8 +8,12 @@ import { existsSync } from "node:fs";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExternalAgentEvent } from "../events.js";
-import type { ExternalAgentRunRequest } from "../external-agent-driver.js";
+import {
+  type ExternalAgentRunRequest,
+  resolveAbortSignal,
+} from "../external-agent-driver.js";
 import { mapPermissionPolicyToFlags } from "../permissions/mapper.js";
+import { classifyRecoverable } from "../runtime/error-classification.js";
 import type { ExternalAgentPermissionPolicy } from "../permissions/schema.js";
 import { CLAUDE_PROVIDER } from "../provider/schema.js";
 import {
@@ -34,6 +38,7 @@ type ClaudeAgentSdkSettingSource = "user" | "project" | "local";
 type ClaudeAgentSdkOptions = {
   cwd?: string;
   env?: Record<string, string | undefined>;
+  abortController?: AbortController;
   permissionMode?: ClaudeAgentSdkPermissionMode;
   additionalDirectories?: string[];
   pathToClaudeCodeExecutable?: string;
@@ -55,11 +60,22 @@ type ClaudeAgentSdkToolResult = {
 };
 type ClaudeAgentSdkToolDefinition = unknown;
 
+/**
+ * The object returned by `query()`. The real SDK returns a `Query` (an
+ * `AsyncGenerator` that additionally exposes `interrupt()`); generator-based
+ * test fakes expose `return()`. Both are used to tear down the spawned
+ * subprocess on early break/error (LIFECYCLE-1).
+ */
+type ClaudeAgentSdkQuery = AsyncIterable<ClaudeAgentSdkMessage> & {
+  interrupt?(): Promise<void> | void;
+  return?(value?: unknown): Promise<unknown> | unknown;
+};
+
 type ClaudeAgentSdkLike = {
   query(params: {
     prompt: string | AsyncIterable<unknown>;
     options?: ClaudeAgentSdkOptions;
-  }): AsyncIterable<ClaudeAgentSdkMessage>;
+  }): ClaudeAgentSdkQuery;
   createSdkMcpServer?(options: {
     name: string;
     version?: string;
@@ -91,6 +107,13 @@ export interface ClaudeAgentSdkDriverConfig {
   model?: string;
   debugEvents?: boolean;
   /**
+   * AUTH-2: opt-in plain-string system prompt. When set, it REPLACES the
+   * `claude_code` preset (and `request.instruction` is appended to it) so a
+   * non-coding agent is not forced into the full coding-agent persona/token
+   * cost. When unset, the driver keeps the preset+append default.
+   */
+  systemPrompt?: string;
+  /**
    * If set, the driver passes this session id to the Claude SDK
    * `options.resume` field and sends only the current user turn (not the full
    * ADK history) so the SDK appends to the resumed session instead of
@@ -111,12 +134,13 @@ export class ClaudeAgentSdkDriver {
   readonly #env: Record<string, string | undefined>;
   readonly #pathToClaudeCodeExecutable?: string;
   readonly #executableSearchPaths: string[];
-  readonly #settingSources?: ClaudeAgentSdkSettingSource[];
+  readonly #settingSources: ClaudeAgentSdkSettingSource[];
   readonly #maxTurns?: number;
   readonly #model?: string;
   readonly #debugEvents: boolean;
   readonly #resumeSessionId?: string;
   readonly #forkSession?: boolean;
+  readonly #systemPrompt?: string;
 
   constructor(config: ClaudeAgentSdkDriverConfig = {}) {
     this.#sdk = config.sdk;
@@ -124,12 +148,19 @@ export class ClaudeAgentSdkDriver {
     this.#env = config.env ?? process.env;
     this.#pathToClaudeCodeExecutable = config.pathToClaudeCodeExecutable;
     this.#executableSearchPaths = config.executableSearchPaths ?? [];
-    this.#settingSources = config.settingSources;
+    // AUTH-1: default to SDK isolation (`[]`) instead of `undefined`. Leaving it
+    // undefined causes `removeUndefined` to strip the key, which makes the SDK
+    // load ALL host setting sources (user `~/.claude` + project `.claude` +
+    // local) — permission rules, MCP servers, hooks, CLAUDE.md — and can
+    // silently override the intended policy. Consumers opt back in by passing an
+    // explicit allowlist.
+    this.#settingSources = config.settingSources ?? [];
     this.#maxTurns = config.maxTurns;
     this.#model = config.model;
     this.#debugEvents = config.debugEvents ?? false;
     this.#resumeSessionId = config.resumeSessionId;
     this.#forkSession = config.forkSession;
+    this.#systemPrompt = config.systemPrompt;
   }
 
   async *run(request: ExternalAgentRunRequest): AsyncIterable<ExternalAgentEvent> {
@@ -145,25 +176,63 @@ export class ClaudeAgentSdkDriver {
 
     let completed = false;
     let failed = false;
+    let emittedOutput = false;
+    // LIFECYCLE-1: capture the Query so we can tear down the spawned `claude`
+    // subprocess on early consumer break or thrown error. We drive the iterator
+    // manually (rather than `for await`) so the `finally` reliably runs even
+    // when the consumer breaks out of *this* generator early — a `for await`
+    // over the inner Query can swallow the outer return on some runtimes.
+    // `query()` itself is invoked inside the try so a synchronous throw is
+    // classified too. The `finally` runs on normal completion, break, AND throw.
+    let query: ClaudeAgentSdkQuery | undefined;
     try {
-      for await (const message of sdk.query({ prompt, options })) {
+      query = sdk.query({ prompt, options });
+      const iterator = query[Symbol.asyncIterator]();
+      while (true) {
+        const next = await iterator.next();
+        if (next.done) {
+          break;
+        }
+        const message = next.value;
+        // ERR-3: if the turn produced no streamed assistant text, fall back to
+        // the aggregated `result.result` on a successful result message so the
+        // run does not complete with silent-empty output.
+        if (!emittedOutput && isSuccessResultWithText(message)) {
+          const text = stringValue(asRecord(message).result);
+          if (text) {
+            emittedOutput = true;
+            yield { type: "output", content: text, timestamp: Date.now() };
+          }
+        }
         const events = this.normalizeMessage(message);
         for (const event of events) {
           if (event.type === "completed") {
             completed = true;
+          }
+          if (event.type === "output") {
+            emittedOutput = true;
           }
           yield event;
         }
       }
     } catch (error) {
       failed = true;
+      const message = this.describeError(error, request);
+      const classification = classifyRecoverable({
+        message,
+        fallbackCode: "CLAUDE_AGENT_SDK_ERROR",
+      });
       yield {
         type: "error",
-        message: this.describeError(error, request),
-        code: "CLAUDE_AGENT_SDK_ERROR",
-        recoverable: true,
+        message,
+        code: classification.code,
+        recoverable: classification.recoverable,
         timestamp: Date.now(),
       };
+    } finally {
+      if (query) {
+        await this.disposeQuery(query, completed);
+      }
     }
 
     if (!completed) {
@@ -176,6 +245,7 @@ export class ClaudeAgentSdkDriver {
     const options: ClaudeAgentSdkOptions = {
       cwd: request.workingDirectory,
       env: this.buildEnv(request),
+      abortController: this.buildAbortController(request),
       permissionMode: permission.permissionMode,
       additionalDirectories: request.permissions?.allowedPaths
         ? [...request.permissions.allowedPaths]
@@ -184,15 +254,31 @@ export class ClaudeAgentSdkDriver {
       settingSources: this.#settingSources,
       maxTurns: this.#maxTurns,
       model: this.#model,
-      systemPrompt: request.instruction
-        ? { type: "preset", preset: "claude_code", append: request.instruction }
-        : { type: "preset", preset: "claude_code" },
+      systemPrompt: this.buildSystemPrompt(request),
       allowDangerouslySkipPermissions: permission.allowDangerouslySkipPermissions,
       resume: this.#resumeSessionId,
       forkSession: this.#forkSession,
     };
 
     return removeUndefined(options) as ClaudeAgentSdkOptions;
+  }
+
+  /**
+   * AUTH-2: resolve the system prompt. A configured plain-string
+   * `systemPrompt` replaces the `claude_code` preset (with the run instruction
+   * appended); otherwise the preset+append default is kept.
+   */
+  private buildSystemPrompt(
+    request: ExternalAgentRunRequest,
+  ): ClaudeAgentSdkOptions["systemPrompt"] {
+    if (this.#systemPrompt) {
+      return request.instruction
+        ? `${this.#systemPrompt}\n\n${request.instruction}`
+        : this.#systemPrompt;
+    }
+    return request.instruction
+      ? { type: "preset", preset: "claude_code", append: request.instruction }
+      : { type: "preset", preset: "claude_code" };
   }
 
   /**
@@ -293,6 +379,59 @@ export class ClaudeAgentSdkDriver {
     return env;
   }
 
+  /**
+   * Build the `AbortController` wired into `options.abortController` (LIFECYCLE-1).
+   * The SDK aborts the spawned `claude` subprocess and releases resources when
+   * this controller fires. We bridge the shared run cancellation signal
+   * (`request.abortSignal` ?? `context.abortSignal`) onto a fresh controller so
+   * the driver also owns a handle it can abort from its own `finally` cleanup.
+   */
+  private buildAbortController(
+    request: ExternalAgentRunRequest,
+  ): AbortController {
+    const controller = new AbortController();
+    const signal = resolveAbortSignal(request);
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort(signal.reason);
+      } else {
+        signal.addEventListener(
+          "abort",
+          () => controller.abort(signal.reason),
+          { once: true },
+        );
+      }
+    }
+    return controller;
+  }
+
+  /**
+   * Tear down a Query (LIFECYCLE-1). When the loop ends early (break/throw)
+   * the turn is still in flight, so `interrupt()` is requested first to stop
+   * the spawned subprocess gracefully; `return()` then finalizes the
+   * generator. Both are best-effort — disposal must never mask the original
+   * outcome, so all errors here are swallowed.
+   */
+  private async disposeQuery(
+    query: ClaudeAgentSdkQuery,
+    completed: boolean,
+  ): Promise<void> {
+    if (!completed && typeof query.interrupt === "function") {
+      try {
+        await query.interrupt();
+      } catch {
+        // best-effort: subprocess may already be gone
+      }
+    }
+    if (typeof query.return === "function") {
+      try {
+        await query.return(undefined);
+      } catch {
+        // best-effort: generator may already be finalized
+      }
+    }
+  }
+
   normalizeMessage(message: ClaudeAgentSdkMessage): ExternalAgentEvent[] {
     const record = asRecord(message);
     const type = stringValue(record.type);
@@ -300,12 +439,19 @@ export class ClaudeAgentSdkDriver {
     if (type === "assistant") {
       const error = stringValue(record.error);
       if (error) {
+        // `record.error` is an SDKAssistantMessageError subtype
+        // (authentication_failed/billing_error/rate_limit/server_error/…).
+        const classification = classifyRecoverable({
+          subtype: error,
+          message: error,
+          fallbackCode: error,
+        });
         return [
           {
             type: "error",
             message: error,
-            code: error,
-            recoverable: true,
+            code: classification.code,
+            recoverable: classification.recoverable,
             timestamp: Date.now(),
           },
         ];
@@ -323,12 +469,23 @@ export class ClaudeAgentSdkDriver {
       const errors = Array.isArray(record.errors)
         ? record.errors.filter((item): item is string => typeof item === "string")
         : [];
+      const subtype = stringValue(record.subtype);
+      const message =
+        errors.join("\n") ||
+        `Claude Agent SDK result: ${String(record.subtype ?? "error")}`;
+      // SDKResultError subtype (error_max_turns/error_max_budget_usd/
+      // error_max_structured_output_retries/error_during_execution).
+      const classification = classifyRecoverable({
+        subtype,
+        message,
+        fallbackCode: subtype ?? "CLAUDE_AGENT_SDK_RESULT_ERROR",
+      });
       return [
         {
           type: "error",
-          message: errors.join("\n") || `Claude Agent SDK result: ${String(record.subtype ?? "error")}`,
-          code: stringValue(record.subtype),
-          recoverable: true,
+          message,
+          code: classification.code,
+          recoverable: classification.recoverable,
           timestamp: Date.now(),
         },
         { type: "completed", exitCode: 1, timestamp: Date.now() },
@@ -337,18 +494,46 @@ export class ClaudeAgentSdkDriver {
 
     if (type === "auth_status") {
       const error = stringValue(record.error);
-      return error
-        ? [{ type: "error", message: error, code: "CLAUDE_AUTH_STATUS", recoverable: true, timestamp: Date.now() }]
-        : [];
-    }
-
-    if (type === "system" && record.subtype === "permission_denied") {
+      if (!error) {
+        return [];
+      }
+      const classification = classifyRecoverable({
+        subtype: "CLAUDE_AUTH_STATUS",
+        message: error,
+        fallbackCode: "CLAUDE_AUTH_STATUS",
+      });
       return [
         {
           type: "error",
-          message: stringValue(record.message) ?? "Claude permission denied",
+          message: error,
+          code: classification.code,
+          recoverable: classification.recoverable,
+          timestamp: Date.now(),
+        },
+      ];
+    }
+
+    if (type === "system" && record.subtype === "permission_denied") {
+      // ERR-1 was REFUTED: keep the base SDK rejection message. ERR-2 enriches
+      // it with tool_name / decision_reason when present. Permission denials do
+      // not become allowed by retrying, so they are non-recoverable.
+      const base = stringValue(record.message) ?? "Claude permission denied";
+      const toolName = stringValue(record.tool_name);
+      const decisionReason =
+        stringValue(record.decision_reason) ??
+        stringValue(record.decision_reason_type);
+      const details = [
+        toolName ? `tool: ${toolName}` : undefined,
+        decisionReason ? `reason: ${decisionReason}` : undefined,
+      ].filter((part): part is string => part !== undefined);
+      const message =
+        details.length > 0 ? `${base} (${details.join(", ")})` : base;
+      return [
+        {
+          type: "error",
+          message,
           code: "CLAUDE_PERMISSION_DENIED",
-          recoverable: true,
+          recoverable: false,
           timestamp: Date.now(),
         },
       ];
@@ -468,7 +653,12 @@ export function mapPolicyToClaudeSdkPermission(
   const flags = mapPermissionPolicyToFlags(policy);
 
   if (flags.readOnly) {
-    return { permissionMode: "plan" };
+    // A read-only policy must still answer questions and run read-only tools.
+    // `"plan"` is interactive planning mode (explore-without-executing, driven
+    // by ExitPlanMode) and can stall a plain Q&A run or return a plan artifact
+    // instead of an answer. `"default"` keeps normal execution while the
+    // bridge's read-only permission rules continue to gate write/edit tools.
+    return { permissionMode: "default" };
   }
   if (flags.workspaceWrite) {
     return { permissionMode: "acceptEdits" };
@@ -670,6 +860,16 @@ function copyIfPresent(
 function removeUndefined(value: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== undefined),
+  );
+}
+
+function isSuccessResultWithText(message: ClaudeAgentSdkMessage): boolean {
+  const record = asRecord(message);
+  return (
+    record.type === "result" &&
+    record.subtype === "success" &&
+    typeof record.result === "string" &&
+    record.result.length > 0
   );
 }
 

--- a/src/agents/driver/claude-cli.ts
+++ b/src/agents/driver/claude-cli.ts
@@ -1,0 +1,456 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ExternalAgentEvent } from "../events.js";
+import type { ExternalAgentRunRequest } from "../external-agent-driver.js";
+import { mapPermissionPolicyToFlags } from "../permissions/mapper.js";
+import type { ExternalAgentPermissionPolicy } from "../permissions/schema.js";
+import { CLAUDE_PROVIDER } from "../provider/schema.js";
+import { SubprocessJsonlDriver } from "./subprocess-jsonl.js";
+
+declare const Bun: {
+  spawn(
+    command: string[],
+    options: {
+      cwd?: string;
+      env?: Record<string, string>;
+      stdout: "pipe";
+      stderr: "pipe";
+    },
+  ): {
+    stdout: ReadableStream<Uint8Array>;
+    stderr: ReadableStream<Uint8Array>;
+    exited: Promise<number>;
+  };
+};
+
+export interface ClaudeCliSubprocess {
+  stdout?: LineSource | null;
+  stderr?: LineSource | null;
+  exited: Promise<number>;
+}
+
+export interface ClaudeCliSpawnOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export type LineSource =
+  | ReadableStream<Uint8Array | string>
+  | AsyncIterable<Uint8Array | string>
+  | Iterable<Uint8Array | string>;
+
+export type ClaudeCliSpawn = (
+  command: string,
+  args: readonly string[],
+  options: ClaudeCliSpawnOptions,
+) => ClaudeCliSubprocess;
+
+export interface ClaudeCliDriverConfig {
+  command?: string;
+  args?: readonly string[];
+  spawn?: ClaudeCliSpawn;
+  env?: Record<string, string | undefined>;
+}
+
+export class ClaudeCliDriver extends SubprocessJsonlDriver {
+  readonly #spawn: ClaudeCliSpawn;
+  readonly #env: Record<string, string | undefined>;
+
+  constructor(config: ClaudeCliDriverConfig = {}) {
+    super({
+      providerId: CLAUDE_PROVIDER.id,
+      command: config.command ?? CLAUDE_PROVIDER.command ?? "claude",
+      args: config.args,
+    });
+    this.#spawn = config.spawn ?? spawnWithBun;
+    this.#env = config.env ?? process.env;
+  }
+
+  override async *run(
+    request: ExternalAgentRunRequest,
+  ): AsyncIterable<ExternalAgentEvent> {
+    const args = this.buildArgs(request);
+    const env = this.buildEnv(request);
+
+    yield {
+      type: "started",
+      providerId: this.providerId,
+      timestamp: Date.now(),
+    };
+
+    const child = this.#spawn(this.command, args, {
+      cwd: request.workingDirectory,
+      env,
+    });
+
+    const stderrLines: string[] = [];
+    const stderrPromise = child.stderr
+      ? collectLines(child.stderr, stderrLines)
+      : Promise.resolve();
+
+    for await (const line of readLines(child.stdout)) {
+      const event = this.parseClaudeLine(line);
+      if (event) {
+        yield event;
+      }
+    }
+
+    const exitCode = await child.exited;
+    await stderrPromise;
+
+    if (exitCode === 0) {
+      yield { type: "completed", exitCode, timestamp: Date.now() };
+      return;
+    }
+
+    yield {
+      type: "error",
+      message:
+        stderrLines.join("\n").trim() || `Claude CLI exited with code ${exitCode}`,
+      code: "CLAUDE_CLI_EXIT",
+      recoverable: true,
+      timestamp: Date.now(),
+    };
+    yield { type: "completed", exitCode, timestamp: Date.now() };
+  }
+
+  buildArgs(request: ExternalAgentRunRequest): readonly string[] {
+    return [
+      "-p",
+      buildPrompt(request),
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      ...mapClaudePermissionArgs(request.permissions),
+      ...this.args,
+    ];
+  }
+
+  buildEnv(request: ExternalAgentRunRequest): Record<string, string> {
+    const env: Record<string, string> = {};
+
+    copyIfPresent(this.#env, env, "PATH");
+    copyIfPresent(this.#env, env, "HOME");
+    copyIfPresent(this.#env, env, "USER");
+    copyIfPresent(this.#env, env, "SHELL");
+
+    // These provider-native config variables allow Claude Code to use its
+    // existing local OAuth/native login cache without the bridge storing secrets.
+    copyIfPresent(this.#env, env, "CLAUDE_CONFIG_DIR");
+    copyIfPresent(this.#env, env, "XDG_CONFIG_HOME");
+
+    if (request.credential?.kind === "env") {
+      for (const key of request.provider.envAllowlist ?? []) {
+        const value = request.credential.env?.[key];
+        if (typeof value === "string" && value.length > 0) {
+          env[key] = value;
+        }
+      }
+    }
+
+    return env;
+  }
+
+  parseClaudeLine(line: string): ExternalAgentEvent | undefined {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    const parsed = JSON.parse(trimmed) as ClaudeStreamEvent;
+    return normalizeClaudeEvent(parsed);
+  }
+}
+
+type ClaudeStreamEvent =
+  | ExternalAgentEvent
+  | {
+      type?: string;
+      subtype?: string;
+      message?: unknown;
+      result?: string;
+      text?: string;
+      content?: unknown;
+      name?: string;
+      input?: unknown;
+      tool_name?: string;
+      tool_input?: unknown;
+      error?: string | { message?: string; code?: string };
+      code?: string;
+      exitCode?: number;
+      signal?: string;
+      session_id?: string;
+      providerId?: string;
+    };
+
+export function mapClaudePermissionArgs(
+  permissions?: ExternalAgentPermissionPolicy,
+): string[] {
+  const policy = permissions ?? { mode: "ask" as const };
+  const flags = mapPermissionPolicyToFlags(policy);
+  const args: string[] = [];
+
+  if (flags.readOnly) {
+    args.push("--permission-mode", "plan");
+  } else if (flags.requireApproval) {
+    args.push("--permission-mode", "default");
+  } else if (flags.workspaceWrite) {
+    args.push("--permission-mode", "acceptEdits");
+  } else if (flags.fullAccess) {
+    args.push("--permission-mode", "bypassPermissions");
+  } else {
+    args.push("--permission-mode", "default");
+  }
+
+  for (const path of flags.paths ?? []) {
+    args.push("--add-dir", path);
+  }
+
+  return args;
+}
+
+function normalizeClaudeEvent(
+  event: ClaudeStreamEvent,
+): ExternalAgentEvent | undefined {
+  if (isNormalizedExternalEvent(event)) {
+    return event;
+  }
+
+  const type = event.type;
+  if (type === "system" || type === "rate_limit_event") {
+    // Claude Code stream-json emits lifecycle, hook, plugin, and rate-limit
+    // diagnostics as system events. The bridge already emits a normalized
+    // started/completed lifecycle, so suppress these diagnostics from chat text.
+    return undefined;
+  }
+
+  if (type === "assistant" || type === "user") {
+    const text = extractText(event.message ?? event.content ?? event.text);
+    return text ? { type: "output", content: text, timestamp: Date.now() } : undefined;
+  }
+
+  if (type === "result" || type === "completed" || type === "complete") {
+    const resultText = stringValue(event.result);
+    if (resultText) {
+      return { type: "output", content: resultText, timestamp: Date.now() };
+    }
+    return {
+      type: "completed",
+      exitCode: event.exitCode,
+      signal: event.signal,
+      timestamp: Date.now(),
+    };
+  }
+
+  const toolName = stringValue(event.name) ?? stringValue(event.tool_name);
+  if (toolName && (type === "tool_call" || type === "tool_use")) {
+    return {
+      type: "tool_call",
+      name: toolName,
+      input: event.input ?? event.tool_input,
+      timestamp: Date.now(),
+    };
+  }
+
+  if (type === "error") {
+    const message =
+      typeof event.error === "string"
+        ? event.error
+        : (event.error?.message ?? stringValue(event.message) ?? "Claude CLI error");
+    const code = typeof event.error === "object" ? event.error.code : event.code;
+    return { type: "error", message, code, recoverable: true, timestamp: Date.now() };
+  }
+
+  const fallbackText = extractText(event);
+  return fallbackText
+    ? { type: "output", content: fallbackText, timestamp: Date.now() }
+    : undefined;
+}
+
+function buildPrompt(request: ExternalAgentRunRequest): string {
+  const parts = [request.instruction, extractContextText(request.context)].filter(
+    (part): part is string => typeof part === "string" && part.length > 0,
+  );
+  return parts.join("\n\n");
+}
+
+function extractContextText(context: unknown): string | undefined {
+  const record = asRecord(context);
+  return (
+    extractText(record.userContent ?? record.user_content) ??
+    stringValue(record.input) ??
+    stringValue(record.prompt)
+  );
+}
+
+function extractText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  const record = asRecord(value);
+  const direct =
+    stringValue(record.text) ??
+    stringValue(record.content) ??
+    stringValue(record.result) ??
+    stringValue(record.message);
+  if (direct) {
+    return direct;
+  }
+
+  const arrayContent = Array.isArray(record.content)
+    ? record.content
+    : Array.isArray(record.parts)
+      ? record.parts
+      : undefined;
+  if (arrayContent) {
+    const parts = arrayContent
+      .map((part) => extractText(part))
+      .filter((part): part is string => typeof part === "string");
+    if (parts.length > 0) {
+      return parts.join("");
+    }
+  }
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((part) => extractText(part))
+      .filter((part): part is string => typeof part === "string");
+    if (parts.length > 0) {
+      return parts.join("");
+    }
+  }
+
+  return undefined;
+}
+
+function isNormalizedExternalEvent(
+  event: ClaudeStreamEvent,
+): event is ExternalAgentEvent {
+  switch (event.type) {
+    case "started":
+      return typeof event.providerId === "string";
+    case "output":
+      return typeof event.content === "string";
+    case "tool_call":
+      return typeof event.name === "string";
+    case "error":
+      return typeof event.message === "string";
+    case "completed":
+      return true;
+    default:
+      return false;
+  }
+}
+
+async function collectLines(
+  input: LineSource,
+  target: string[],
+): Promise<void> {
+  for await (const line of readLines(input)) {
+    if (line.trim().length > 0) {
+      target.push(line);
+    }
+  }
+}
+
+async function* readLines(input?: LineSource | null): AsyncIterable<string> {
+  if (!input) {
+    return;
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of toAsyncIterable(input)) {
+    buffer +=
+      typeof chunk === "string"
+        ? chunk
+        : decoder.decode(chunk, { stream: true });
+
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      yield buffer.slice(0, newlineIndex).replace(/\r$/, "");
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.length > 0) {
+    yield buffer.replace(/\r$/, "");
+  }
+}
+
+async function* toAsyncIterable<T>(
+  input: AsyncIterable<T> | Iterable<T> | ReadableStream<T>,
+): AsyncIterable<T> {
+  const asyncIterable = input as AsyncIterable<T>;
+  if (typeof asyncIterable[Symbol.asyncIterator] === "function") {
+    yield* asyncIterable;
+    return;
+  }
+
+  const iterable = input as Iterable<T>;
+  if (typeof iterable[Symbol.iterator] === "function") {
+    yield* iterable;
+    return;
+  }
+
+  const reader = (input as ReadableStream<T>).getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return;
+      }
+      yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function spawnWithBun(
+  command: string,
+  args: readonly string[],
+  options: ClaudeCliSpawnOptions,
+): ClaudeCliSubprocess {
+  const child = Bun.spawn([command, ...args], {
+    cwd: options.cwd,
+    env: options.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    stdout: child.stdout,
+    stderr: child.stderr,
+    exited: child.exited,
+  };
+}
+
+function copyIfPresent(
+  source: Record<string, string | undefined>,
+  target: Record<string, string>,
+  key: string,
+): void {
+  const value = source[key];
+  if (typeof value === "string" && value.length > 0) {
+    target[key] = value;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/agents/driver/claude-message-mapper.ts
+++ b/src/agents/driver/claude-message-mapper.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { Content, Part } from "@google/genai";
+
+/**
+ * Anthropic ContentBlockParam variant subset we emit. The full union from
+ * `@anthropic-ai/sdk/resources/messages` is much broader, but we only use a
+ * handful of block kinds when translating ADK history into Claude messages.
+ */
+export type ClaudeBase64ImageMediaType =
+  | "image/jpeg"
+  | "image/png"
+  | "image/gif"
+  | "image/webp";
+
+export type ClaudeBase64ImageSource = {
+  type: "base64";
+  media_type: ClaudeBase64ImageMediaType;
+  data: string;
+};
+
+export type ClaudeURLImageSource = {
+  type: "url";
+  url: string;
+};
+
+export type ClaudeBase64PDFSource = {
+  type: "base64";
+  media_type: "application/pdf";
+  data: string;
+};
+
+export type ClaudeURLDocumentSource = {
+  type: "url";
+  url: string;
+};
+
+export type ClaudeTextBlockParam = { type: "text"; text: string };
+export type ClaudeImageBlockParam = {
+  type: "image";
+  source: ClaudeBase64ImageSource | ClaudeURLImageSource;
+};
+export type ClaudeDocumentBlockParam = {
+  type: "document";
+  source: ClaudeBase64PDFSource | ClaudeURLDocumentSource;
+};
+export type ClaudeToolUseBlockParam = {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+export type ClaudeToolResultBlockParam = {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+};
+
+export type ClaudeContentBlockParam =
+  | ClaudeTextBlockParam
+  | ClaudeImageBlockParam
+  | ClaudeDocumentBlockParam
+  | ClaudeToolUseBlockParam
+  | ClaudeToolResultBlockParam;
+
+export type ClaudeMessageParam = {
+  role: "user" | "assistant";
+  content: ClaudeContentBlockParam[];
+};
+
+/**
+ * Minimal structural type matching `SDKUserMessage` from
+ * `@anthropic-ai/claude-agent-sdk`. We avoid importing the SDK type directly
+ * because the SDK is an optional dependency.
+ */
+export type SDKUserMessage = {
+  type: "user";
+  message: ClaudeMessageParam;
+  parent_tool_use_id: string | null;
+  isSynthetic?: boolean;
+  shouldQuery?: boolean;
+};
+
+const IMAGE_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+/**
+ * Translate ADK history (`Content[]`) into a sequence of Claude SDK user
+ * messages with native multimodal `ContentBlockParam` blocks. The final
+ * emitted message is marked `shouldQuery: true` so the SDK triggers an
+ * assistant turn; preceding messages are appended as synthetic transcript
+ * entries.
+ */
+export function contentsToSdkMessages(
+  contents: ReadonlyArray<Content>,
+): SDKUserMessage[] {
+  const messages: SDKUserMessage[] = [];
+
+  for (let i = 0; i < contents.length; i++) {
+    const content = contents[i];
+    let role: "user" | "assistant" = content.role === "model" ? "assistant" : "user";
+    const blocks: ClaudeContentBlockParam[] = [];
+
+    const parts = content.parts ?? [];
+    let hasFunctionCall = false;
+    let hasFunctionResponse = false;
+    for (const part of parts) {
+      if (part.functionCall) hasFunctionCall = true;
+      if (part.functionResponse) hasFunctionResponse = true;
+    }
+    if (hasFunctionResponse) {
+      role = "user";
+    } else if (hasFunctionCall) {
+      role = "assistant";
+    }
+
+    for (let p = 0; p < parts.length; p++) {
+      const block = mapPart(parts[p], i, p);
+      if (block) {
+        blocks.push(block);
+      }
+    }
+
+    if (blocks.length === 0) {
+      continue;
+    }
+
+    messages.push({
+      type: "user",
+      parent_tool_use_id: null,
+      message: { role, content: blocks },
+    });
+  }
+
+  if (messages.length === 0) {
+    return messages;
+  }
+
+  for (let i = 0; i < messages.length - 1; i++) {
+    messages[i].isSynthetic = true;
+    messages[i].shouldQuery = false;
+  }
+  messages[messages.length - 1].shouldQuery = true;
+
+  return messages;
+}
+
+function mapPart(
+  part: Part,
+  contentIndex: number,
+  partIndex: number,
+): ClaudeContentBlockParam | undefined {
+  if (part.thought) {
+    return undefined;
+  }
+  if (typeof part.text === "string" && part.text.length > 0) {
+    return { type: "text", text: part.text };
+  }
+  if (part.inlineData) {
+    const mime = part.inlineData.mimeType ?? "application/octet-stream";
+    const data = part.inlineData.data ?? "";
+    if (IMAGE_MEDIA_TYPES.has(mime)) {
+      return {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: mime as ClaudeBase64ImageMediaType,
+          data,
+        },
+      };
+    }
+    if (mime === "application/pdf") {
+      return {
+        type: "document",
+        source: { type: "base64", media_type: "application/pdf", data },
+      };
+    }
+    return { type: "text", text: `[document: ${mime}]` };
+  }
+  if (part.fileData) {
+    const uri = part.fileData.fileUri ?? "<unknown>";
+    const mime = part.fileData.mimeType ?? "application/octet-stream";
+    if (uri.startsWith("http://") || uri.startsWith("https://")) {
+      return { type: "document", source: { type: "url", url: uri } };
+    }
+    return { type: "text", text: `[file: ${uri} (${mime})]` };
+  }
+  if (part.functionCall) {
+    const id = part.functionCall.id ?? generatedId(contentIndex, partIndex);
+    return {
+      type: "tool_use",
+      id,
+      name: part.functionCall.name ?? "<unknown>",
+      input: (part.functionCall.args ?? {}) as Record<string, unknown>,
+    };
+  }
+  if (part.functionResponse) {
+    const id = part.functionResponse.id ?? generatedId(contentIndex, partIndex);
+    return {
+      type: "tool_result",
+      tool_use_id: id,
+      content: stringifyFunctionResponse(part.functionResponse.response),
+    };
+  }
+  if (part.executableCode) {
+    const lang = part.executableCode.language ?? "PLAINTEXT";
+    const code = part.executableCode.code ?? "";
+    return { type: "text", text: `[code (${lang}): ${code}]` };
+  }
+  if (part.codeExecutionResult) {
+    const outcome = part.codeExecutionResult.outcome ?? "OUTCOME_UNSPECIFIED";
+    const output = part.codeExecutionResult.output ?? "";
+    return { type: "text", text: `[exec ${outcome}: ${output}]` };
+  }
+  return undefined;
+}
+
+function generatedId(contentIndex: number, partIndex: number): string {
+  return `tool_${contentIndex}_${partIndex}`;
+}
+
+function stringifyFunctionResponse(value: unknown): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
+}

--- a/src/agents/driver/codex-cli.ts
+++ b/src/agents/driver/codex-cli.ts
@@ -1,0 +1,403 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { type ExternalAgentEvent, isExternalAgentEvent } from "../events.js";
+import type { ExternalAgentRunRequest } from "../external-agent-driver.js";
+import type { ExternalAgentPermissionPolicy } from "../permissions/schema.js";
+import { CODEX_PROVIDER } from "../provider/codex.js";
+import { SubprocessJsonlDriver } from "./subprocess-jsonl.js";
+
+declare const Bun: {
+  spawn(
+    command: string[],
+    options: {
+      cwd?: string;
+      env?: Record<string, string>;
+      stdout: "pipe";
+      stderr: "pipe";
+    },
+  ): {
+    stdout: ReadableStream<Uint8Array>;
+    stderr: ReadableStream<Uint8Array>;
+    exited: Promise<number>;
+  };
+};
+
+export interface CodexCliSpawnOptions {
+  cwd?: string;
+  env: Record<string, string>;
+}
+
+export interface CodexCliSubprocess {
+  stdout?: LineSource;
+  stderr?: LineSource;
+  exited: Promise<number>;
+}
+
+export type LineSource =
+  | ReadableStream<Uint8Array>
+  | AsyncIterable<Uint8Array | string>;
+
+export type CodexCliSpawn = (
+  command: string,
+  args: readonly string[],
+  options: CodexCliSpawnOptions,
+) => CodexCliSubprocess;
+
+export interface CodexCliDriverConfig {
+  command?: string;
+  args?: readonly string[];
+  spawn?: CodexCliSpawn;
+  env?: Record<string, string | undefined>;
+}
+
+export class CodexCliDriver extends SubprocessJsonlDriver {
+  readonly #spawn: CodexCliSpawn;
+  readonly #env: Record<string, string | undefined>;
+
+  constructor(config: CodexCliDriverConfig = {}) {
+    super({
+      providerId: CODEX_PROVIDER.id,
+      command: config.command ?? CODEX_PROVIDER.command ?? "codex",
+      args: config.args,
+    });
+    this.#spawn = config.spawn ?? spawnWithBun;
+    this.#env = config.env ?? process.env;
+  }
+
+  async *run(
+    request: ExternalAgentRunRequest,
+  ): AsyncIterable<ExternalAgentEvent> {
+    const args = this.buildArgs(request);
+    const child = this.#spawn(this.command, args, {
+      cwd: request.workingDirectory,
+      env: this.buildEnv(request),
+    });
+
+    yield {
+      type: "started",
+      providerId: this.providerId,
+      timestamp: Date.now(),
+    };
+
+    if (child.stdout) {
+      for await (const line of readLines(child.stdout)) {
+        if (line.trim().length === 0) {
+          continue;
+        }
+        yield this.parseLine(line);
+      }
+    }
+
+    if (child.stderr) {
+      for await (const line of readLines(child.stderr)) {
+        if (line.trim().length === 0 || isIgnorableCodexStderr(line)) {
+          continue;
+        }
+        yield { type: "error", message: line, recoverable: false };
+      }
+    }
+
+    const exitCode = await child.exited;
+    yield { type: "completed", exitCode, timestamp: Date.now() };
+  }
+
+  buildArgs(request: ExternalAgentRunRequest): readonly string[] {
+    const prompt = buildPrompt(request);
+    return [
+      ...mapPolicyToCodexArgs(request.permissions),
+      ...this.args,
+      prompt,
+    ];
+  }
+
+  buildEnv(request: ExternalAgentRunRequest): Record<string, string> {
+    const env: Record<string, string> = {};
+    copyIfPresent(this.#env, env, "PATH");
+    copyIfPresent(this.#env, env, "HOME");
+    copyIfPresent(this.#env, env, "USER");
+    copyIfPresent(this.#env, env, "SHELL");
+    copyIfPresent(this.#env, env, "XDG_CONFIG_HOME");
+
+    if (request.credential?.kind === "env") {
+      for (const key of request.provider.envAllowlist ?? []) {
+        const value = request.credential.env?.[key];
+        if (typeof value === "string" && value.length > 0) {
+          env[key] = value;
+        }
+      }
+    }
+
+    return env;
+  }
+
+  override parseLine(line: string): ExternalAgentEvent {
+    const parsed = JSON.parse(line) as unknown;
+    if (isExternalAgentEvent(parsed)) {
+      return parsed;
+    }
+    return normalizeCodexEvent(parsed);
+  }
+}
+
+export function mapPolicyToCodexArgs(
+  policy: ExternalAgentPermissionPolicy = { mode: "read-only" },
+): readonly string[] {
+  switch (policy.mode) {
+    case "read-only":
+      return [
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--json",
+        "--sandbox",
+        "read-only",
+      ];
+    case "ask":
+      return [
+        "--ask-for-approval",
+        "on-request",
+        "exec",
+        "--json",
+        "--sandbox",
+        "workspace-write",
+      ];
+    case "workspace-write":
+      return [
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--json",
+        "--sandbox",
+        "workspace-write",
+      ];
+    case "full-access":
+      return ["--dangerously-bypass-approvals-and-sandbox", "exec", "--json"];
+  }
+}
+
+function normalizeCodexEvent(value: unknown): ExternalAgentEvent {
+  const record = asRecord(value);
+  const type =
+    stringValue(record.type) ?? stringValue(record.event) ?? "unknown";
+  const timestamp = numberValue(record.timestamp);
+
+  if (type.includes("error")) {
+    return {
+      type: "error",
+      message:
+        stringValue(record.message) ??
+        stringValue(record.error) ??
+        JSON.stringify(value),
+      code: stringValue(record.code),
+      recoverable: false,
+      timestamp,
+    };
+  }
+
+  const item = asRecord(record.item);
+  const itemType = stringValue(item.type);
+  if (itemType === "agent_message") {
+    return {
+      type: "output",
+      content: extractText(item) ?? JSON.stringify(item),
+      stream: "stdout",
+      timestamp,
+    };
+  }
+
+  const toolName = extractToolName(record);
+  if (toolName) {
+    return {
+      type: "tool_call",
+      name: toolName,
+      input: record.input ?? record.arguments,
+      timestamp,
+    };
+  }
+
+  if (type.includes("started") || type.includes("created")) {
+    return {
+      type: "started",
+      providerId: CODEX_PROVIDER.id,
+      runId: stringValue(record.run_id) ?? stringValue(record.id),
+      timestamp,
+    };
+  }
+
+  if (type.includes("completed") || type.includes("done")) {
+    return {
+      type: "completed",
+      exitCode: numberValue(record.exit_code),
+      timestamp,
+    };
+  }
+
+  return {
+    type: "output",
+    content: extractText(value) ?? JSON.stringify(value),
+    stream: "stdout",
+    timestamp,
+  };
+}
+
+function extractToolName(record: Record<string, unknown>): string | undefined {
+  const directName = stringValue(record.name) ?? stringValue(record.tool_name);
+  const type = stringValue(record.type) ?? "";
+  if (directName && (type.includes("tool") || type.includes("call"))) {
+    return directName;
+  }
+
+  const item = asRecord(record.item);
+  const itemType = stringValue(item.type) ?? "";
+  if (itemType.includes("tool") || itemType.includes("call")) {
+    return stringValue(item.name) ?? stringValue(item.tool_name);
+  }
+
+  return undefined;
+}
+
+function extractText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  const record = asRecord(value);
+  const direct =
+    stringValue(record.content) ??
+    stringValue(record.text) ??
+    stringValue(record.delta) ??
+    stringValue(record.message);
+  if (direct) {
+    return direct;
+  }
+
+  if (record.item !== undefined) {
+    const itemText = extractText(record.item);
+    if (itemText) {
+      return itemText;
+    }
+  }
+
+  if (Array.isArray(record.content)) {
+    const parts = record.content
+      .map((part) => extractText(part))
+      .filter((part): part is string => typeof part === "string");
+    if (parts.length > 0) {
+      return parts.join("");
+    }
+  }
+
+  return undefined;
+}
+
+function buildPrompt(request: ExternalAgentRunRequest): string {
+  const parts = [
+    request.instruction,
+    extractContextText(request.context),
+  ].filter(
+    (part): part is string => typeof part === "string" && part.length > 0,
+  );
+  return parts.join("\n\n");
+}
+
+function extractContextText(context: unknown): string | undefined {
+  const record = asRecord(context);
+  const userContent = record.userContent ?? record.user_content;
+  const text = extractText(userContent);
+  if (text) {
+    return text;
+  }
+  return stringValue(record.input) ?? stringValue(record.prompt);
+}
+
+async function* readLines(source: LineSource): AsyncIterable<string> {
+  let buffer = "";
+  for await (const chunk of toAsyncIterable(source)) {
+    buffer +=
+      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      yield buffer.slice(0, newlineIndex).replace(/\r$/, "");
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+    }
+  }
+  if (buffer.length > 0) {
+    yield buffer.replace(/\r$/, "");
+  }
+}
+
+async function* toAsyncIterable(
+  source: LineSource,
+): AsyncIterable<Uint8Array | string> {
+  const maybeReadableStream = source as Partial<ReadableStream<Uint8Array>>;
+  if (typeof maybeReadableStream.getReader === "function") {
+    const reader = maybeReadableStream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return;
+      }
+      yield value;
+    }
+  }
+
+  const maybeAsyncIterable = source as Partial<
+    AsyncIterable<Uint8Array | string>
+  >;
+  if (typeof maybeAsyncIterable[Symbol.asyncIterator] === "function") {
+    yield* source as AsyncIterable<Uint8Array | string>;
+  }
+}
+
+function isIgnorableCodexStderr(line: string): boolean {
+  return line.trim() === "Reading additional input from stdin...";
+}
+
+function spawnWithBun(
+  command: string,
+  args: readonly string[],
+  options: CodexCliSpawnOptions,
+): CodexCliSubprocess {
+  const child = Bun.spawn([command, ...args], {
+    cwd: options.cwd,
+    env: options.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    stdout: child.stdout,
+    stderr: child.stderr,
+    exited: child.exited,
+  };
+}
+
+function copyIfPresent(
+  source: Record<string, string | undefined>,
+  target: Record<string, string>,
+  key: string,
+): void {
+  const value = source[key];
+  if (typeof value === "string" && value.length > 0) {
+    target[key] = value;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}

--- a/src/agents/driver/codex-input-mapper.ts
+++ b/src/agents/driver/codex-input-mapper.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { promises as fs, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Content, Part } from "@google/genai";
+import { flattenContentsToPrompt } from "../runtime/content-collector.js";
+
+export type CodexInputPart =
+  | { type: "text"; text: string }
+  | { type: "local_image"; path: string };
+
+export interface CodexInputMapping {
+  input: string | CodexInputPart[];
+  cleanup: () => Promise<void>;
+}
+
+export interface CodexInputMapperOptions {
+  tmpDir?: string;
+  idPrefix?: string;
+}
+
+const noopCleanup: () => Promise<void> = async () => {};
+
+/**
+ * Convert an ADK Content (the current user turn) into Codex SDK input.
+ *
+ * Codex accepts either a string or an array of text / local_image parts.
+ * Non-text/image parts (file URIs, tool calls/responses, code) are flattened
+ * into short text markers that mirror Phase-1's transcript style.
+ */
+export function userContentToCodexInput(
+  content: Content,
+  opts: CodexInputMapperOptions = {},
+): CodexInputMapping {
+  const parts = content.parts ?? [];
+  const tmpDir = opts.tmpDir ?? tmpdir();
+  const idPrefix = opts.idPrefix ?? "turn";
+
+  // Fast path: a single text part becomes a string (Codex's preferred shape).
+  if (parts.length === 1) {
+    const only = parts[0];
+    if (typeof only.text === "string" && isPlainText(only)) {
+      return { input: only.text, cleanup: noopCleanup };
+    }
+  }
+
+  const tmpFiles: string[] = [];
+  const result: CodexInputPart[] = [];
+
+  parts.forEach((part, index) => {
+    if (part.thought) {
+      return;
+    }
+    if (typeof part.text === "string" && part.text.length > 0) {
+      result.push({ type: "text", text: part.text });
+      return;
+    }
+    if (part.inlineData) {
+      const mime = part.inlineData.mimeType ?? "application/octet-stream";
+      if (mime.startsWith("image/") && typeof part.inlineData.data === "string") {
+        const ext = extensionForMime(mime);
+        const path = join(tmpDir, `codex-${idPrefix}-${index}.${ext}`);
+        try {
+          const bytes = Buffer.from(part.inlineData.data, "base64");
+          // Synchronous write keeps the API non-async; the file count is small.
+          writeFileSync(path, bytes);
+          tmpFiles.push(path);
+          result.push({ type: "local_image", path });
+        } catch {
+          result.push({ type: "text", text: `[image: ${mime} (write failed)]` });
+        }
+        return;
+      }
+      result.push({ type: "text", text: markerForInlineData(mime) });
+      return;
+    }
+    if (part.fileData) {
+      const mime = part.fileData.mimeType ?? "application/octet-stream";
+      const uri = part.fileData.fileUri ?? "<unknown>";
+      result.push({ type: "text", text: `[file: ${uri} (${mime})]` });
+      return;
+    }
+    if (part.functionCall) {
+      const name = part.functionCall.name ?? "<unknown>";
+      const args = part.functionCall.args ?? {};
+      result.push({
+        type: "text",
+        text: `[tool_call ${name}(${safeJsonStringify(args)})]`,
+      });
+      return;
+    }
+    if (part.functionResponse) {
+      const name = part.functionResponse.name ?? "<unknown>";
+      const response = part.functionResponse.response ?? {};
+      result.push({
+        type: "text",
+        text: `[tool_result ${name}: ${safeJsonStringify(response)}]`,
+      });
+      return;
+    }
+    if (part.executableCode) {
+      const lang = part.executableCode.language ?? "PLAINTEXT";
+      const code = part.executableCode.code ?? "";
+      result.push({ type: "text", text: `[code (${lang}): ${code}]` });
+      return;
+    }
+    if (part.codeExecutionResult) {
+      const outcome = part.codeExecutionResult.outcome ?? "OUTCOME_UNSPECIFIED";
+      const output = part.codeExecutionResult.output ?? "";
+      result.push({ type: "text", text: `[exec ${outcome}: ${output}]` });
+      return;
+    }
+    result.push({ type: "text", text: "[unsupported-part]" });
+  });
+
+  // If everything filtered out (e.g. only thoughts), keep an empty text block
+  // so Codex still gets a valid input.
+  if (result.length === 0) {
+    return { input: "", cleanup: noopCleanup };
+  }
+
+  // Collapse single-text result back to string form.
+  if (result.length === 1 && result[0].type === "text") {
+    return { input: result[0].text, cleanup: noopCleanup };
+  }
+
+  const cleanup = async (): Promise<void> => {
+    await Promise.all(
+      tmpFiles.map(async (path) => {
+        try {
+          await fs.unlink(path);
+        } catch {
+          // best-effort: swallow ENOENT and other transient errors.
+        }
+      }),
+    );
+  };
+
+  return { input: result, cleanup };
+}
+
+/**
+ * Render every content except the last (the current user turn) into a textual
+ * transcript suitable for prepending to a fresh Codex thread when no saved
+ * thread id exists. Returns "" when there is no prior history.
+ */
+export function summarizeHistoryForColdStart(
+  contents: ReadonlyArray<Content>,
+): string {
+  if (contents.length <= 1) {
+    return "";
+  }
+  return flattenContentsToPrompt(contents.slice(0, -1));
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function isPlainText(part: Part): boolean {
+  return !(
+    part.inlineData ||
+    part.fileData ||
+    part.functionCall ||
+    part.functionResponse ||
+    part.executableCode ||
+    part.codeExecutionResult ||
+    part.thought
+  );
+}
+
+function extensionForMime(mime: string): string {
+  const lower = mime.toLowerCase();
+  if (lower === "image/png") return "png";
+  if (lower === "image/jpeg" || lower === "image/jpg") return "jpg";
+  if (lower === "image/gif") return "gif";
+  if (lower === "image/webp") return "webp";
+  if (lower === "image/bmp") return "bmp";
+  if (lower === "image/svg+xml") return "svg";
+  const slash = lower.indexOf("/");
+  if (slash >= 0 && slash < lower.length - 1) {
+    return lower.slice(slash + 1).replace(/[^a-z0-9]+/g, "") || "bin";
+  }
+  return "bin";
+}
+
+function markerForInlineData(mime: string): string {
+  if (mime.startsWith("image/")) return `[image: ${mime}]`;
+  if (mime.startsWith("audio/")) return `[audio: ${mime}]`;
+  if (mime.startsWith("video/")) return `[video: ${mime}]`;
+  return `[document: ${mime}]`;
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "{}";
+  } catch {
+    return "{}";
+  }
+}

--- a/src/agents/driver/codex-sdk.ts
+++ b/src/agents/driver/codex-sdk.ts
@@ -1,0 +1,854 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { existsSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Content } from "@google/genai";
+import type { ExternalAgentEvent } from "../events.js";
+import type { ExternalAgentRunRequest } from "../external-agent-driver.js";
+import type { ExternalAgentPermissionPolicy } from "../permissions/schema.js";
+import { CODEX_PROVIDER } from "../provider/codex.js";
+import { collectContents } from "../runtime/content-collector.js";
+import {
+  type CodexInputPart,
+  summarizeHistoryForColdStart,
+  userContentToCodexInput,
+} from "./codex-input-mapper.js";
+
+type CodexSdkApprovalMode = "never" | "on-request" | "on-failure" | "untrusted";
+type CodexSdkSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+type CodexSdkModelReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+type CodexSdkWebSearchMode = "disabled" | "cached" | "live";
+type CodexSdkConfigValue =
+  | string
+  | number
+  | boolean
+  | CodexSdkConfigValue[]
+  | CodexSdkConfigObject;
+type CodexSdkConfigObject = { [key: string]: CodexSdkConfigValue };
+
+type CodexSdkOptions = {
+  codexPathOverride?: string;
+  baseUrl?: string;
+  apiKey?: string;
+  config?: CodexSdkConfigObject;
+  env?: Record<string, string>;
+};
+
+type CodexSdkThreadOptions = {
+  model?: string;
+  sandboxMode?: CodexSdkSandboxMode;
+  workingDirectory?: string;
+  skipGitRepoCheck?: boolean;
+  modelReasoningEffort?: CodexSdkModelReasoningEffort;
+  networkAccessEnabled?: boolean;
+  webSearchMode?: CodexSdkWebSearchMode;
+  webSearchEnabled?: boolean;
+  approvalPolicy?: CodexSdkApprovalMode;
+  additionalDirectories?: string[];
+};
+
+type CodexSdkTurnOptions = {
+  signal?: AbortSignal;
+  outputSchema?: Record<string, unknown>;
+};
+
+type CodexSdkThreadEvent = Record<string, unknown>;
+
+type CodexSdkInput = string | CodexInputPart[];
+
+type CodexSdkThreadLike = {
+  readonly id?: string | null;
+  runStreamed(
+    input: CodexSdkInput,
+    options?: CodexSdkTurnOptions,
+  ): Promise<{ events: AsyncGenerator<CodexSdkThreadEvent> }>;
+};
+
+type CodexSdkClientLike = {
+  startThread(options?: CodexSdkThreadOptions): CodexSdkThreadLike;
+  resumeThread(id: string, options?: CodexSdkThreadOptions): CodexSdkThreadLike;
+};
+
+type CodexSdkConstructor = new (options?: CodexSdkOptions) => CodexSdkClientLike;
+
+type CodexSdkModuleLike = {
+  Codex: CodexSdkConstructor;
+};
+
+export interface CodexBinaryResolution {
+  path?: string;
+  checked: string[];
+}
+
+export interface CodexSdkDriverConfig {
+  sdk?: CodexSdkClientLike;
+  Codex?: CodexSdkConstructor;
+  importSdk?: () => Promise<CodexSdkModuleLike>;
+  codexPathOverride?: string;
+  env?: Record<string, string | undefined>;
+  baseUrl?: string;
+  apiKey?: string;
+  config?: CodexSdkConfigObject;
+  model?: string;
+  modelReasoningEffort?: CodexSdkModelReasoningEffort;
+  skipGitRepoCheck?: boolean;
+  webSearchMode?: CodexSdkWebSearchMode;
+  webSearchEnabled?: boolean;
+  outputSchema?: Record<string, unknown>;
+  /**
+   * Computes the `session.state` key used to persist Codex thread IDs so a
+   * subsequent invocation can call `resumeThread(savedId)` instead of starting
+   * a fresh thread. Defaults to `"codex_thread:" + agentName`.
+   */
+  threadStateKey?: (agentName: string) => string;
+}
+
+export class CodexSdkDriver {
+  readonly providerId = CODEX_PROVIDER.id;
+  readonly #sdk?: CodexSdkClientLike;
+  readonly #Codex?: CodexSdkConstructor;
+  readonly #importSdk: () => Promise<CodexSdkModuleLike>;
+  readonly #codexPathOverride?: string;
+  readonly #env: Record<string, string | undefined>;
+  readonly #baseUrl?: string;
+  readonly #apiKey?: string;
+  readonly #config?: CodexSdkConfigObject;
+  readonly #model?: string;
+  readonly #modelReasoningEffort?: CodexSdkModelReasoningEffort;
+  readonly #skipGitRepoCheck?: boolean;
+  readonly #webSearchMode?: CodexSdkWebSearchMode;
+  readonly #webSearchEnabled?: boolean;
+  readonly #outputSchema?: Record<string, unknown>;
+  readonly #threadStateKey: (agentName: string) => string;
+
+  constructor(config: CodexSdkDriverConfig = {}) {
+    this.#sdk = config.sdk;
+    this.#Codex = config.Codex;
+    this.#importSdk = config.importSdk ?? importCodexSdk;
+    this.#codexPathOverride = config.codexPathOverride;
+    this.#env = config.env ?? process.env;
+    this.#baseUrl = config.baseUrl;
+    this.#apiKey = config.apiKey;
+    this.#config = config.config;
+    this.#model = config.model;
+    this.#modelReasoningEffort = config.modelReasoningEffort;
+    this.#skipGitRepoCheck = config.skipGitRepoCheck;
+    this.#webSearchMode = config.webSearchMode;
+    this.#webSearchEnabled = config.webSearchEnabled;
+    this.#outputSchema = config.outputSchema;
+    this.#threadStateKey =
+      config.threadStateKey ?? ((agentName) => `codex_thread:${agentName}`);
+  }
+
+  capabilities() {
+    return {
+      streaming: true,
+      sessions: true,
+      permissions: true,
+      tools: true,
+      mcpServers: true,
+    };
+  }
+
+  async *run(request: ExternalAgentRunRequest): AsyncIterable<ExternalAgentEvent> {
+    yield {
+      type: "started",
+      providerId: this.providerId,
+      timestamp: Date.now(),
+    };
+
+    let completed = false;
+    let failed = false;
+    const pendingEvents: ExternalAgentEvent[] = [];
+    let cleanup: () => Promise<void> = async () => {};
+    try {
+      const sdk = await this.loadSdk(request);
+      const threadOptions = this.buildThreadOptions(request);
+      const agentName = request.agent?.name ?? request.context?.agent?.name;
+      const stateKey = agentName ? this.#threadStateKey(agentName) : undefined;
+      const savedThreadId = readSavedThreadId(request, stateKey);
+      const contents = safeCollectContents(request);
+      const lastContent = contents[contents.length - 1];
+
+      let thread: CodexSdkThreadLike;
+      let input: CodexSdkInput;
+
+      if (savedThreadId) {
+        thread = sdk.resumeThread(savedThreadId, threadOptions);
+        const mapping = mapLastContentOrFallback(lastContent, request);
+        cleanup = mapping.cleanup;
+        input = applyInstruction(request.instruction, mapping.input);
+      } else if (contents.length > 1 && lastContent) {
+        thread = sdk.startThread(threadOptions);
+        const mapping = userContentToCodexInput(lastContent);
+        cleanup = mapping.cleanup;
+        const transcript = summarizeHistoryForColdStart(contents);
+        input = applyInstruction(
+          request.instruction,
+          prependColdStartTranscript(mapping.input, transcript),
+        );
+      } else {
+        thread = sdk.startThread(threadOptions);
+        const mapping = mapLastContentOrFallback(lastContent, request);
+        cleanup = mapping.cleanup;
+        input = applyInstruction(request.instruction, mapping.input);
+      }
+
+      const { events } = await thread.runStreamed(input, {
+        signal: request.context?.abortSignal,
+        outputSchema: this.#outputSchema,
+      });
+      for await (const event of events) {
+        for (const normalized of this.normalizeEvent(event)) {
+          if (normalized.type === "completed") {
+            pendingEvents.push(normalized);
+            continue;
+          }
+          yield normalized;
+        }
+      }
+
+      const newThreadId = thread.id ?? undefined;
+      if (stateKey && newThreadId && newThreadId !== savedThreadId) {
+        yield {
+          type: "state_delta",
+          stateDelta: { [stateKey]: newThreadId },
+          timestamp: Date.now(),
+        };
+      }
+
+      for (const event of pendingEvents) {
+        if (event.type === "completed") {
+          completed = true;
+        }
+        yield event;
+      }
+    } catch (error) {
+      failed = true;
+      yield {
+        type: "error",
+        message: this.describeError(error, request),
+        code: "CODEX_SDK_ERROR",
+        recoverable: true,
+        timestamp: Date.now(),
+      };
+    } finally {
+      try {
+        await cleanup();
+      } catch {
+        // best-effort cleanup; never let tmp deletion mask the real error.
+      }
+    }
+
+    if (!completed) {
+      yield { type: "completed", exitCode: failed ? 1 : 0, timestamp: Date.now() };
+    }
+  }
+
+  buildClientOptions(request: ExternalAgentRunRequest): CodexSdkOptions {
+    return removeUndefined({
+      codexPathOverride: this.resolveCodexBinary(request).path,
+      baseUrl: this.#baseUrl,
+      apiKey: this.#apiKey ?? readCredentialEnv(request, "CODEX_API_KEY"),
+      config: this.#config,
+      env: this.buildEnv(request),
+    }) as CodexSdkOptions;
+  }
+
+  buildThreadOptions(request: ExternalAgentRunRequest): CodexSdkThreadOptions {
+    return removeUndefined({
+      ...mapPolicyToCodexSdkThreadOptions(request.permissions),
+      model: this.#model,
+      workingDirectory: request.workingDirectory,
+      skipGitRepoCheck: this.#skipGitRepoCheck,
+      modelReasoningEffort: this.#modelReasoningEffort,
+      webSearchMode: this.#webSearchMode,
+      webSearchEnabled: this.#webSearchEnabled,
+    }) as CodexSdkThreadOptions;
+  }
+
+  resolveCodexBinary(request: ExternalAgentRunRequest): CodexBinaryResolution {
+    const checked: string[] = [];
+    const explicit = firstNonEmpty(
+      this.#codexPathOverride,
+      this.#env.CODEX_EXECUTABLE,
+      this.#env.CODEX_CLI_PATH,
+      readCredentialEnv(request, "CODEX_EXECUTABLE"),
+      readCredentialEnv(request, "CODEX_CLI_PATH"),
+    );
+    if (explicit) {
+      checked.push(explicit);
+      return { path: explicit, checked };
+    }
+
+    for (const candidate of codexBinaryCandidates({
+      env: this.#env,
+      workingDirectory: request.workingDirectory,
+    })) {
+      checked.push(candidate);
+      if (existsSync(candidate)) {
+        return { path: candidate, checked };
+      }
+    }
+
+    return { checked };
+  }
+
+  buildEnv(request: ExternalAgentRunRequest): Record<string, string> {
+    const env: Record<string, string> = {};
+    copyIfPresent(this.#env, env, "PATH");
+    copyIfPresent(this.#env, env, "HOME");
+    copyIfPresent(this.#env, env, "USER");
+    copyIfPresent(this.#env, env, "SHELL");
+    copyIfPresent(this.#env, env, "XDG_CONFIG_HOME");
+
+    if (request.credential?.kind === "env") {
+      for (const key of request.provider.envAllowlist ?? []) {
+        const value = request.credential.env?.[key];
+        if (typeof value === "string" && value.length > 0) {
+          env[key] = value;
+        }
+      }
+    }
+
+    return env;
+  }
+
+  normalizeEvent(event: CodexSdkThreadEvent): ExternalAgentEvent[] {
+    const type = stringValue(event.type);
+    const timestamp = Date.now();
+
+    if (type === "turn.completed") {
+      return [{ type: "completed", exitCode: 0, timestamp }];
+    }
+
+    if (type === "turn.failed") {
+      const error = asRecord(event.error);
+      return [
+        {
+          type: "error",
+          message: stringValue(error.message) ?? "Codex turn failed",
+          code: "CODEX_TURN_FAILED",
+          recoverable: true,
+          timestamp,
+        },
+        { type: "completed", exitCode: 1, timestamp },
+      ];
+    }
+
+    if (type === "error") {
+      return [
+        {
+          type: "error",
+          message: stringValue(event.message) ?? "Codex SDK error",
+          code: "CODEX_SDK_STREAM_ERROR",
+          recoverable: true,
+          timestamp,
+        },
+      ];
+    }
+
+    if (type === "item.started" || type === "item.updated") {
+      return normalizeProgressItem(asRecord(event.item), timestamp);
+    }
+
+    if (type !== "item.completed") {
+      return [];
+    }
+
+    return normalizeCompletedItem(asRecord(event.item), timestamp);
+  }
+
+  private async loadSdk(request: ExternalAgentRunRequest): Promise<CodexSdkClientLike> {
+    if (this.#sdk) {
+      return this.#sdk;
+    }
+
+    const Codex = this.#Codex ?? (await this.loadConstructor());
+    return new Codex(this.buildClientOptions(request));
+  }
+
+  private async loadConstructor(): Promise<CodexSdkConstructor> {
+    try {
+      return (await this.#importSdk()).Codex;
+    } catch (error) {
+      throw new Error(
+        "CodexAgent requires @openai/codex-sdk. Install it or pass driver: new CodexCliDriver(...).",
+        { cause: error },
+      );
+    }
+  }
+
+  private describeError(error: unknown, request: ExternalAgentRunRequest): string {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Unable to locate Codex CLI binaries")) {
+      return message;
+    }
+
+    const resolution = this.resolveCodexBinary(request);
+    const checked = resolution.checked.length > 0
+      ? resolution.checked.map((item) => `  - ${item}`).join("\n")
+      : "  - <no candidates>";
+    return [
+      "Codex SDK could not locate a Codex binary.",
+      "Set CODEX_EXECUTABLE=/absolute/path/to/codex or CODEX_CLI_PATH=/absolute/path/to/codex, or reinstall @openai/codex with optional dependencies.",
+      `Original error: ${message}`,
+      "Checked paths:",
+      checked,
+    ].join("\n");
+  }
+}
+
+export function mapPolicyToCodexSdkThreadOptions(
+  permissions?: ExternalAgentPermissionPolicy,
+): CodexSdkThreadOptions {
+  const policy = permissions ?? { mode: "read-only" as const };
+  const base = {
+    networkAccessEnabled: policy.allowNetwork,
+    additionalDirectories: policy.allowedPaths ? [...policy.allowedPaths] : undefined,
+  };
+
+  switch (policy.mode) {
+    case "read-only":
+      return removeUndefined({
+        ...base,
+        sandboxMode: "read-only",
+        approvalPolicy: "never",
+      }) as CodexSdkThreadOptions;
+    case "ask":
+      return removeUndefined({
+        ...base,
+        sandboxMode: "workspace-write",
+        approvalPolicy: "on-request",
+      }) as CodexSdkThreadOptions;
+    case "workspace-write":
+      return removeUndefined({
+        ...base,
+        sandboxMode: "workspace-write",
+        approvalPolicy: "never",
+      }) as CodexSdkThreadOptions;
+    case "full-access":
+      return removeUndefined({
+        ...base,
+        sandboxMode: "danger-full-access",
+        approvalPolicy: "never",
+      }) as CodexSdkThreadOptions;
+  }
+}
+
+async function importCodexSdk(): Promise<CodexSdkModuleLike> {
+  return import("@openai/codex-sdk") as Promise<CodexSdkModuleLike>;
+}
+
+function normalizeProgressItem(
+  item: Record<string, unknown>,
+  timestamp: number,
+): ExternalAgentEvent[] {
+  const itemType = stringValue(item.type);
+
+  if (itemType === "command_execution") {
+    const command = stringValue(item.command);
+    const status = stringValue(item.status);
+    return command
+      ? [
+          {
+            type: "output",
+            content: `Codex command ${status ?? "running"}: ${command}`,
+            partial: true,
+            turnComplete: false,
+            metadata: {
+              itemType,
+              status,
+              command,
+              exitCode: item.exit_code,
+              title: `Codex: command_execution ${status ?? "running"}`,
+            },
+            timestamp,
+          },
+        ]
+      : [];
+  }
+
+  if (itemType === "mcp_tool_call") {
+    const toolName = stringValue(item.tool) ?? "mcp_tool_call";
+    const status = stringValue(item.status) ?? "running";
+    return [
+      {
+        type: "output",
+        content: `Codex MCP tool ${status}: ${toolName}`,
+        partial: true,
+        turnComplete: false,
+        metadata: {
+          itemType,
+          toolName,
+          status: item.status,
+          title: `Codex: ${toolName} ${status}`,
+        },
+        timestamp,
+      },
+    ];
+  }
+
+  if (itemType === "web_search") {
+    const query = stringValue(item.query);
+    return query
+      ? [
+          {
+            type: "output",
+            content: `Codex web search: ${query}`,
+            partial: true,
+            turnComplete: false,
+            metadata: { itemType, query, title: "Codex: web_search" },
+            timestamp,
+          },
+        ]
+      : [];
+  }
+
+  return [];
+}
+
+function normalizeCompletedItem(
+  item: Record<string, unknown>,
+  timestamp: number,
+): ExternalAgentEvent[] {
+  const itemType = stringValue(item.type);
+
+  if (itemType === "agent_message") {
+    const text = stringValue(item.text);
+    return text ? [{ type: "output", content: text, stream: "stdout", timestamp }] : [];
+  }
+
+  if (itemType === "error") {
+    return [
+      {
+        type: "error",
+        message: stringValue(item.message) ?? "Codex item error",
+        code: "CODEX_ITEM_ERROR",
+        recoverable: true,
+        timestamp,
+      },
+    ];
+  }
+
+  if (itemType === "mcp_tool_call") {
+    const toolName = stringValue(item.tool) ?? "mcp_tool_call";
+    const status = stringValue(item.status) ?? "completed";
+    return [
+      {
+        type: "tool_call",
+        name: toolName,
+        input: {
+          server: item.server,
+          arguments: item.arguments,
+          status: item.status,
+        },
+        callId: stringValue(item.id),
+        metadata: {
+          itemType,
+          status: item.status,
+          title: `Codex: ${toolName} call`,
+        },
+        timestamp,
+      },
+      {
+        type: "tool_result",
+        name: toolName,
+        result: {
+          server: item.server,
+          status: item.status,
+          result: item.result,
+          error: item.error,
+        },
+        callId: stringValue(item.id),
+        error: stringValue(item.error),
+        metadata: {
+          itemType,
+          status: item.status,
+          title: `Codex: ${toolName} ${status}`,
+        },
+        timestamp,
+      },
+    ];
+  }
+
+  if (itemType === "command_execution") {
+    const command = stringValue(item.command);
+    const status = stringValue(item.status) ?? "completed";
+    return [
+      {
+        type: "tool_call",
+        name: "command_execution",
+        input: {
+          command: item.command,
+          status: item.status,
+          exitCode: item.exit_code,
+        },
+        callId: stringValue(item.id),
+        metadata: {
+          itemType,
+          status: item.status,
+          command,
+          title: "Codex: command_execution call",
+        },
+        timestamp,
+      },
+      {
+        type: "tool_result",
+        name: "command_execution",
+        result: {
+          command: item.command,
+          status: item.status,
+          exitCode: item.exit_code,
+        },
+        callId: stringValue(item.id),
+        metadata: {
+          itemType,
+          status: item.status,
+          command,
+          exitCode: item.exit_code,
+          title: `Codex: command_execution ${status}`,
+        },
+        timestamp,
+      },
+    ];
+  }
+
+  return [];
+}
+
+function safeCollectContents(request: ExternalAgentRunRequest): Content[] {
+  try {
+    return collectContents(request.context);
+  } catch {
+    return [];
+  }
+}
+
+function mapLastContentOrFallback(
+  lastContent: Content | undefined,
+  request: ExternalAgentRunRequest,
+): { input: CodexSdkInput; cleanup: () => Promise<void> } {
+  if (lastContent) {
+    return userContentToCodexInput(lastContent);
+  }
+  // No content collected — fall back to the legacy text extractor so synthetic
+  // contexts (e.g. unit tests with just `userContent: {...}`) keep working.
+  const text = extractContextText(request.context) ?? "";
+  return { input: text, cleanup: async () => {} };
+}
+
+function applyInstruction(
+  instruction: string | undefined,
+  input: CodexSdkInput,
+): CodexSdkInput {
+  if (!instruction || instruction.length === 0) {
+    return input;
+  }
+  if (typeof input === "string") {
+    return input.length > 0 ? `${instruction}\n\n${input}` : instruction;
+  }
+  return [{ type: "text", text: instruction }, ...input];
+}
+
+function prependColdStartTranscript(
+  input: CodexSdkInput,
+  transcript: string,
+): CodexSdkInput {
+  if (!transcript || transcript.length === 0) {
+    return input;
+  }
+  if (typeof input === "string") {
+    return input.length > 0 ? `${transcript}\n\n${input}` : transcript;
+  }
+  // Array input. If the first part is text, fold the transcript into it;
+  // otherwise (e.g. starts with an image), insert a synthetic text part.
+  const first = input[0];
+  if (first && first.type === "text") {
+    return [
+      { type: "text", text: `${transcript}\n\n${first.text}` },
+      ...input.slice(1),
+    ];
+  }
+  return [{ type: "text", text: transcript }, ...input];
+}
+
+function readSavedThreadId(
+  request: ExternalAgentRunRequest,
+  stateKey: string | undefined,
+): string | undefined {
+  if (!stateKey) return undefined;
+  const session = (request.context as { session?: { state?: unknown } } | undefined)
+    ?.session;
+  const state = session?.state;
+  if (!state || typeof state !== "object") {
+    return undefined;
+  }
+  const value = (state as Record<string, unknown>)[stateKey];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function extractContextText(context: unknown): string | undefined {
+  const record = asRecord(context);
+  const userContent = record.userContent ?? record.user_content;
+  const text = extractText(userContent);
+  if (text) {
+    return text;
+  }
+  return stringValue(record.input) ?? stringValue(record.prompt);
+}
+
+function extractText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  const record = asRecord(value);
+  const direct =
+    stringValue(record.content) ??
+    stringValue(record.text) ??
+    stringValue(record.delta) ??
+    stringValue(record.message);
+  if (direct) {
+    return direct;
+  }
+
+  if (Array.isArray(record.content)) {
+    const parts = record.content
+      .map((part) => extractText(part))
+      .filter((part): part is string => typeof part === "string");
+    if (parts.length > 0) {
+      return parts.join("");
+    }
+  }
+
+  if (Array.isArray(record.parts)) {
+    const parts = record.parts
+      .map((part) => extractText(part))
+      .filter((part): part is string => typeof part === "string");
+    if (parts.length > 0) {
+      return parts.join("");
+    }
+  }
+
+  return undefined;
+}
+
+function codexBinaryCandidates({
+  env,
+  workingDirectory,
+}: {
+  env: Record<string, string | undefined>;
+  workingDirectory?: string;
+}): string[] {
+  const executable = process.platform === "win32" ? "codex.exe" : "codex";
+  const candidates = new Set<string>();
+
+  for (const dir of (env.PATH ?? "").split(delimiter)) {
+    if (dir.length > 0) {
+      candidates.add(join(dir, executable));
+    }
+  }
+
+  for (const base of candidateBaseDirectories(workingDirectory)) {
+    candidates.add(join(base, "node_modules", ".bin", executable));
+    for (const [platformPackage, targetTriple] of platformCodexPackages()) {
+      candidates.add(
+        join(
+          base,
+          "node_modules",
+          "@openai",
+          platformPackage,
+          "vendor",
+          targetTriple,
+          "codex",
+          executable,
+        ),
+      );
+    }
+  }
+
+  return [...candidates];
+}
+
+function candidateBaseDirectories(workingDirectory?: string): string[] {
+  const roots = new Set<string>();
+  if (workingDirectory) {
+    roots.add(resolve(workingDirectory));
+  }
+  roots.add(process.cwd());
+
+  let current = dirname(fileURLToPath(import.meta.url));
+  for (let index = 0; index < 8; index++) {
+    roots.add(current);
+    const next = dirname(current);
+    if (next === current) {
+      break;
+    }
+    current = next;
+  }
+
+  return [...roots].filter((item) => isAbsolute(item));
+}
+
+function platformCodexPackages(): Array<[string, string]> {
+  switch (`${process.platform}:${process.arch}`) {
+    case "darwin:arm64":
+      return [["codex-darwin-arm64", "aarch64-apple-darwin"]];
+    case "darwin:x64":
+      return [["codex-darwin-x64", "x86_64-apple-darwin"]];
+    case "linux:arm64":
+      return [["codex-linux-arm64", "aarch64-unknown-linux-musl"]];
+    case "linux:x64":
+      return [["codex-linux-x64", "x86_64-unknown-linux-musl"]];
+    case "win32:arm64":
+      return [["codex-win32-arm64", "aarch64-pc-windows-msvc"]];
+    case "win32:x64":
+      return [["codex-win32-x64", "x86_64-pc-windows-msvc"]];
+    default:
+      return [];
+  }
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+function readCredentialEnv(
+  request: ExternalAgentRunRequest,
+  key: string,
+): string | undefined {
+  return request.credential?.kind === "env" ? request.credential.env?.[key] : undefined;
+}
+
+function copyIfPresent(
+  source: Record<string, string | undefined>,
+  target: Record<string, string>,
+  key: string,
+): void {
+  const value = source[key];
+  if (typeof value === "string" && value.length > 0) {
+    target[key] = value;
+  }
+}
+
+function removeUndefined(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/agents/driver/codex-sdk.ts
+++ b/src/agents/driver/codex-sdk.ts
@@ -9,15 +9,36 @@ import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Content } from "@google/genai";
 import type { ExternalAgentEvent } from "../events.js";
-import type { ExternalAgentRunRequest } from "../external-agent-driver.js";
+import {
+  type ExternalAgentRunRequest,
+  resolveAbortSignal,
+} from "../external-agent-driver.js";
 import type { ExternalAgentPermissionPolicy } from "../permissions/schema.js";
 import { CODEX_PROVIDER } from "../provider/codex.js";
 import { collectContents } from "../runtime/content-collector.js";
+import { classifyRecoverable } from "../runtime/error-classification.js";
 import {
   type CodexInputPart,
   summarizeHistoryForColdStart,
   userContentToCodexInput,
 } from "./codex-input-mapper.js";
+
+/**
+ * Ambient environment variables forwarded from `this.#env` into the Codex SDK's
+ * replacement env (the SDK does not inherit `process.env`). Covers proxy/cert
+ * egress configuration plus a custom shell `CODEX_HOME` (CODEX-3).
+ */
+const CODEX_AMBIENT_PASSTHROUGH = [
+  "HTTPS_PROXY",
+  "https_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "NO_PROXY",
+  "no_proxy",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "CODEX_HOME",
+] as const;
 
 type CodexSdkApprovalMode = "never" | "on-request" | "on-failure" | "untrusted";
 type CodexSdkSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
@@ -200,10 +221,37 @@ export class CodexSdkDriver {
       }
 
       const { events } = await thread.runStreamed(input, {
-        signal: request.context?.abortSignal,
+        signal: resolveAbortSignal(request),
         outputSchema: this.#outputSchema,
       });
+
+      // Track the thread id as soon as it is known so resumability survives a
+      // mid-turn throw. The `thread.started` event carries it before the first
+      // turn completes; we emit the `state_delta` immediately (CODEX-4) and
+      // remember it so the post-loop read does not re-emit.
+      let emittedThreadId: string | undefined;
+      const emitThreadId = (threadId: string | undefined) => {
+        if (!stateKey || !threadId) return undefined;
+        if (threadId === savedThreadId || threadId === emittedThreadId) {
+          return undefined;
+        }
+        emittedThreadId = threadId;
+        const delta: ExternalAgentEvent = {
+          type: "state_delta",
+          stateDelta: { [stateKey]: threadId },
+          timestamp: Date.now(),
+        };
+        return delta;
+      };
+
       for await (const event of events) {
+        if (stringValue(event.type) === "thread.started") {
+          const delta = emitThreadId(threadStartedId(event));
+          if (delta) {
+            yield delta;
+          }
+          continue;
+        }
         for (const normalized of this.normalizeEvent(event)) {
           if (normalized.type === "completed") {
             pendingEvents.push(normalized);
@@ -213,13 +261,11 @@ export class CodexSdkDriver {
         }
       }
 
-      const newThreadId = thread.id ?? undefined;
-      if (stateKey && newThreadId && newThreadId !== savedThreadId) {
-        yield {
-          type: "state_delta",
-          stateDelta: { [stateKey]: newThreadId },
-          timestamp: Date.now(),
-        };
+      // Fallback: if `thread.started` was never observed (older event stream),
+      // persist the id from the post-loop accessor.
+      const postLoopDelta = emitThreadId(thread.id ?? undefined);
+      if (postLoopDelta) {
+        yield postLoopDelta;
       }
 
       for (const event of pendingEvents) {
@@ -230,11 +276,16 @@ export class CodexSdkDriver {
       }
     } catch (error) {
       failed = true;
+      const rawMessage = error instanceof Error ? error.message : String(error);
+      const { recoverable, code } = classifyRecoverable({
+        message: rawMessage,
+        fallbackCode: "CODEX_SDK_ERROR",
+      });
       yield {
         type: "error",
         message: this.describeError(error, request),
-        code: "CODEX_SDK_ERROR",
-        recoverable: true,
+        code,
+        recoverable,
         timestamp: Date.now(),
       };
     } finally {
@@ -261,14 +312,19 @@ export class CodexSdkDriver {
   }
 
   buildThreadOptions(request: ExternalAgentRunRequest): CodexSdkThreadOptions {
+    const policyOptions = mapPolicyToCodexSdkThreadOptions(request.permissions);
+    // Web search needs network egress. When the resolved sandbox has network
+    // access disabled (`policy.allowNetwork:false`), requesting web search asks
+    // for egress the sandbox cannot grant, so omit it entirely (CODEX-7).
+    const networkAccessEnabled = policyOptions.networkAccessEnabled === true;
     return removeUndefined({
-      ...mapPolicyToCodexSdkThreadOptions(request.permissions),
+      ...policyOptions,
       model: this.#model,
       workingDirectory: request.workingDirectory,
       skipGitRepoCheck: this.#skipGitRepoCheck,
       modelReasoningEffort: this.#modelReasoningEffort,
-      webSearchMode: this.#webSearchMode,
-      webSearchEnabled: this.#webSearchEnabled,
+      webSearchMode: networkAccessEnabled ? this.#webSearchMode : undefined,
+      webSearchEnabled: networkAccessEnabled ? this.#webSearchEnabled : undefined,
     }) as CodexSdkThreadOptions;
   }
 
@@ -307,6 +363,17 @@ export class CodexSdkDriver {
     copyIfPresent(this.#env, env, "SHELL");
     copyIfPresent(this.#env, env, "XDG_CONFIG_HOME");
 
+    // The SDK builds a *replacement* env (it does not inherit `process.env`
+    // when `env` is supplied), so ambient proxy/cert vars must be forwarded
+    // explicitly or egress through a corporate proxy / custom CA breaks. A
+    // custom shell `CODEX_HOME` is also carried through here so it is not lost
+    // when it is not delivered via a structured credential (CODEX-3). When a
+    // credential supplies one of these keys it overrides the ambient value via
+    // the allowlist loop below.
+    for (const key of CODEX_AMBIENT_PASSTHROUGH) {
+      copyIfPresent(this.#env, env, key);
+    }
+
     if (request.credential?.kind === "env") {
       for (const key of request.provider.envAllowlist ?? []) {
         const value = request.credential.env?.[key];
@@ -329,12 +396,17 @@ export class CodexSdkDriver {
 
     if (type === "turn.failed") {
       const error = asRecord(event.error);
+      const message = stringValue(error.message) ?? "Codex turn failed";
+      const { recoverable, code } = classifyRecoverable({
+        message,
+        fallbackCode: "CODEX_TURN_FAILED",
+      });
       return [
         {
           type: "error",
-          message: stringValue(error.message) ?? "Codex turn failed",
-          code: "CODEX_TURN_FAILED",
-          recoverable: true,
+          message,
+          code,
+          recoverable,
           timestamp,
         },
         { type: "completed", exitCode: 1, timestamp },
@@ -342,12 +414,17 @@ export class CodexSdkDriver {
     }
 
     if (type === "error") {
+      const message = stringValue(event.message) ?? "Codex SDK error";
+      const { recoverable, code } = classifyRecoverable({
+        message,
+        fallbackCode: "CODEX_SDK_STREAM_ERROR",
+      });
       return [
         {
           type: "error",
-          message: stringValue(event.message) ?? "Codex SDK error",
-          code: "CODEX_SDK_STREAM_ERROR",
-          recoverable: true,
+          message,
+          code,
+          recoverable,
           timestamp,
         },
       ];
@@ -525,12 +602,17 @@ function normalizeCompletedItem(
   }
 
   if (itemType === "error") {
+    const message = stringValue(item.message) ?? "Codex item error";
+    const { recoverable, code } = classifyRecoverable({
+      message,
+      fallbackCode: "CODEX_ITEM_ERROR",
+    });
     return [
       {
         type: "error",
-        message: stringValue(item.message) ?? "Codex item error",
-        code: "CODEX_ITEM_ERROR",
-        recoverable: true,
+        message,
+        code,
+        recoverable,
         timestamp,
       },
     ];
@@ -620,6 +702,14 @@ function normalizeCompletedItem(
   }
 
   return [];
+}
+
+/**
+ * Extract the thread id from a `thread.started` event. The SDK shape is
+ * `ThreadStartedEvent { type: "thread.started", thread_id }`.
+ */
+function threadStartedId(event: CodexSdkThreadEvent): string | undefined {
+  return stringValue(event.thread_id) ?? stringValue((asRecord(event.thread)).id);
 }
 
 function safeCollectContents(request: ExternalAgentRunRequest): Content[] {

--- a/src/agents/driver/gemini-cli.ts
+++ b/src/agents/driver/gemini-cli.ts
@@ -1,0 +1,381 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { SubprocessJsonlDriver } from "./subprocess-jsonl.js";
+import type { ExternalAgentRunRequest } from "../external-agent-driver.js";
+import type { ExternalAgentEvent } from "../events.js";
+import { mapPermissionPolicyToFlags } from "../permissions/mapper.js";
+import type { ExternalAgentPermissionPolicy } from "../permissions/schema.js";
+import { GEMINI_CLI_PROVIDER } from "../provider/gemini-cli.js";
+
+declare const Bun: {
+  spawn(
+    command: string[],
+    options: {
+      cwd?: string;
+      env?: Record<string, string>;
+      stdout: "pipe";
+      stderr: "pipe";
+    },
+  ): {
+    stdout: ReadableStream<Uint8Array>;
+    stderr: ReadableStream<Uint8Array>;
+    exited: Promise<number>;
+  };
+};
+
+export interface GeminiCliSubprocess {
+  stdout?:
+    | AsyncIterable<Uint8Array | string>
+    | Iterable<Uint8Array | string>
+    | ReadableStream<Uint8Array | string>
+    | null;
+  stderr?:
+    | AsyncIterable<Uint8Array | string>
+    | Iterable<Uint8Array | string>
+    | ReadableStream<Uint8Array | string>
+    | null;
+  exited: Promise<number>;
+}
+
+export interface GeminiCliSpawnOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export type GeminiCliSpawn = (
+  command: string,
+  args: readonly string[],
+  options: GeminiCliSpawnOptions,
+) => GeminiCliSubprocess;
+
+export interface GeminiCliDriverConfig {
+  command?: string;
+  spawn?: GeminiCliSpawn;
+  env?: Record<string, string | undefined>;
+}
+
+export class GeminiCliDriver extends SubprocessJsonlDriver {
+  readonly #spawn: GeminiCliSpawn;
+  readonly #env: Record<string, string | undefined>;
+
+  constructor(config: GeminiCliDriverConfig = {}) {
+    super({
+      providerId: GEMINI_CLI_PROVIDER.id,
+      command: config.command ?? GEMINI_CLI_PROVIDER.command ?? "gemini",
+    });
+    this.#spawn = config.spawn ?? bunSpawn;
+    this.#env = config.env ?? process.env;
+  }
+
+  override async *run(
+    request: ExternalAgentRunRequest,
+  ): AsyncIterable<ExternalAgentEvent> {
+    const prompt = buildPrompt(request);
+    const args = buildGeminiArgs(prompt, request.permissions);
+    const env = buildGeminiEnv(this.#env, request);
+
+    yield {
+      type: "started",
+      providerId: this.providerId,
+      timestamp: Date.now(),
+    };
+
+    const child = this.#spawn(this.command, args, {
+      cwd: request.workingDirectory,
+      env,
+    });
+
+    if (child.stderr) {
+      void drainStderr(child.stderr);
+    }
+
+    for await (const line of readLines(child.stdout)) {
+      const event = this.parseGeminiLine(line);
+      if (event) {
+        yield event;
+      }
+    }
+
+    const exitCode = await child.exited;
+    if (exitCode === 0) {
+      yield { type: "completed", exitCode, timestamp: Date.now() };
+      return;
+    }
+
+    yield {
+      type: "error",
+      message: `Gemini CLI exited with code ${exitCode}`,
+      code: "GEMINI_CLI_EXIT",
+      recoverable: true,
+      timestamp: Date.now(),
+    };
+    yield { type: "completed", exitCode, timestamp: Date.now() };
+  }
+
+  parseGeminiLine(line: string): ExternalAgentEvent | undefined {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    const parsed = JSON.parse(trimmed) as GeminiStreamEvent;
+    return normalizeGeminiEvent(parsed);
+  }
+}
+
+type GeminiStreamEvent =
+  | ExternalAgentEvent
+  | {
+      type?: string;
+      event?: string;
+      text?: string;
+      content?: string;
+      message?: string;
+      name?: string;
+      input?: unknown;
+      toolCall?: { name?: string; input?: unknown };
+      error?: string | { message?: string; code?: string };
+      code?: string;
+      exitCode?: number;
+      signal?: string;
+      providerId?: string;
+    };
+
+export function buildGeminiArgs(
+  prompt: string,
+  permissions?: ExternalAgentPermissionPolicy,
+): string[] {
+  return [
+    "-p",
+    prompt,
+    "--output-format",
+    "stream-json",
+    ...mapGeminiPermissionArgs(permissions),
+  ];
+}
+
+export function mapGeminiPermissionArgs(
+  permissions?: ExternalAgentPermissionPolicy,
+): string[] {
+  const policy = permissions ?? { mode: "ask" as const };
+  const flags = mapPermissionPolicyToFlags(policy);
+  const args: string[] = [];
+
+  if (flags.readOnly) {
+    args.push("--approval-mode=plan", "--sandbox");
+  } else if (flags.requireApproval) {
+    args.push("--approval-mode=default", "--sandbox");
+  } else if (flags.workspaceWrite) {
+    args.push("--approval-mode=auto_edit", "--sandbox");
+  } else if (flags.fullAccess) {
+    args.push("--approval-mode=yolo");
+  } else {
+    args.push("--approval-mode=default", "--sandbox");
+  }
+
+  for (const path of flags.paths ?? []) {
+    args.push("--include-directories", path);
+  }
+
+  return args;
+}
+
+function buildPrompt(request: ExternalAgentRunRequest): string {
+  return request.instruction ?? "";
+}
+
+function buildGeminiEnv(
+  processEnv: Record<string, string | undefined>,
+  request: ExternalAgentRunRequest,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  if (processEnv.PATH) {
+    env.PATH = processEnv.PATH;
+  }
+  if (processEnv.HOME) {
+    env.HOME = processEnv.HOME;
+  }
+
+  const credentialEnv =
+    request.credential?.kind === "env" ? request.credential.env : undefined;
+  if (credentialEnv) {
+    for (const key of request.provider.envAllowlist ?? []) {
+      const value = credentialEnv[key];
+      if (typeof value === "string" && value.length > 0) {
+        env[key] = value;
+      }
+    }
+  }
+
+  return env;
+}
+
+function normalizeGeminiEvent(
+  event: GeminiStreamEvent,
+): ExternalAgentEvent | undefined {
+  if (isNormalizedExternalEvent(event)) {
+    return event;
+  }
+
+  const type = event.type ?? event.event;
+
+  if (type === "content" || type === "output" || type === "message") {
+    const content = event.text ?? event.content ?? event.message;
+    return typeof content === "string"
+      ? { type: "output", content, timestamp: Date.now() }
+      : undefined;
+  }
+
+  if (type === "tool_call" || type === "tool-call") {
+    const name = event.name ?? event.toolCall?.name;
+    if (typeof name === "string") {
+      return {
+        type: "tool_call",
+        name,
+        input: event.input ?? event.toolCall?.input,
+        timestamp: Date.now(),
+      };
+    }
+  }
+
+  if (type === "error") {
+    const message =
+      typeof event.error === "string"
+        ? event.error
+        : (event.error?.message ?? event.message ?? "Gemini CLI error");
+    const code =
+      typeof event.error === "object" ? event.error.code : event.code;
+    return {
+      type: "error",
+      message,
+      code,
+      recoverable: true,
+      timestamp: Date.now(),
+    };
+  }
+
+  if (type === "result" || type === "completed" || type === "complete") {
+    return {
+      type: "completed",
+      exitCode: event.exitCode,
+      signal: event.signal,
+      timestamp: Date.now(),
+    };
+  }
+
+  return undefined;
+}
+
+function isNormalizedExternalEvent(
+  event: GeminiStreamEvent,
+): event is ExternalAgentEvent {
+  switch (event.type) {
+    case "started":
+      return typeof event.providerId === "string";
+    case "output":
+      return typeof event.content === "string";
+    case "tool_call":
+      return typeof event.name === "string";
+    case "error":
+      return typeof event.message === "string";
+    case "completed":
+      return true;
+    default:
+      return false;
+  }
+}
+
+async function* readLines(
+  input?:
+    | AsyncIterable<Uint8Array | string>
+    | Iterable<Uint8Array | string>
+    | ReadableStream<Uint8Array | string>
+    | null,
+): AsyncIterable<string> {
+  if (!input) {
+    return;
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of toAsyncIterable(input)) {
+    buffer +=
+      typeof chunk === "string"
+        ? chunk
+        : decoder.decode(chunk, { stream: true });
+
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      yield buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.length > 0) {
+    yield buffer;
+  }
+}
+
+async function* toAsyncIterable<T>(
+  input: AsyncIterable<T> | Iterable<T> | ReadableStream<T>,
+): AsyncIterable<T> {
+  const asyncIterable = input as AsyncIterable<T>;
+  if (typeof asyncIterable[Symbol.asyncIterator] === "function") {
+    yield* asyncIterable;
+    return;
+  }
+
+  const iterable = input as Iterable<T>;
+  if (typeof iterable[Symbol.iterator] === "function") {
+    yield* iterable;
+    return;
+  }
+
+  const reader = (input as ReadableStream<T>).getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return;
+      }
+      yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function drainStderr(
+  input:
+    | AsyncIterable<Uint8Array | string>
+    | Iterable<Uint8Array | string>
+    | ReadableStream<Uint8Array | string>,
+): Promise<void> {
+  for await (const _line of readLines(input)) {
+    // Gemini stream-json events are read from stdout. Stderr is drained so the
+    // subprocess cannot block if it emits diagnostics.
+  }
+}
+
+const bunSpawn: GeminiCliSpawn = (command, args, options) => {
+  const subprocess = Bun.spawn([command, ...args], {
+    cwd: options.cwd,
+    env: options.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    stdout: subprocess.stdout,
+    stderr: subprocess.stderr,
+    exited: subprocess.exited,
+  };
+};

--- a/src/agents/driver/subprocess-jsonl.ts
+++ b/src/agents/driver/subprocess-jsonl.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {
+  ExternalAgentDriver,
+  ExternalAgentRunRequest,
+} from "../external-agent-driver.js";
+import { isExternalAgentEvent, type ExternalAgentEvent } from "../events.js";
+
+export interface SubprocessJsonlDriverConfig {
+  providerId: string;
+  command: string;
+  args?: readonly string[];
+}
+
+/**
+ * Foundation placeholder for JSONL subprocess-backed drivers.
+ *
+ * The class intentionally performs no work until `run` is called, which keeps
+ * imports free of CLI execution, auth prompts, and other side effects.
+ */
+export class SubprocessJsonlDriver implements ExternalAgentDriver {
+  readonly providerId: string;
+  readonly command: string;
+  readonly args: readonly string[];
+
+  constructor(config: SubprocessJsonlDriverConfig) {
+    this.providerId = config.providerId;
+    this.command = config.command;
+    this.args = config.args ?? [];
+  }
+
+  async *run(_request: ExternalAgentRunRequest): AsyncIterable<ExternalAgentEvent> {
+    yield {
+      type: "error",
+      message:
+        "Subprocess JSONL execution is a provider-driver concern and is not implemented in the foundation layer.",
+      recoverable: true,
+    };
+  }
+
+  parseLine(line: string): ExternalAgentEvent {
+    const parsed = JSON.parse(line) as unknown;
+    if (!isExternalAgentEvent(parsed)) {
+      throw new Error("Invalid external agent JSONL event");
+    }
+    return parsed;
+  }
+}

--- a/src/agents/events.ts
+++ b/src/agents/events.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+/** Lifecycle and output events emitted by external coding-agent runtimes. */
+export type ExternalAgentEvent =
+  | ExternalAgentStartedEvent
+  | ExternalAgentOutputEvent
+  | ExternalAgentToolCallEvent
+  | ExternalAgentToolResultEvent
+  | ExternalAgentErrorEvent
+  | ExternalAgentStateDeltaEvent
+  | ExternalAgentCompletedEvent;
+
+export interface ExternalAgentStartedEvent {
+  type: "started";
+  runId?: string;
+  providerId: string;
+  timestamp?: number;
+}
+
+export interface ExternalAgentOutputEvent {
+  type: "output";
+  content: string;
+  stream?: "stdout" | "stderr";
+  partial?: boolean;
+  turnComplete?: boolean;
+  metadata?: Record<string, unknown>;
+  timestamp?: number;
+}
+
+export interface ExternalAgentToolCallEvent {
+  type: "tool_call";
+  name: string;
+  input?: unknown;
+  callId?: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: number;
+}
+
+export interface ExternalAgentToolResultEvent {
+  type: "tool_result";
+  name: string;
+  result: unknown;
+  callId?: string;
+  error?: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: number;
+}
+
+export interface ExternalAgentErrorEvent {
+  type: "error";
+  message: string;
+  code?: string;
+  recoverable?: boolean;
+  timestamp?: number;
+}
+
+export interface ExternalAgentStateDeltaEvent {
+  type: "state_delta";
+  stateDelta: Record<string, unknown>;
+  timestamp?: number;
+}
+
+export interface ExternalAgentCompletedEvent {
+  type: "completed";
+  exitCode?: number;
+  signal?: string;
+  timestamp?: number;
+}
+
+export function isExternalAgentEvent(value: unknown): value is ExternalAgentEvent {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const type = (value as { type?: unknown }).type;
+  return (
+    type === "started" ||
+    type === "output" ||
+    type === "tool_call" ||
+    type === "tool_result" ||
+    type === "error" ||
+    type === "state_delta" ||
+    type === "completed"
+  );
+}

--- a/src/agents/external-agent-driver.ts
+++ b/src/agents/external-agent-driver.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { BaseAgent, BaseTool, InvocationContext } from "@google/adk";
+import type { ExternalAgentCredential } from "./auth/schema.js";
+import type { ExternalAgentEvent } from "./events.js";
+import type { ExternalAgentPermissionPolicy } from "./permissions/schema.js";
+import type { ExternalAgentProviderDefinition } from "./provider/schema.js";
+import type { AgentRuntimeCapabilities } from "./runtime/capabilities.js";
+import type { AgentRuntimeSession } from "./runtime/runtime-session.js";
+import type { ToolGateway } from "./tools/tool-gateway.js";
+
+export interface ExternalAgentRunRequest {
+  provider: ExternalAgentProviderDefinition;
+  context: InvocationContext;
+  instruction?: string;
+  workingDirectory?: string;
+  credential?: ExternalAgentCredential;
+  permissions?: ExternalAgentPermissionPolicy;
+  agent?: BaseAgent;
+  rootAgent?: BaseAgent;
+  subAgents?: readonly BaseAgent[];
+  tools?: readonly BaseTool[];
+  toolGateway?: ToolGateway;
+  runtimeSession?: AgentRuntimeSession;
+}
+
+export interface ExternalAgentDriver {
+  readonly providerId: string;
+  capabilities?(): AgentRuntimeCapabilities;
+  run(request: ExternalAgentRunRequest): AsyncIterable<ExternalAgentEvent>;
+}
+
+export class PlaceholderExternalAgentDriver implements ExternalAgentDriver {
+  constructor(readonly providerId: string) {}
+
+  async *run(): AsyncIterable<ExternalAgentEvent> {
+    yield {
+      type: "error",
+      message:
+        "No external agent driver is configured. Provider-specific runtime execution is not part of the foundation layer.",
+      recoverable: true,
+    };
+  }
+}

--- a/src/agents/external-agent-driver.ts
+++ b/src/agents/external-agent-driver.ts
@@ -26,6 +26,33 @@ export interface ExternalAgentRunRequest {
   tools?: readonly BaseTool[];
   toolGateway?: ToolGateway;
   runtimeSession?: AgentRuntimeSession;
+  /**
+   * First-class cancellation signal for the run. When this signal aborts,
+   * drivers MUST stop streaming and release any spawned subprocess/SDK
+   * resources (e.g. via the SDK's own abort/interrupt mechanism).
+   *
+   * This is the single, shared cancellation contract for all external-agent
+   * drivers. When unset, drivers SHOULD fall back to
+   * {@link InvocationContext.abortSignal} (`context.abortSignal`) for backward
+   * compatibility. Use {@link resolveAbortSignal} to obtain the effective
+   * signal honoring both sources.
+   */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Resolve the effective cancellation signal for a run, preferring the
+ * first-class {@link ExternalAgentRunRequest.abortSignal} and falling back to
+ * the ADK {@link InvocationContext.abortSignal}. Returns `undefined` when
+ * neither is present.
+ *
+ * This is the one place every driver should call so they share a single
+ * cancellation contract.
+ */
+export function resolveAbortSignal(
+  request: Pick<ExternalAgentRunRequest, "abortSignal" | "context">,
+): AbortSignal | undefined {
+  return request.abortSignal ?? request.context?.abortSignal;
 }
 
 export interface ExternalAgentDriver {

--- a/src/agents/external-agent.ts
+++ b/src/agents/external-agent.ts
@@ -1,0 +1,547 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+  BaseAgent,
+  createEvent,
+  createEventActions,
+  type Event,
+  type InvocationContext,
+} from "@google/adk";
+import type { Content } from "@google/genai";
+import { trace } from "@opentelemetry/api";
+import type { ExternalAgentCredentialProvider } from "./auth/credential-provider.js";
+import { NoopCredentialProvider } from "./auth/credential-provider.js";
+import type { ExternalAgentDriver } from "./external-agent-driver.js";
+import { PlaceholderExternalAgentDriver } from "./external-agent-driver.js";
+import type { ExternalAgentEvent } from "./events.js";
+import type { ExternalAgentPermissionPolicy } from "./permissions/schema.js";
+import type { ExternalAgentProviderDefinition } from "./provider/schema.js";
+import { ToolGateway } from "./tools/tool-gateway.js";
+
+const tracerName = "gcp.vertex.agent";
+const tracerVersion = "adk-llm-bridge";
+
+function readPermissionOverride(
+  context: InvocationContext,
+): ExternalAgentPermissionPolicy | undefined {
+  const override = (context as { externalAgentPermissionOverride?: unknown })
+    .externalAgentPermissionOverride;
+  return isPermissionPolicy(override) ? override : undefined;
+}
+
+function isPermissionPolicy(value: unknown): value is ExternalAgentPermissionPolicy {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "mode" in value &&
+      typeof (value as { mode?: unknown }).mode === "string",
+  );
+}
+
+function normalizeToolCallArgs(input: unknown): Record<string, unknown> {
+  if (input === undefined) {
+    return {};
+  }
+
+  if (typeof input === "object" && input !== null && !Array.isArray(input)) {
+    return input as Record<string, unknown>;
+  }
+
+  return { input };
+}
+
+export interface ExternalAgentConfig {
+  name: string;
+  description?: string;
+  provider: ExternalAgentProviderDefinition;
+  driver?: ExternalAgentDriver;
+  credentialProvider?: ExternalAgentCredentialProvider;
+  instruction?: string;
+  workingDirectory?: string;
+  permissions?: ExternalAgentPermissionPolicy;
+  subAgents?: BaseAgent[];
+}
+
+export class ExternalAgent extends BaseAgent {
+  readonly provider: ExternalAgentProviderDefinition;
+  readonly driver: ExternalAgentDriver;
+  readonly credentialProvider: ExternalAgentCredentialProvider;
+  readonly instruction?: string;
+  readonly workingDirectory?: string;
+  readonly permissions?: ExternalAgentPermissionPolicy;
+
+  constructor(config: ExternalAgentConfig) {
+    super({
+      name: config.name,
+      description: config.description,
+      subAgents: config.subAgents,
+    });
+    this.provider = config.provider;
+    this.driver =
+      config.driver ?? new PlaceholderExternalAgentDriver(config.provider.id);
+    this.credentialProvider =
+      config.credentialProvider ?? new NoopCredentialProvider();
+    this.instruction = config.instruction;
+    this.workingDirectory = config.workingDirectory;
+    this.permissions = config.permissions;
+  }
+
+  protected createInvocationContext(parentContext: InvocationContext): InvocationContext {
+    const context = super.createInvocationContext(parentContext);
+    const inherited = readPermissionOverride(parentContext);
+    if (inherited) {
+      (context as { externalAgentPermissionOverride?: ExternalAgentPermissionPolicy })
+        .externalAgentPermissionOverride = inherited;
+    }
+    return context;
+  }
+
+  protected async *runAsyncImpl(
+    context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    const credential = await this.credentialProvider.getCredential({
+      providerId: this.provider.id,
+      envAllowlist: this.provider.envAllowlist,
+    });
+    const permissions = readPermissionOverride(context) ?? this.permissions;
+
+    const queue = new AsyncEventQueue<Event>();
+    const rootAgent = this.rootAgent ?? context.agent ?? this;
+    const subAgents = this.subAgents;
+    const toolGateway = subAgents.length > 0
+      ? new ToolGateway({
+          rootAgent,
+          subAgents,
+          parentContext: context,
+          parentPermissions: permissions,
+          eventSink: (event) => {
+            traceAdkEvent({ event, context, providerId: this.provider.id });
+            queue.push(event);
+          },
+        })
+      : undefined;
+
+    void (async () => {
+      try {
+        for await (const event of this.driver.run({
+          provider: this.provider,
+          context,
+          instruction: this.instruction,
+          workingDirectory: this.workingDirectory,
+          credential,
+          permissions,
+          agent: this,
+          rootAgent,
+          subAgents,
+          toolGateway,
+          runtimeSession: {
+            id: context.invocationId,
+            rootAgentName: rootAgent.name,
+          },
+        })) {
+          const adkEvent = this.toAdkEvent(event, context);
+          if (adkEvent) {
+            traceAdkEvent({ event: adkEvent, context, providerId: this.provider.id });
+            queue.push(adkEvent);
+          }
+        }
+        queue.close();
+      } catch (error) {
+        queue.fail(error);
+      }
+    })();
+
+    yield* queue;
+  }
+
+  protected async *runLiveImpl(
+    context: InvocationContext,
+  ): AsyncGenerator<Event, void, void> {
+    yield* this.runAsyncImpl(context);
+  }
+
+  protected toAdkEvent(
+    event: ExternalAgentEvent,
+    context: InvocationContext,
+  ): Event | undefined {
+    switch (event.type) {
+      case "output":
+        return createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          branch: context.branch,
+          content: { role: "model", parts: [{ text: event.content }] },
+          partial: event.partial,
+          turnComplete: event.turnComplete ?? !event.partial,
+          customMetadata: metadataForExternalEvent(this.name, event),
+          timestamp: event.timestamp,
+        });
+      case "error":
+        return createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          branch: context.branch,
+          errorCode: event.code ?? "EXTERNAL_AGENT_ERROR",
+          errorMessage: event.message,
+          customMetadata: metadataForExternalEvent(this.name, event),
+          timestamp: event.timestamp,
+        });
+      case "tool_call":
+        return createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          branch: context.branch,
+          content: this.toolCallToContent(event),
+          customMetadata: metadataForExternalEvent(this.name, event),
+          timestamp: event.timestamp,
+        });
+      case "tool_result":
+        return createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          branch: context.branch,
+          content: this.toolResultToContent(event),
+          customMetadata: metadataForExternalEvent(this.name, event),
+          timestamp: event.timestamp,
+        });
+      case "state_delta":
+        return createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          branch: context.branch,
+          actions: createEventActions({ stateDelta: event.stateDelta }),
+          customMetadata: metadataForExternalEvent(this.name, event),
+          timestamp: event.timestamp,
+        });
+      case "started":
+      case "completed":
+        return undefined;
+    }
+  }
+
+  private toolCallToContent(
+    event: Extract<ExternalAgentEvent, { type: "tool_call" }>,
+  ): Content {
+    return {
+      role: "model",
+      parts: [
+        {
+          functionCall: {
+            id: event.callId,
+            name: event.name,
+            args: normalizeToolCallArgs(event.input),
+          },
+        },
+      ],
+    };
+  }
+
+  private toolResultToContent(
+    event: Extract<ExternalAgentEvent, { type: "tool_result" }>,
+  ): Content {
+    const response = typeof event.result === "object" && event.result !== null
+      ? (event.result as Record<string, unknown>)
+      : { result: event.result };
+    return {
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            id: event.callId,
+            name: event.name,
+            response: event.error ? { ...response, error: event.error } : response,
+          },
+        },
+      ],
+    };
+  }
+}
+
+function metadataForExternalEvent(agentName: string, event: ExternalAgentEvent): Record<string, unknown> {
+  const metadata = "metadata" in event && event.metadata ? event.metadata : {};
+  return {
+    ...metadata,
+    title: typeof metadata.title === "string"
+      ? metadata.title
+      : readableExternalEventTitle(agentName, event),
+    externalAgent: true,
+  };
+}
+
+function readableExternalEventTitle(agentName: string, event: ExternalAgentEvent): string {
+  switch (event.type) {
+    case "output": {
+      const itemType = stringValue(event.metadata?.itemType);
+      const status = stringValue(event.metadata?.status);
+      if (itemType) {
+        return `${agentName}: ${itemType}${status ? ` ${status}` : ""}`;
+      }
+      return event.partial ? `${agentName}: progress` : `${agentName}: final response`;
+    }
+    case "error":
+      return `${agentName}: error ${event.code ?? "EXTERNAL_AGENT_ERROR"}`;
+    case "tool_call":
+      return `${agentName}: ${event.name} call${toolDetail(event.input)}`;
+    case "tool_result":
+      return `${agentName}: ${event.name} response${toolDetail(event.result)}`;
+    case "state_delta":
+      return `${agentName}: state update`;
+    case "started":
+      return `${agentName}: started`;
+    case "completed":
+      return `${agentName}: completed`;
+  }
+}
+
+class AsyncEventQueue<T> implements AsyncIterable<T> {
+  readonly #items: T[] = [];
+  readonly #waiters: Array<{
+    resolve: (result: IteratorResult<T>) => void;
+    reject: (reason?: unknown) => void;
+  }> = [];
+  #closed = false;
+  #error: unknown;
+
+  push(item: T): void {
+    if (this.#closed) {
+      return;
+    }
+    const waiter = this.#waiters.shift();
+    if (waiter) {
+      waiter.resolve({ value: item, done: false });
+      return;
+    }
+    this.#items.push(item);
+  }
+
+  close(): void {
+    this.#closed = true;
+    while (this.#waiters.length > 0) {
+      this.#waiters.shift()?.resolve({ value: undefined, done: true });
+    }
+  }
+
+  fail(error: unknown): void {
+    this.#error = error;
+    this.#closed = true;
+    while (this.#waiters.length > 0) {
+      this.#waiters.shift()?.reject(error);
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => this.next(),
+    };
+  }
+
+  private next(): Promise<IteratorResult<T>> {
+    if (this.#items.length > 0) {
+      return Promise.resolve({ value: this.#items.shift() as T, done: false });
+    }
+    if (this.#error) {
+      return Promise.reject(this.#error);
+    }
+    if (this.#closed) {
+      return Promise.resolve({ value: undefined, done: true });
+    }
+    return new Promise<IteratorResult<T>>((resolve, reject) => {
+      this.#waiters.push({ resolve, reject });
+    });
+  }
+}
+
+function traceAdkEvent({
+  event,
+  context,
+  providerId,
+}: {
+  event: Event;
+  context: InvocationContext;
+  providerId: string;
+}): void {
+  const spanName = spanNameForEvent(event);
+  const tracer = trace.getTracer(tracerName, tracerVersion);
+  const span = tracer.startSpan(spanName);
+  try {
+    const title = readableEventTitle(event);
+    const metadata = readCustomMetadata(event);
+    const llmRequest = buildSyntheticAdkLlmRequest(context, providerId);
+    const parentToolName = stringValue(metadata.parentToolName);
+    const parentToolCallId = stringValue(metadata.parentToolCallId);
+    const metadataSubAgentName = stringValue(metadata.subAgentName);
+    span.setAttributes({
+      "gen_ai.system": "gcp.vertex.agent",
+      "gen_ai.agent.name": event.author ?? context.agent?.name ?? "external_agent",
+      "gen_ai.operation.name": spanName === "call_llm" ? "call_llm" : "execute_tool",
+      "gen_ai.request.model": providerId,
+      "gcp.vertex.agent.invocation_id": context.invocationId,
+      "gcp.vertex.agent.session_id": readSessionId(context),
+      "gcp.vertex.agent.event_id": event.id,
+      "gcp.vertex.agent.provider_id": providerId,
+      "gcp.vertex.agent.external_agent.name": event.author ?? "",
+      "gcp.vertex.agent.event_title": title,
+      "gcp.vertex.agent.branch": event.branch ?? "",
+      "gcp.vertex.agent.subagent.name": metadataSubAgentName,
+      "gcp.vertex.agent.parent_tool.name": parentToolName,
+      "gcp.vertex.agent.parent_tool.call_id": parentToolCallId,
+      "gcp.vertex.agent.llm_request": safeJsonSerialize(llmRequest),
+      "gcp.vertex.agent.llm_response": safeJsonSerialize(event),
+    });
+
+    const functionCall = event.content?.parts?.find((part) => part.functionCall)?.functionCall;
+    const functionResponse = event.content?.parts?.find((part) => part.functionResponse)?.functionResponse;
+    if (functionCall) {
+      span.setAttributes({
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": functionCall.name ?? "run_adk_subagent",
+        "gen_ai.tool.call.id": functionCall.id ?? event.id,
+        "gcp.vertex.agent.tool_call_args": safeJsonSerialize(functionCall.args ?? {}),
+        "gcp.vertex.agent.subagent.name": stringValue((functionCall.args as { agentName?: unknown } | undefined)?.agentName) || metadataSubAgentName,
+      });
+    }
+    if (functionResponse) {
+      span.setAttributes({
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": functionResponse.name ?? "run_adk_subagent",
+        "gen_ai.tool.call.id": functionResponse.id ?? event.id,
+        "gcp.vertex.agent.tool_response": safeJsonSerialize(functionResponse.response ?? {}),
+        "gcp.vertex.agent.subagent.name": stringValue((functionResponse.response as { agentName?: unknown } | undefined)?.agentName) || metadataSubAgentName,
+      });
+    }
+  } finally {
+    span.end();
+  }
+}
+
+function buildSyntheticAdkLlmRequest(
+  context: InvocationContext,
+  providerId: string,
+): { model: string; contents: Content[] } {
+  const userContent = (context as { userContent?: Content }).userContent;
+  return {
+    model: providerId,
+    contents: userContent ? [contentForTrace(userContent)] : [],
+  };
+}
+
+function contentForTrace(content: Content): Content {
+  return {
+    role: content.role,
+    parts: content.parts?.filter((part) => !part.inlineData) ?? [],
+  };
+}
+
+function spanNameForEvent(event: Event): string {
+  const functionCall = event.content?.parts?.find((part) => part.functionCall)?.functionCall;
+  if (functionCall) {
+    const subAgentName = stringValue((functionCall.args as { agentName?: unknown } | undefined)?.agentName);
+    return functionCall.name === "run_adk_subagent" && subAgentName
+      ? `execute_tool run_adk_subagent → ${subAgentName}`
+      : `execute_tool ${functionCall.name ?? "<unknown>"}${toolDetail(functionCall.args)}`;
+  }
+
+  const functionResponse = event.content?.parts?.find((part) => part.functionResponse)?.functionResponse;
+  if (functionResponse) {
+    const subAgentName = stringValue((functionResponse.response as { agentName?: unknown } | undefined)?.agentName);
+    return functionResponse.name === "run_adk_subagent" && subAgentName
+      ? `execute_tool run_adk_subagent ← ${subAgentName}`
+      : `execute_tool ${functionResponse.name ?? "<unknown>"}${toolDetail(functionResponse.response)}`;
+  }
+
+  const toolProgressSpanName = spanNameForToolProgress(event);
+  if (toolProgressSpanName) {
+    return toolProgressSpanName;
+  }
+
+  return "call_llm";
+}
+
+function spanNameForToolProgress(event: Event): string | undefined {
+  const metadata = readCustomMetadata(event);
+  const itemType = stringValue(metadata.itemType);
+  if (!isToolProgressItemType(itemType)) {
+    return undefined;
+  }
+  return `execute_tool ${itemType}${toolDetail(metadata)}`;
+}
+
+function isToolProgressItemType(value: string): boolean {
+  return value === "command_execution" || value === "web_search" || value === "mcp_tool_call";
+}
+
+function toolDetail(value: unknown): string {
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  const record = value as Record<string, unknown>;
+  const command = stringValue(record.command);
+  const status = stringValue(record.status);
+  const query = stringValue(record.query);
+  const toolName = stringValue(record.toolName);
+  const detail = command || query || toolName || status;
+  return detail ? `: ${truncate(detail, 72)}` : "";
+}
+
+function readableEventTitle(event: Event): string {
+  const metadata = readCustomMetadata(event);
+  const metadataTitle = stringValue(metadata.title);
+  if (metadataTitle) {
+    return metadataTitle;
+  }
+
+  const functionCall = event.content?.parts?.find((part) => part.functionCall)?.functionCall;
+  if (functionCall?.name) {
+    return `functionCall:${functionCall.name}`;
+  }
+
+  const functionResponse = event.content?.parts?.find((part) => part.functionResponse)?.functionResponse;
+  if (functionResponse?.name) {
+    return `functionResponse:${functionResponse.name}`;
+  }
+
+  const text = event.content?.parts
+    ?.map((part) => part.text)
+    .find((part): part is string => typeof part === "string" && part.length > 0);
+  if (text) {
+    return truncate(text, 80);
+  }
+
+  const itemType = stringValue(metadata.itemType);
+  const status = stringValue(metadata.status);
+  const subAgentName = stringValue(metadata.subAgentName) || event.author;
+  if (itemType && subAgentName) {
+    return `${subAgentName}: ${itemType}${status ? ` ${status}` : ""}`;
+  }
+
+  return event.errorMessage ? `error:${event.errorCode ?? "EXTERNAL_AGENT_ERROR"}` : event.author ?? "external_agent";
+}
+
+function readCustomMetadata(event: Event): Record<string, unknown> {
+  return (event as { customMetadata?: Record<string, unknown> }).customMetadata ?? {};
+}
+
+function readSessionId(context: InvocationContext): string {
+  const session = (context as { session?: { id?: unknown } }).session;
+  return typeof session?.id === "string" ? session.id : "";
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function safeJsonSerialize(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "<not serializable>";
+  }
+}

--- a/src/agents/gemini-cli-agent.ts
+++ b/src/agents/gemini-cli-agent.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+  createExternalAgentConfig,
+  type ExternalAgentDefinition,
+  type ExternalAgentDefinitionConfig,
+} from "./agent-schema.js";
+import { EnvCredentialProvider } from "./auth/env.js";
+import { GeminiCliDriver } from "./driver/gemini-cli.js";
+import { ExternalAgent } from "./external-agent.js";
+import { GEMINI_CLI_PROVIDER } from "./provider/gemini-cli.js";
+
+export const GEMINI_CLI_AGENT_DEFINITION: ExternalAgentDefinition = {
+  provider: GEMINI_CLI_PROVIDER,
+  runtime: "cli",
+  capabilities: {
+    streaming: true,
+    permissions: true,
+    tools: true,
+  },
+  createCredentialProvider: () => new EnvCredentialProvider(),
+  createDriver: () => new GeminiCliDriver(),
+};
+
+export type GeminiCliAgentConfig = ExternalAgentDefinitionConfig;
+
+export class GeminiCliAgent extends ExternalAgent {
+  static readonly definition = GEMINI_CLI_AGENT_DEFINITION;
+
+  constructor(config: GeminiCliAgentConfig) {
+    super(createExternalAgentConfig(GEMINI_CLI_AGENT_DEFINITION, config));
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -104,6 +104,7 @@ export type { ExternalAgentConfig } from "./external-agent.js";
 export { ExternalAgent } from "./external-agent.js";
 export {
   PlaceholderExternalAgentDriver,
+  resolveAbortSignal,
 } from "./external-agent-driver.js";
 export type {
   ExternalAgentDriver,
@@ -142,6 +143,11 @@ export {
   collectContents,
   flattenContentsToPrompt,
 } from "./runtime/content-collector.js";
+export { classifyRecoverable } from "./runtime/error-classification.js";
+export type {
+  ClassifyRecoverableInput,
+  RecoverableClassification,
+} from "./runtime/error-classification.js";
 export type { AgentRuntimeRequestMetadata } from "./runtime/runtime-request.js";
 export type { AgentRuntimeSession } from "./runtime/runtime-session.js";
 export { ToolGateway } from "./tools/tool-gateway.js";

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+export { BaseAgent } from "@google/adk";
+
+export {
+  createExternalAgent,
+  createExternalAgentConfig,
+} from "./agent-schema.js";
+export type {
+  ExternalAgentDefinition,
+  ExternalAgentDefinitionConfig,
+  ExternalAgentRuntimeKind,
+} from "./agent-schema.js";
+export {
+  createDefaultExternalAgentDefinitionRegistry,
+  ExternalAgentDefinitionRegistry,
+  externalAgentDefinitionRegistry,
+} from "./agent-registry.js";
+export type { ExternalAgentCredentialProvider } from "./auth/credential-provider.js";
+export { NoopCredentialProvider } from "./auth/credential-provider.js";
+export { EnvCredentialProvider, readAllowedEnv } from "./auth/env.js";
+export type {
+  CredentialRequest,
+  ExternalAgentAuthKind,
+  ExternalAgentCredential,
+} from "./auth/schema.js";
+
+export { CLAUDE_AGENT_DEFINITION, ClaudeAgent } from "./claude-agent.js";
+export type { ClaudeAgentConfig } from "./claude-agent.js";
+export { CODEX_AGENT_DEFINITION, CodexAgent } from "./codex-agent.js";
+export type { CodexAgentConfig } from "./codex-agent.js";
+export {
+  CodexCliDriver,
+  mapPolicyToCodexArgs,
+} from "./driver/codex-cli.js";
+export type {
+  CodexCliDriverConfig,
+  CodexCliSpawn,
+  CodexCliSpawnOptions,
+  CodexCliSubprocess,
+} from "./driver/codex-cli.js";
+export {
+  CodexSdkDriver,
+  mapPolicyToCodexSdkThreadOptions,
+} from "./driver/codex-sdk.js";
+export type { CodexSdkDriverConfig } from "./driver/codex-sdk.js";
+export {
+  summarizeHistoryForColdStart,
+  userContentToCodexInput,
+} from "./driver/codex-input-mapper.js";
+export type {
+  CodexInputMapperOptions,
+  CodexInputMapping,
+  CodexInputPart,
+} from "./driver/codex-input-mapper.js";
+export {
+  ClaudeAgentSdkDriver,
+  mapPolicyToClaudeSdkPermission,
+} from "./driver/claude-agent-sdk.js";
+export type { ClaudeAgentSdkDriverConfig } from "./driver/claude-agent-sdk.js";
+export { contentsToSdkMessages } from "./driver/claude-message-mapper.js";
+export type {
+  ClaudeContentBlockParam,
+  ClaudeMessageParam,
+  SDKUserMessage,
+} from "./driver/claude-message-mapper.js";
+export { ClaudeCliDriver, mapClaudePermissionArgs } from "./driver/claude-cli.js";
+export type {
+  ClaudeCliDriverConfig,
+  ClaudeCliSpawn,
+  ClaudeCliSpawnOptions,
+  ClaudeCliSubprocess,
+} from "./driver/claude-cli.js";
+export {
+  GeminiCliDriver,
+  buildGeminiArgs,
+  mapGeminiPermissionArgs,
+} from "./driver/gemini-cli.js";
+export type {
+  GeminiCliDriverConfig,
+  GeminiCliSpawn,
+  GeminiCliSpawnOptions,
+  GeminiCliSubprocess,
+} from "./driver/gemini-cli.js";
+export { SubprocessJsonlDriver } from "./driver/subprocess-jsonl.js";
+export type { SubprocessJsonlDriverConfig } from "./driver/subprocess-jsonl.js";
+
+export type {
+  ExternalAgentCompletedEvent,
+  ExternalAgentErrorEvent,
+  ExternalAgentEvent,
+  ExternalAgentOutputEvent,
+  ExternalAgentStartedEvent,
+  ExternalAgentStateDeltaEvent,
+  ExternalAgentToolCallEvent,
+  ExternalAgentToolResultEvent,
+} from "./events.js";
+export { isExternalAgentEvent } from "./events.js";
+export type { ExternalAgentConfig } from "./external-agent.js";
+export { ExternalAgent } from "./external-agent.js";
+export {
+  PlaceholderExternalAgentDriver,
+} from "./external-agent-driver.js";
+export type {
+  ExternalAgentDriver,
+  ExternalAgentRunRequest,
+} from "./external-agent-driver.js";
+export { GEMINI_CLI_AGENT_DEFINITION, GeminiCliAgent } from "./gemini-cli-agent.js";
+export type { GeminiCliAgentConfig } from "./gemini-cli-agent.js";
+
+export {
+  mapPermissionModeToPolicy,
+  mapPermissionPolicyToFlags,
+} from "./permissions/mapper.js";
+export { deriveSubAgentPermissionPolicy } from "./permissions/inheritance.js";
+export type {
+  ExternalAgentPermissionMode,
+  ExternalAgentPermissionPolicy,
+  ProviderPermissionFlags,
+} from "./permissions/schema.js";
+export {
+  createDefaultExternalAgentProviderRegistry,
+  ExternalAgentProviderRegistry,
+  externalAgentProviderRegistry,
+} from "./provider/registry.js";
+export { CODEX_ENV_ALLOWLIST, CODEX_PROVIDER } from "./provider/codex.js";
+export {
+  GEMINI_CLI_ENV_ALLOWLIST,
+  GEMINI_CLI_PROVIDER,
+} from "./provider/gemini-cli.js";
+export { CLAUDE_PROVIDER } from "./provider/schema.js";
+export type {
+  ExternalAgentProviderDefinition,
+  ExternalAgentProviderId,
+} from "./provider/schema.js";
+export type { AgentRuntimeCapabilities } from "./runtime/capabilities.js";
+export {
+  collectContents,
+  flattenContentsToPrompt,
+} from "./runtime/content-collector.js";
+export type { AgentRuntimeRequestMetadata } from "./runtime/runtime-request.js";
+export type { AgentRuntimeSession } from "./runtime/runtime-session.js";
+export { ToolGateway } from "./tools/tool-gateway.js";
+export type {
+  RunSubAgentInput,
+  RunSubAgentResult,
+  ToolGatewayConfig,
+} from "./tools/tool-gateway.js";

--- a/src/agents/permissions/inheritance.ts
+++ b/src/agents/permissions/inheritance.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {
+  ExternalAgentPermissionMode,
+  ExternalAgentPermissionPolicy,
+} from "./schema.js";
+
+const MODE_RANK: Record<ExternalAgentPermissionMode, number> = {
+  "read-only": 0,
+  ask: 1,
+  "workspace-write": 2,
+  "full-access": 3,
+};
+
+const MODES: readonly ExternalAgentPermissionMode[] = [
+  "read-only",
+  "ask",
+  "workspace-write",
+  "full-access",
+];
+
+export function deriveSubAgentPermissionPolicy(
+  parent?: ExternalAgentPermissionPolicy,
+  child?: ExternalAgentPermissionPolicy,
+): ExternalAgentPermissionPolicy {
+  const parentPolicy = parent ?? { mode: "ask" as const };
+  const childPolicy = child ?? parentPolicy;
+  const mode = moreRestrictiveMode(parentPolicy.mode, childPolicy.mode);
+  const allowedPaths = deriveAllowedPaths(parentPolicy.allowedPaths, childPolicy.allowedPaths);
+
+  return {
+    mode,
+    allowNetwork: Boolean(parentPolicy.allowNetwork && childPolicy.allowNetwork),
+    ...(allowedPaths ? { allowedPaths } : {}),
+  };
+}
+
+function moreRestrictiveMode(
+  parent: ExternalAgentPermissionMode,
+  child: ExternalAgentPermissionMode,
+): ExternalAgentPermissionMode {
+  return MODES[Math.min(MODE_RANK[parent], MODE_RANK[child])] ?? "read-only";
+}
+
+function deriveAllowedPaths(
+  parent?: readonly string[],
+  child?: readonly string[],
+): readonly string[] | undefined {
+  if (parent && child) {
+    const parentSet = new Set(parent);
+    return child.filter((path) => parentSet.has(path));
+  }
+  return parent ?? child;
+}

--- a/src/agents/permissions/mapper.ts
+++ b/src/agents/permissions/mapper.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {
+  ExternalAgentPermissionMode,
+  ExternalAgentPermissionPolicy,
+  ProviderPermissionFlags,
+} from "./schema.js";
+
+export function mapPermissionPolicyToFlags(
+  policy: ExternalAgentPermissionPolicy,
+): ProviderPermissionFlags {
+  const common = {
+    network: policy.allowNetwork,
+    paths: policy.allowedPaths,
+  };
+
+  switch (policy.mode) {
+    case "read-only":
+      return { ...common, readOnly: true, requireApproval: false };
+    case "ask":
+      return { ...common, requireApproval: true };
+    case "workspace-write":
+      return { ...common, workspaceWrite: true, requireApproval: false };
+    case "full-access":
+      return { ...common, fullAccess: true, requireApproval: false };
+  }
+}
+
+export function mapPermissionModeToPolicy(
+  mode: ExternalAgentPermissionMode,
+): ExternalAgentPermissionPolicy {
+  return { mode };
+}

--- a/src/agents/permissions/schema.ts
+++ b/src/agents/permissions/schema.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+export type ExternalAgentPermissionMode = "read-only" | "ask" | "workspace-write" | "full-access";
+
+export interface ExternalAgentPermissionPolicy {
+  mode: ExternalAgentPermissionMode;
+  allowNetwork?: boolean;
+  allowedPaths?: readonly string[];
+}
+
+export interface ProviderPermissionFlags {
+  readOnly?: boolean;
+  requireApproval?: boolean;
+  workspaceWrite?: boolean;
+  fullAccess?: boolean;
+  network?: boolean;
+  paths?: readonly string[];
+}

--- a/src/agents/provider/codex.ts
+++ b/src/agents/provider/codex.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ExternalAgentProviderDefinition } from "./schema.js";
+
+export const CODEX_ENV_ALLOWLIST = [
+  "CODEX_API_KEY",
+  "CODEX_HOME",
+  "CODEX_EXECUTABLE",
+  "CODEX_CLI_PATH",
+  "CODEX_CA_CERTIFICATE",
+  "SSL_CERT_FILE",
+] as const;
+
+export const CODEX_PROVIDER: ExternalAgentProviderDefinition = {
+  id: "codex",
+  name: "Codex",
+  command: "codex",
+  envAllowlist: CODEX_ENV_ALLOWLIST,
+};

--- a/src/agents/provider/codex.ts
+++ b/src/agents/provider/codex.ts
@@ -8,6 +8,7 @@ import type { ExternalAgentProviderDefinition } from "./schema.js";
 
 export const CODEX_ENV_ALLOWLIST = [
   "CODEX_API_KEY",
+  "CODEX_ACCESS_TOKEN",
   "CODEX_HOME",
   "CODEX_EXECUTABLE",
   "CODEX_CLI_PATH",

--- a/src/agents/provider/gemini-cli.ts
+++ b/src/agents/provider/gemini-cli.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ExternalAgentProviderDefinition } from "./schema.js";
+
+export const GEMINI_CLI_ENV_ALLOWLIST = [
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "GOOGLE_GENAI_USE_VERTEXAI",
+  "GOOGLE_CLOUD_PROJECT",
+  "GOOGLE_CLOUD_PROJECT_ID",
+  "GOOGLE_CLOUD_LOCATION",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+] as const;
+
+export const GEMINI_CLI_PROVIDER: ExternalAgentProviderDefinition = {
+  id: "gemini-cli",
+  name: "Gemini CLI",
+  command: "gemini",
+  envAllowlist: GEMINI_CLI_ENV_ALLOWLIST,
+};

--- a/src/agents/provider/registry.ts
+++ b/src/agents/provider/registry.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { CODEX_PROVIDER } from "./codex.js";
+import { GEMINI_CLI_PROVIDER } from "./gemini-cli.js";
+import {
+  CLAUDE_PROVIDER,
+  type ExternalAgentProviderDefinition,
+} from "./schema.js";
+
+export class ExternalAgentProviderRegistry {
+  readonly #providers = new Map<string, ExternalAgentProviderDefinition>();
+
+  constructor(providers: readonly ExternalAgentProviderDefinition[] = []) {
+    for (const provider of providers) {
+      this.register(provider);
+    }
+  }
+
+  register(provider: ExternalAgentProviderDefinition): void {
+    if (!provider.id) {
+      throw new Error("External agent provider id is required");
+    }
+    this.#providers.set(provider.id, provider);
+  }
+
+  get(id: string): ExternalAgentProviderDefinition | undefined {
+    return this.#providers.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.#providers.has(id);
+  }
+
+  list(): ExternalAgentProviderDefinition[] {
+    return [...this.#providers.values()];
+  }
+}
+
+export function createDefaultExternalAgentProviderRegistry(): ExternalAgentProviderRegistry {
+  return new ExternalAgentProviderRegistry([
+    CODEX_PROVIDER,
+    CLAUDE_PROVIDER,
+    GEMINI_CLI_PROVIDER,
+  ]);
+}
+
+export const externalAgentProviderRegistry =
+  createDefaultExternalAgentProviderRegistry();

--- a/src/agents/provider/schema.ts
+++ b/src/agents/provider/schema.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+export type ExternalAgentProviderId =
+  | "codex"
+  | "claude"
+  | "gemini-cli"
+  | (string & {});
+
+export interface ExternalAgentProviderDefinition {
+  /** Stable provider id used in events, registries, and configuration. */
+  id: ExternalAgentProviderId;
+  /** Human-readable provider name. */
+  name: string;
+  /** Optional executable name. The foundation does not execute it at import time. */
+  command?: string;
+  /** Environment variables this provider is allowed to read for auth/config. */
+  envAllowlist?: readonly string[];
+}
+
+export { CODEX_PROVIDER } from "./codex.js";
+
+export const CLAUDE_PROVIDER: ExternalAgentProviderDefinition = {
+  id: "claude",
+  name: "Claude Code",
+  command: "claude",
+  envAllowlist: [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_EXECUTABLE",
+    "CLAUDE_CODE_PATH",
+    "CLAUDE_CONFIG_DIR",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+  ],
+};

--- a/src/agents/runtime/capabilities.ts
+++ b/src/agents/runtime/capabilities.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+export interface AgentRuntimeCapabilities {
+  tools?: boolean;
+  subagents?: boolean;
+  mcpServers?: boolean;
+  streaming?: boolean;
+  sessions?: boolean;
+  permissions?: boolean;
+}

--- a/src/agents/runtime/content-collector.ts
+++ b/src/agents/runtime/content-collector.ts
@@ -1,0 +1,304 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { InvocationContext } from "@google/adk";
+import type { Content, Part } from "@google/genai";
+
+/**
+ * Reimplementation of ADK's `getContents` (see
+ * node_modules/@google/adk/dist/esm/agents/processors/content_processor_utils.js)
+ * that is not exposed via the package's public `exports` map. Walks the session
+ * event history for the current invocation, filters events by branch and
+ * visibility, rewrites foreign-agent turns into user-role context markers, and
+ * reorders async function-call/response pairs so each response sits adjacent to
+ * its call.
+ */
+export function collectContents(context: InvocationContext): Content[] {
+  const ctxRecord = (context ?? {}) as unknown as Record<string, unknown>;
+  const session = ctxRecord.session as { events?: ReadonlyArray<AdkEventLike> } | undefined;
+  // If no session is present we treat this as a synthetic context and bail out;
+  // the driver fallback path will reconstruct the prompt via extractContextText.
+  if (!session || !Array.isArray(session.events)) {
+    return [];
+  }
+  const events: ReadonlyArray<AdkEventLike> = session.events;
+  const agentName = (ctxRecord.agent as { name?: string } | undefined)?.name;
+  const currentBranch =
+    typeof ctxRecord.branch === "string" ? (ctxRecord.branch as string) : undefined;
+  const userContent = ctxRecord.userContent as Content | undefined;
+
+  const filtered: AdkEventLike[] = [];
+  for (const event of events) {
+    if (!event || typeof event !== "object") {
+      continue;
+    }
+    if (event.partial === true) {
+      continue;
+    }
+    const content = event.content;
+    if (!content || !Array.isArray(content.parts) || content.parts.length === 0) {
+      continue;
+    }
+    if (!hasVisibleContent(content.parts)) {
+      continue;
+    }
+    if (
+      currentBranch &&
+      event.branch &&
+      currentBranch !== event.branch &&
+      !currentBranch.startsWith(`${event.branch}.`)
+    ) {
+      continue;
+    }
+
+    if (isForeignEvent(agentName, event)) {
+      filtered.push(rewriteForeignEvent(event));
+    } else {
+      filtered.push(event);
+    }
+  }
+
+  const reordered = rearrangeAsyncFunctionResponses(filtered);
+
+  const contents: Content[] = [];
+  for (const event of reordered) {
+    if (event.content) {
+      contents.push(normalizeContent(event.content));
+    }
+  }
+
+  if (userContent) {
+    const last = contents[contents.length - 1];
+    if (!last || last !== userContent) {
+      contents.push(userContent);
+    }
+  }
+
+  return contents;
+}
+
+/**
+ * Render `Content[]` into a deterministic prompt string suitable for external
+ * runtimes that consume a single text turn.
+ */
+export function flattenContentsToPrompt(contents: ReadonlyArray<Content>): string {
+  const blocks: string[] = [];
+  for (const content of contents) {
+    const header = content.role === "model" ? "assistant:" : "user:";
+    const partStrings: string[] = [];
+    for (const part of content.parts ?? []) {
+      const rendered = renderPart(part);
+      if (rendered !== undefined) {
+        partStrings.push(rendered);
+      }
+    }
+    if (partStrings.length === 0) {
+      continue;
+    }
+    blocks.push(`${header}\n${partStrings.join("\n")}`);
+  }
+  return blocks.join("\n\n").replace(/\s+$/g, "");
+}
+
+// --- internals ----------------------------------------------------------------
+
+type AdkEventLike = {
+  author?: string;
+  branch?: string;
+  partial?: boolean;
+  content?: Content;
+};
+
+function hasVisibleContent(parts: ReadonlyArray<Part>): boolean {
+  for (const part of parts) {
+    if (typeof part.text === "string" && part.text.length > 0) {
+      return true;
+    }
+    if (part.inlineData || part.fileData || part.functionCall || part.functionResponse) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isForeignEvent(agentName: string | undefined, event: AdkEventLike): boolean {
+  if (!agentName) {
+    return false;
+  }
+  const author = event.author;
+  return !!author && author !== "user" && author !== agentName;
+}
+
+function rewriteForeignEvent(event: AdkEventLike): AdkEventLike {
+  const author = event.author ?? "unknown";
+  const parts = event.content?.parts ?? [];
+  const textParts: string[] = [];
+  const newParts: Part[] = [];
+
+  for (const part of parts) {
+    if (typeof part.text === "string" && part.text.length > 0 && !part.thought) {
+      textParts.push(part.text);
+    }
+  }
+  if (textParts.length > 0) {
+    newParts.push({ text: `[${author} said: ${textParts.join("")}]` });
+  }
+  for (const part of parts) {
+    if (part.functionCall) {
+      const args = part.functionCall.args ?? {};
+      newParts.push({
+        text: `[${author} called tool ${part.functionCall.name ?? "<unknown>"} with parameters ${safeJsonStringify(args)}]`,
+      });
+    }
+    // functionResponse, inlineData, fileData from foreign agents are intentionally dropped.
+  }
+
+  return {
+    author: "user",
+    branch: event.branch,
+    content: { role: "user", parts: newParts },
+  };
+}
+
+/**
+ * Single-pass reorder: for each event with `functionCall` parts, if any matching
+ * `functionResponse` event lives later in the array we emit it immediately after
+ * the call. Mirrors the common-case behaviour of ADK's
+ * `rearrangeEventsForAsyncFunctionResponsesInHistory`.
+ */
+function rearrangeAsyncFunctionResponses(events: AdkEventLike[]): AdkEventLike[] {
+  const responseIndexById = new Map<string, number>();
+  for (let i = 0; i < events.length; i++) {
+    for (const part of events[i].content?.parts ?? []) {
+      const id = part.functionResponse?.id;
+      if (id) {
+        responseIndexById.set(id, i);
+      }
+    }
+  }
+
+  const consumed = new Set<number>();
+  const result: AdkEventLike[] = [];
+  for (let i = 0; i < events.length; i++) {
+    if (consumed.has(i)) {
+      continue;
+    }
+    const event = events[i];
+    const isResponseEvent = (event.content?.parts ?? []).some(
+      (part) => part.functionResponse,
+    );
+    if (isResponseEvent && hasMatchingEarlierCall(events, event, i)) {
+      // Skip — will be (or has been) appended after its call.
+      continue;
+    }
+    result.push(event);
+
+    const callIds = collectCallIds(event);
+    if (callIds.length === 0) {
+      continue;
+    }
+    for (const callId of callIds) {
+      const responseIdx = responseIndexById.get(callId);
+      if (responseIdx !== undefined && responseIdx !== i && !consumed.has(responseIdx)) {
+        result.push(events[responseIdx]);
+        consumed.add(responseIdx);
+      }
+    }
+  }
+  return result;
+}
+
+function collectCallIds(event: AdkEventLike): string[] {
+  const ids: string[] = [];
+  for (const part of event.content?.parts ?? []) {
+    const id = part.functionCall?.id;
+    if (id) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+function hasMatchingEarlierCall(
+  events: AdkEventLike[],
+  responseEvent: AdkEventLike,
+  responseIdx: number,
+): boolean {
+  const respIds = new Set<string>();
+  for (const part of responseEvent.content?.parts ?? []) {
+    const id = part.functionResponse?.id;
+    if (id) {
+      respIds.add(id);
+    }
+  }
+  if (respIds.size === 0) {
+    return false;
+  }
+  for (let i = 0; i < responseIdx; i++) {
+    for (const part of events[i].content?.parts ?? []) {
+      const id = part.functionCall?.id;
+      if (id && respIds.has(id)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function normalizeContent(content: Content): Content {
+  const role: "user" | "model" = content.role === "model" ? "model" : "user";
+  return { role, parts: content.parts ?? [] };
+}
+
+function renderPart(part: Part): string | undefined {
+  if (part.thought) {
+    return undefined;
+  }
+  if (typeof part.text === "string" && part.text.length > 0) {
+    return part.text;
+  }
+  if (part.inlineData) {
+    const mime = part.inlineData.mimeType ?? "application/octet-stream";
+    if (mime.startsWith("image/")) return `[image: ${mime}]`;
+    if (mime.startsWith("audio/")) return `[audio: ${mime}]`;
+    if (mime.startsWith("video/")) return `[video: ${mime}]`;
+    return `[document: ${mime}]`;
+  }
+  if (part.fileData) {
+    const mime = part.fileData.mimeType ?? "application/octet-stream";
+    const uri = part.fileData.fileUri ?? "<unknown>";
+    return `[file: ${uri} (${mime})]`;
+  }
+  if (part.functionCall) {
+    const name = part.functionCall.name ?? "<unknown>";
+    const args = part.functionCall.args ?? {};
+    return `[tool_call ${name}(${safeJsonStringify(args)})]`;
+  }
+  if (part.functionResponse) {
+    const name = part.functionResponse.name ?? "<unknown>";
+    const response = part.functionResponse.response ?? {};
+    return `[tool_result ${name}: ${safeJsonStringify(response)}]`;
+  }
+  if (part.executableCode) {
+    const lang = part.executableCode.language ?? "PLAINTEXT";
+    const code = part.executableCode.code ?? "";
+    return `[code (${lang}): ${code}]`;
+  }
+  if (part.codeExecutionResult) {
+    const outcome = part.codeExecutionResult.outcome ?? "OUTCOME_UNSPECIFIED";
+    const output = part.codeExecutionResult.output ?? "";
+    return `[exec ${outcome}: ${output}]`;
+  }
+  return "[unsupported-part]";
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "{}";
+  } catch {
+    return "{}";
+  }
+}

--- a/src/agents/runtime/error-classification.ts
+++ b/src/agents/runtime/error-classification.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Shared error-classification helper for external-agent drivers.
+ *
+ * Both the Codex (`@openai/codex-sdk`) and Claude
+ * (`@anthropic-ai/claude-agent-sdk`) drivers historically labelled every error
+ * `recoverable: true`, which causes upstream retry loops to spin on unfixable
+ * conditions (auth/billing/missing-binary/quota). This module centralizes the
+ * recoverable-vs-non-recoverable decision so both drivers share ONE contract.
+ *
+ * Classification is heuristic: the underlying SDKs frequently expose only a
+ * free-form message string, so callers may pass a known typed subtype (when
+ * available) and/or the raw message text. A known subtype always wins over the
+ * message heuristic.
+ */
+
+/** Result of classifying an error condition. */
+export interface RecoverableClassification {
+  /** Whether retrying the operation could plausibly succeed. */
+  recoverable: boolean;
+  /** Stable, machine-readable code describing the classified condition. */
+  code: string;
+}
+
+/** Input to {@link classifyRecoverable}. */
+export interface ClassifyRecoverableInput {
+  /**
+   * A known typed subtype from the SDK (e.g. Claude's
+   * `SDKAssistantMessageError` / `SDKResultError` subtypes, or a synthetic
+   * Codex subtype). Takes precedence over the message heuristic.
+   */
+  subtype?: string | null;
+  /** Free-form error message text used for heuristic classification. */
+  message?: string | null;
+  /**
+   * Fallback code to emit when no subtype or message signal matches. Defaults
+   * to `UNKNOWN_ERROR`.
+   */
+  fallbackCode?: string;
+  /**
+   * Default recoverability when no signal matches. Defaults to `true`
+   * (preserve the historical "assume transient" behavior for truly unknown
+   * errors).
+   */
+  defaultRecoverable?: boolean;
+}
+
+/**
+ * Known typed subtypes that map to a deterministic classification.
+ *
+ * Codex contributes synthetic subtypes (the SDK only exposes a message
+ * string); Claude contributes its real `SDKAssistantMessageError` /
+ * `SDKResultError` subtypes plus driver-level status codes.
+ */
+const SUBTYPE_TABLE: Record<string, RecoverableClassification> = {
+  // --- Non-recoverable: credential / authorization ---
+  authentication_failed: { recoverable: false, code: "CLAUDE_AUTH_ERROR" },
+  oauth_org_not_allowed: { recoverable: false, code: "CLAUDE_AUTH_ERROR" },
+  CLAUDE_AUTH_STATUS: { recoverable: false, code: "CLAUDE_AUTH_STATUS" },
+  CODEX_AUTH_ERROR: { recoverable: false, code: "CODEX_AUTH_ERROR" },
+
+  // --- Non-recoverable: billing / quota ---
+  billing_error: { recoverable: false, code: "CLAUDE_BILLING_ERROR" },
+  error_max_budget_usd: { recoverable: false, code: "error_max_budget_usd" },
+  quota_exhausted: { recoverable: false, code: "CODEX_QUOTA_EXHAUSTED" },
+
+  // --- Non-recoverable: client/config errors that won't fix on retry ---
+  invalid_request: { recoverable: false, code: "CLAUDE_INVALID_REQUEST" },
+  error_max_turns: { recoverable: false, code: "error_max_turns" },
+  error_max_structured_output_retries: {
+    recoverable: false,
+    code: "error_max_structured_output_retries",
+  },
+  max_output_tokens: { recoverable: false, code: "max_output_tokens" },
+
+  // --- Non-recoverable: environment (missing binary) ---
+  missing_binary: { recoverable: false, code: "CODEX_MISSING_BINARY" },
+
+  // --- Recoverable: transient / transport / rate-limit ---
+  rate_limit: { recoverable: true, code: "CLAUDE_RATE_LIMIT" },
+  server_error: { recoverable: true, code: "CLAUDE_SERVER_ERROR" },
+  transient: { recoverable: true, code: "TRANSIENT_ERROR" },
+  transport: { recoverable: true, code: "TRANSPORT_ERROR" },
+};
+
+interface MessageRule {
+  readonly test: RegExp;
+  readonly result: RecoverableClassification;
+}
+
+/**
+ * Heuristic message rules, evaluated in order. The first match wins. Tuned so
+ * that auth/billing/missing-binary/quota are non-recoverable and
+ * transport/rate-limit are recoverable.
+ *
+ * Order matters: rate-limit (recoverable) is checked before the generic
+ * "quota" non-recoverable rule so a "rate limit" message is not mis-bucketed.
+ */
+const MESSAGE_RULES: readonly MessageRule[] = [
+  {
+    test: /\b(rate[\s_-]?limit|429|too many requests)\b/i,
+    result: { recoverable: true, code: "RATE_LIMIT" },
+  },
+  {
+    test: /\b(unauthor|authentication|invalid api key|invalid_api_key|401|403|forbidden|oauth)\b/i,
+    result: { recoverable: false, code: "AUTH_ERROR" },
+  },
+  {
+    test: /\b(billing|payment|insufficient (?:funds|credit)|quota\b.*\bexhaust|exhaust\w*\b.*\bquota|over quota|out of credit)/i,
+    result: { recoverable: false, code: "BILLING_ERROR" },
+  },
+  {
+    test: /\b(unable to locate|not found on path|missing binary|no such file|enoent|executable not found)\b/i,
+    result: { recoverable: false, code: "MISSING_BINARY" },
+  },
+  {
+    test: /\b(timed?\s?out|timeout|econnreset|econnrefused|enetunreach|socket hang up|network|transport|temporarily unavailable|503|502|504)\b/i,
+    result: { recoverable: true, code: "TRANSPORT_ERROR" },
+  },
+];
+
+/**
+ * Classify an error as recoverable (retry may succeed) or non-recoverable
+ * (retrying is futile until the operator fixes the underlying condition).
+ *
+ * Precedence: known {@link ClassifyRecoverableInput.subtype} > message
+ * heuristic > configured fallback.
+ */
+export function classifyRecoverable(
+  input: ClassifyRecoverableInput,
+): RecoverableClassification {
+  const subtype = input.subtype?.trim();
+  if (subtype && subtype in SUBTYPE_TABLE) {
+    return SUBTYPE_TABLE[subtype];
+  }
+
+  const message = input.message ?? "";
+  if (message) {
+    for (const rule of MESSAGE_RULES) {
+      if (rule.test.test(message)) {
+        return rule.result;
+      }
+    }
+  }
+
+  return {
+    recoverable: input.defaultRecoverable ?? true,
+    code: input.fallbackCode ?? "UNKNOWN_ERROR",
+  };
+}

--- a/src/agents/runtime/runtime-request.ts
+++ b/src/agents/runtime/runtime-request.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+export interface AgentRuntimeRequestMetadata {
+  agentName: string;
+  rootAgentName: string;
+  subAgentNames: readonly string[];
+}

--- a/src/agents/runtime/runtime-session.ts
+++ b/src/agents/runtime/runtime-session.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+export interface AgentRuntimeSession {
+  id: string;
+  parentId?: string;
+  rootAgentName?: string;
+  metadata?: Record<string, unknown>;
+}

--- a/src/agents/tools/tool-gateway.ts
+++ b/src/agents/tools/tool-gateway.ts
@@ -1,0 +1,432 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+  createEvent,
+  createEventActions,
+  type BaseAgent,
+  type Event,
+  type InvocationContext,
+  type Session,
+} from "@google/adk";
+import type { Content } from "@google/genai";
+import { deriveSubAgentPermissionPolicy } from "../permissions/inheritance.js";
+import type { ExternalAgentPermissionPolicy } from "../permissions/schema.js";
+
+export interface RunSubAgentInput {
+  agentName: string;
+  task: string;
+}
+
+export interface RunSubAgentExecutionSummary {
+  events: number;
+  textEvents: number;
+  toolCalls: number;
+  errors: number;
+  durationMs: number;
+}
+
+export interface RunSubAgentResult {
+  agentName: string;
+  output: string;
+  events: number;
+  summary: RunSubAgentExecutionSummary;
+  stateDelta?: Record<string, unknown>;
+  error?: string;
+}
+
+export type ToolGatewayEventSink = (event: Event) => void;
+
+export interface ToolGatewayConfig {
+  rootAgent: BaseAgent;
+  subAgents: readonly BaseAgent[];
+  parentContext: InvocationContext;
+  parentPermissions?: ExternalAgentPermissionPolicy;
+  eventSink?: ToolGatewayEventSink;
+  exposeSubAgentEvents?: boolean;
+}
+
+export class ToolGateway {
+  readonly #rootAgent: BaseAgent;
+  readonly #subAgents: readonly BaseAgent[];
+  readonly #parentContext: InvocationContext;
+  readonly #parentPermissions?: ExternalAgentPermissionPolicy;
+  readonly #eventSink?: ToolGatewayEventSink;
+  readonly #exposeSubAgentEvents: boolean;
+
+  constructor(config: ToolGatewayConfig) {
+    this.#rootAgent = config.rootAgent;
+    this.#subAgents = config.subAgents;
+    this.#parentContext = config.parentContext;
+    this.#parentPermissions = config.parentPermissions;
+    this.#eventSink = config.eventSink;
+    this.#exposeSubAgentEvents = config.exposeSubAgentEvents ?? true;
+  }
+
+  listSubAgents(): readonly BaseAgent[] {
+    return this.#subAgents;
+  }
+
+  async runSubAgent(input: RunSubAgentInput): Promise<RunSubAgentResult> {
+    const agent = this.findSubAgent(input.agentName);
+    if (!agent) {
+      return {
+        agentName: input.agentName,
+        output: "",
+        events: 0,
+        summary: {
+          events: 0,
+          textEvents: 0,
+          toolCalls: 0,
+          errors: 1,
+          durationMs: 0,
+        },
+        error: `Unknown ADK subagent: ${input.agentName}`,
+      };
+    }
+
+    const callId = createBridgeCallId();
+    this.emit(this.createFunctionCallEvent(input, callId));
+
+    const startedAt = Date.now();
+    const events: Event[] = [];
+    const text: string[] = [];
+    const fallbackOutput: string[] = [];
+    const stateDelta: Record<string, unknown> = {};
+    let textEvents = 0;
+    let toolCalls = 0;
+    let errors = 0;
+    let error: string | undefined;
+
+    try {
+      const childContext = this.createChildContext(agent, input.task);
+      for await (const event of agent.runAsync(childContext)) {
+        childContext.session.events.push(event);
+        events.push(event);
+        if (this.#exposeSubAgentEvents) {
+          this.emit(enrichSubAgentEvent({
+            event,
+            rootAgentName: this.#rootAgent.name,
+            subAgentName: agent.name,
+            parentToolCallId: callId,
+          }));
+        }
+        Object.assign(stateDelta, event.actions?.stateDelta ?? {});
+        const visible = event.partial ? undefined : extractVisibleText(event);
+        if (visible) {
+          textEvents++;
+          text.push(visible);
+        } else {
+          const fallback = extractFallbackOutput(event);
+          if (fallback) {
+            fallbackOutput.push(fallback);
+          }
+        }
+        toolCalls += countFunctionCalls(event);
+        if (event.errorMessage) {
+          errors++;
+          error = event.errorMessage;
+        }
+      }
+    } catch (caught) {
+      errors++;
+      error = caught instanceof Error ? caught.message : String(caught);
+    }
+
+    const result: RunSubAgentResult = {
+      agentName: agent.name,
+      output: text.length > 0 ? text.join("\n") : fallbackOutput.join("\n"),
+      events: events.length,
+      summary: {
+        events: events.length,
+        textEvents,
+        toolCalls,
+        errors,
+        durationMs: Date.now() - startedAt,
+      },
+      ...(Object.keys(stateDelta).length > 0 ? { stateDelta } : {}),
+      ...(error ? { error } : {}),
+    };
+    this.emit(this.createFunctionResponseEvent(result, callId));
+
+    return result;
+  }
+
+  private findSubAgent(agentName: string): BaseAgent | undefined {
+    return this.#subAgents.find((agent) => agent.name === agentName) ??
+      this.#rootAgent.findSubAgent(agentName);
+  }
+
+  private createChildContext(agent: BaseAgent, task: string): InvocationContext {
+    const branch = childBranch(this.#parentContext.branch, agent.name);
+    const userContent = taskToContent(task);
+    const syntheticUserEvent = createDelegatedTaskEvent({
+      invocationId: this.#parentContext.invocationId,
+      branch,
+      content: userContent,
+    });
+
+    return {
+      ...this.#parentContext,
+      agent: this.#rootAgent,
+      branch,
+      userContent,
+      session: createChildSessionView(this.#parentContext.session, syntheticUserEvent),
+      externalAgentPermissionOverride: deriveSubAgentPermissionPolicy(
+        this.#parentPermissions,
+        readAgentPermissions(agent),
+      ),
+    } as unknown as InvocationContext;
+  }
+
+  private createFunctionCallEvent(input: RunSubAgentInput, callId: string): Event {
+    return createEvent({
+      invocationId: this.#parentContext.invocationId,
+      author: this.#parentContext.agent?.name ?? this.#rootAgent.name,
+      branch: this.#parentContext.branch,
+      customMetadata: {
+        title: `run_adk_subagent → ${input.agentName}`,
+        externalAgent: true,
+        toolName: "run_adk_subagent",
+        subAgentName: input.agentName,
+      },
+      content: {
+        role: "model",
+        parts: [
+          {
+            functionCall: {
+              id: callId,
+              name: "run_adk_subagent",
+              args: { ...input },
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  private createFunctionResponseEvent(
+    result: RunSubAgentResult,
+    callId: string,
+  ): Event {
+    const { stateDelta: _stateDelta, ...response } = result;
+    return createEvent({
+      invocationId: this.#parentContext.invocationId,
+      author: this.#parentContext.agent?.name ?? this.#rootAgent.name,
+      branch: this.#parentContext.branch,
+      customMetadata: {
+        title: `run_adk_subagent ← ${result.agentName}`,
+        externalAgent: true,
+        toolName: "run_adk_subagent",
+        subAgentName: result.agentName,
+        error: result.error,
+      },
+      actions: result.stateDelta
+        ? createEventActions({ stateDelta: result.stateDelta })
+        : undefined,
+      content: {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              id: callId,
+              name: "run_adk_subagent",
+              response,
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  private emit(event: Event): void {
+    this.#eventSink?.(event);
+  }
+}
+
+function createBridgeCallId(): string {
+  return `adk-run-subagent-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function childBranch(parentBranch: string | undefined, agentName: string): string {
+  return parentBranch ? `${parentBranch}.${agentName}` : agentName;
+}
+
+function taskToContent(task: string): Content {
+  return { role: "user", parts: [{ text: task }] };
+}
+
+function createDelegatedTaskEvent({
+  invocationId,
+  branch,
+  content,
+}: {
+  invocationId: string;
+  branch: string;
+  content: Content;
+}): Event {
+  return createEvent({
+    invocationId,
+    author: "user",
+    branch,
+    content,
+    customMetadata: {
+      externalAgent: true,
+      delegatedTask: true,
+      toolName: "run_adk_subagent",
+    },
+  });
+}
+
+function createChildSessionView(parentSession: Session | undefined, syntheticUserEvent: Event): Session {
+  return {
+    id: parentSession?.id ?? "tool-gateway-child-session",
+    appName: parentSession?.appName ?? "tool-gateway",
+    userId: parentSession?.userId ?? "tool-gateway-user",
+    state: parentSession?.state ?? {},
+    events: [...(parentSession?.events ?? []), syntheticUserEvent],
+    lastUpdateTime: parentSession?.lastUpdateTime ?? Date.now(),
+  };
+}
+
+function readAgentPermissions(agent: BaseAgent): ExternalAgentPermissionPolicy | undefined {
+  const permissions = (agent as { permissions?: unknown }).permissions;
+  return isPermissionPolicy(permissions) ? permissions : undefined;
+}
+
+function isPermissionPolicy(value: unknown): value is ExternalAgentPermissionPolicy {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "mode" in value &&
+      typeof (value as { mode?: unknown }).mode === "string",
+  );
+}
+
+function enrichSubAgentEvent({
+  event,
+  rootAgentName,
+  subAgentName,
+  parentToolCallId,
+}: {
+  event: Event;
+  rootAgentName: string;
+  subAgentName: string;
+  parentToolCallId: string;
+}): Event {
+  const metadata = (event as { customMetadata?: Record<string, unknown> }).customMetadata ?? {};
+  return {
+    ...event,
+    customMetadata: {
+      ...metadata,
+      title: readableSubAgentEventTitle(event, subAgentName),
+      externalAgent: true,
+      subAgentEvent: true,
+      parentToolName: "run_adk_subagent",
+      parentToolCallId,
+      rootAgentName,
+      subAgentName,
+    },
+  };
+}
+
+function readableSubAgentEventTitle(event: Event, subAgentName: string): string {
+  const functionCall = event.content?.parts?.find((part) => part.functionCall)?.functionCall;
+  if (functionCall?.name) {
+    return `${subAgentName}: ${functionCall.name} call${toolDetail(functionCall.args)}`;
+  }
+
+  const functionResponse = event.content?.parts?.find((part) => part.functionResponse)?.functionResponse;
+  if (functionResponse?.name) {
+    return `${subAgentName}: ${functionResponse.name} response${toolDetail(functionResponse.response)}`;
+  }
+
+  const itemType = stringValue((event as { customMetadata?: { itemType?: unknown } }).customMetadata?.itemType);
+  const status = stringValue((event as { customMetadata?: { status?: unknown } }).customMetadata?.status);
+  if (itemType) {
+    return `${subAgentName}: ${itemType}${status ? ` ${status}` : ""}`;
+  }
+
+  if (event.errorMessage) {
+    return `${subAgentName}: error ${event.errorCode ?? "EXTERNAL_AGENT_ERROR"}`;
+  }
+
+  return event.partial ? `${subAgentName}: progress` : `${subAgentName}: final response`;
+}
+
+function toolDetail(value: unknown): string {
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  const record = value as Record<string, unknown>;
+  const command = stringValue(record.command);
+  const status = stringValue(record.status);
+  const detail = command ?? status;
+  return detail ? `: ${truncate(detail, 72)}` : "";
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function countFunctionCalls(event: Event): number {
+  return event.content?.parts?.filter((part) => part.functionCall).length ?? 0;
+}
+
+function extractVisibleText(event: Event): string | undefined {
+  const parts = event.content?.parts;
+  if (!parts) {
+    return undefined;
+  }
+
+  const text = parts
+    .map((part) => part.text)
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join("");
+  return text.length > 0 ? text : undefined;
+}
+
+function extractFallbackOutput(event: Event): string | undefined {
+  if (event.errorMessage) {
+    return event.errorMessage;
+  }
+
+  const parts = event.content?.parts;
+  if (!parts) {
+    return undefined;
+  }
+
+  const output = parts
+    .map((part) => part.functionResponse?.response)
+    .map(stringifyUsefulOutput)
+    .filter((value): value is string => Boolean(value));
+
+  return output.length > 0 ? output.join("\n") : undefined;
+}
+
+function stringifyUsefulOutput(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    const output = (value as { output?: unknown }).output;
+    if (typeof output === "string" && output.length > 0) {
+      return output;
+    }
+  }
+
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized && serialized !== "{}" ? serialized : undefined;
+  } catch {
+    return String(value);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ import type {
   OpenRouterRegisterOptions,
   RegisterOptions,
   XAIRegisterOptions,
-} from "./types";
+} from "./types.js";
 
 /**
  * Mapping of provider identifiers to their configuration types.

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -29,9 +29,9 @@
  * ```
  */
 
-export { convertRequest } from "./request";
+export { convertRequest } from "./request.js";
 export {
   convertResponse,
   convertStreamChunk,
   createStreamAccumulator,
-} from "./response";
+} from "./response.js";

--- a/src/converters/request.ts
+++ b/src/converters/request.ts
@@ -20,7 +20,7 @@ import {
   type Part,
 } from "@google/genai";
 import type OpenAI from "openai";
-import { normalizeSchema } from "./schema";
+import { normalizeSchema } from "./schema.js";
 
 /**
  * Extracts the bare model name from a possibly provider-prefixed id.

--- a/src/converters/response.ts
+++ b/src/converters/response.ts
@@ -16,8 +16,8 @@
 import type { LlmResponse } from "@google/adk";
 import { FinishReason, type Part } from "@google/genai";
 import type OpenAI from "openai";
-import type { StreamAccumulator, StreamChunkResult } from "../types";
-import { safeJsonParse } from "../utils";
+import type { StreamAccumulator, StreamChunkResult } from "../types.js";
+import { safeJsonParse } from "../utils/index.js";
 
 /**
  * Maps an OpenAI `finish_reason` to the ADK/genai {@link FinishReason} enum.

--- a/src/core/base-provider-llm.ts
+++ b/src/core/base-provider-llm.ts
@@ -15,7 +15,7 @@
 
 import type { BaseLlmConnection, LlmRequest, LlmResponse } from "@google/adk";
 import { BaseLlm } from "@google/adk";
-import type { BaseProviderConfig } from "../types";
+import type { BaseProviderConfig } from "../types.js";
 
 /**
  * Abstract base class for all LLM providers in adk-llm-bridge.

--- a/src/core/config-resolver.ts
+++ b/src/core/config-resolver.ts
@@ -13,11 +13,11 @@
  * @module core/config-resolver
  */
 
-import { getProviderConfig } from "../config";
-import { DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT } from "../constants";
-import type { BaseProviderConfig } from "../types";
-import { clampPositive, requireValidURL } from "../utils/validate";
-import type { ProviderDefinition } from "./provider-definition";
+import { getProviderConfig } from "../config.js";
+import { DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT } from "../constants.js";
+import type { BaseProviderConfig } from "../types.js";
+import { clampPositive, requireValidURL } from "../utils/validate.js";
+import type { ProviderDefinition } from "./provider-definition.js";
 
 /**
  * Fully resolved configuration ready to create an OpenAI client.

--- a/src/core/create-provider.ts
+++ b/src/core/create-provider.ts
@@ -12,9 +12,9 @@
  */
 
 import type { BaseLlm } from "@google/adk";
-import type { BaseProviderConfig } from "../types";
-import { OpenAICompatibleLlm } from "./openai-compatible-llm";
-import type { ProviderDefinition } from "./provider-definition";
+import type { BaseProviderConfig } from "../types.js";
+import { OpenAICompatibleLlm } from "./openai-compatible-llm.js";
+import type { ProviderDefinition } from "./provider-definition.js";
 
 /** Type compatible with LLMRegistry.register(). */
 type RegisterableLlm = (new (params: { model: string }) => BaseLlm) & {

--- a/src/core/create-register.ts
+++ b/src/core/create-register.ts
@@ -15,8 +15,8 @@
 
 import type { BaseLlm } from "@google/adk";
 import { LLMRegistry } from "@google/adk";
-import { resetProviderConfig, setProviderConfig } from "../config";
-import type { ProviderDefinition } from "./provider-definition";
+import { resetProviderConfig, setProviderConfig } from "../config.js";
+import type { ProviderDefinition } from "./provider-definition.js";
 
 /** Type that LLMRegistry.register() expects. */
 type RegisterableLlm = (new (params: { model: string }) => BaseLlm) & {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -37,14 +37,14 @@
  * ```
  */
 
-export { BaseProviderLlm } from "./base-provider-llm";
-export type { ResolvedConfig } from "./config-resolver";
-export { resolveConfig, resolveEnvVar } from "./config-resolver";
-export { createProviderClass, createProviderFactory } from "./create-provider";
-export { createRegisterFunction } from "./create-register";
-export type { OpenAIClientConfig } from "./openai-compatible-llm";
-export { OpenAICompatibleLlm } from "./openai-compatible-llm";
+export { BaseProviderLlm } from "./base-provider-llm.js";
+export { resolveConfig, resolveEnvVar } from "./config-resolver.js";
+export type { ResolvedConfig } from "./config-resolver.js";
+export { createProviderClass, createProviderFactory } from "./create-provider.js";
+export { createRegisterFunction } from "./create-register.js";
+export type { OpenAIClientConfig } from "./openai-compatible-llm.js";
+export { OpenAICompatibleLlm } from "./openai-compatible-llm.js";
 export type {
   ProviderDefinition,
   ProviderEnvKeys,
-} from "./provider-definition";
+} from "./provider-definition.js";

--- a/src/core/openai-compatible-llm.ts
+++ b/src/core/openai-compatible-llm.ts
@@ -17,16 +17,16 @@
 
 import type { LlmRequest, LlmResponse } from "@google/adk";
 import OpenAI from "openai";
-import { convertRequest } from "../converters/request";
+import { convertRequest } from "../converters/request.js";
 import {
   convertResponse,
   convertStreamChunk,
   createStreamAccumulator,
-} from "../converters/response";
-import type { BaseProviderConfig } from "../types";
-import { BaseProviderLlm } from "./base-provider-llm";
-import { resolveConfig } from "./config-resolver";
-import type { ProviderDefinition } from "./provider-definition";
+} from "../converters/response.js";
+import type { BaseProviderConfig } from "../types.js";
+import { BaseProviderLlm } from "./base-provider-llm.js";
+import { resolveConfig } from "./config-resolver.js";
+import type { ProviderDefinition } from "./provider-definition.js";
 
 /**
  * Configuration for the underlying OpenAI client.
@@ -122,7 +122,11 @@ export class OpenAICompatibleLlm extends BaseProviderLlm {
       this._errorPrefix = "CUSTOM";
       this.client = new OpenAI({
         baseURL: clientConfig.baseURL,
-        apiKey: clientConfig.apiKey,
+        // OpenAI SDK v6.37 requires a non-empty credential at construction
+        // time. Custom OpenAI-compatible providers such as Ollama, vLLM, and
+        // LM Studio often do not require API keys, so use a harmless dummy key
+        // only for manual/custom mode when the caller intentionally omitted one.
+        apiKey: clientConfig.apiKey || "adk-llm-bridge-custom-provider",
         timeout: clientConfig.timeout,
         maxRetries: clientConfig.maxRetries,
         defaultHeaders: clientConfig.defaultHeaders,

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,9 @@ export { BaseLlm } from "@google/adk";
 // Core (for building custom providers)
 // =============================================================================
 
-export { BaseProviderLlm } from "./core/base-provider-llm";
-export type { OpenAIClientConfig } from "./core/openai-compatible-llm";
-export { OpenAICompatibleLlm } from "./core/openai-compatible-llm";
+export { BaseProviderLlm } from "./core/base-provider-llm.js";
+export type { OpenAIClientConfig } from "./core/openai-compatible-llm.js";
+export { OpenAICompatibleLlm } from "./core/openai-compatible-llm.js";
 
 // =============================================================================
 // AI Gateway Provider
@@ -84,7 +84,7 @@ export {
   AIGatewayLlm,
   isAIGatewayRegistered,
   registerAIGateway,
-} from "./providers/ai-gateway";
+} from "./providers/ai-gateway/index.js";
 
 // =============================================================================
 // OpenRouter Provider
@@ -95,7 +95,7 @@ export {
   OpenRouter,
   OpenRouterLlm,
   registerOpenRouter,
-} from "./providers/openrouter";
+} from "./providers/openrouter/index.js";
 
 // =============================================================================
 // OpenAI Provider
@@ -106,13 +106,13 @@ export {
   OpenAI,
   OpenAILlm,
   registerOpenAI,
-} from "./providers/openai";
+} from "./providers/openai/index.js";
 
 // =============================================================================
 // xAI Provider
 // =============================================================================
 
-export { isXAIRegistered, registerXAI, XAI, XAILlm } from "./providers/xai";
+export { isXAIRegistered, registerXAI, XAI, XAILlm } from "./providers/xai/index.js";
 
 // =============================================================================
 // Anthropic Provider
@@ -123,7 +123,7 @@ export {
   AnthropicLlm,
   isAnthropicRegistered,
   registerAnthropic,
-} from "./providers/anthropic";
+} from "./providers/anthropic/index.js";
 
 // =============================================================================
 // Custom LLM Provider (Any Compatible API)
@@ -134,7 +134,7 @@ export {
   CustomLlm,
   type CustomLlmProviderConfig,
   createCustomLlm,
-} from "./providers/custom";
+} from "./providers/custom/index.js";
 
 // =============================================================================
 // Types
@@ -165,7 +165,7 @@ export type {
   // xAI types
   XAIProviderConfig,
   XAIRegisterOptions,
-} from "./types";
+} from "./types.js";
 
 // =============================================================================
 // Constants
@@ -177,7 +177,7 @@ export {
   OPENROUTER_BASE_URL,
   OPENROUTER_MODEL_PATTERNS,
   PROVIDER_IDS,
-} from "./constants";
+} from "./constants.js";
 
 // =============================================================================
 // Configuration
@@ -193,7 +193,7 @@ export {
   setConfig,
   // Multi-provider API
   setProviderConfig,
-} from "./config";
+} from "./config.js";
 
 // =============================================================================
 // Converters (for building custom providers)
@@ -204,10 +204,10 @@ export {
   convertRequest,
   convertStructuredOutput,
   convertToolChoice,
-} from "./converters/request";
+} from "./converters/request.js";
 export {
   convertResponse,
   convertStreamChunk,
   createStreamAccumulator,
-} from "./converters/response";
-export { normalizeSchema } from "./converters/schema";
+} from "./converters/response.js";
+export { normalizeSchema } from "./converters/schema.js";

--- a/src/providers/ai-gateway/definition.ts
+++ b/src/providers/ai-gateway/definition.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 PAI
  * SPDX-License-Identifier: MIT
  */
-import type { ProviderDefinition } from "../../core/provider-definition";
+import type { ProviderDefinition } from "../../core/provider-definition.js";
 
 export const AI_GATEWAY_DEFINITION: ProviderDefinition = {
   id: "ai-gateway",

--- a/src/providers/ai-gateway/index.ts
+++ b/src/providers/ai-gateway/index.ts
@@ -3,11 +3,11 @@
  * Copyright 2025 PAI
  * SPDX-License-Identifier: MIT
  */
-import { createProviderClass, createProviderFactory } from "../../core/create-provider";
-import { createRegisterFunction } from "../../core/create-register";
-import { AI_GATEWAY_DEFINITION } from "./definition";
+import { createProviderClass, createProviderFactory } from "../../core/create-provider.js";
+import { createRegisterFunction } from "../../core/create-register.js";
+import { AI_GATEWAY_DEFINITION } from "./definition.js";
 
-export { AI_GATEWAY_DEFINITION } from "./definition";
+export { AI_GATEWAY_DEFINITION } from "./definition.js";
 
 export const AIGatewayLlm = createProviderClass(AI_GATEWAY_DEFINITION);
 export const AIGateway = createProviderFactory(AI_GATEWAY_DEFINITION);

--- a/src/providers/anthropic/anthropic-llm.ts
+++ b/src/providers/anthropic/anthropic-llm.ts
@@ -15,12 +15,11 @@
 
 import AnthropicSDK from "@anthropic-ai/sdk";
 import type { LlmRequest, LlmResponse } from "@google/adk";
-import { getProviderConfig } from "../../config";
-import { DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT } from "../../constants";
-import { BaseProviderLlm } from "../../core/base-provider-llm";
-import type { AnthropicProviderConfig } from "../../types";
-import { clampPositive } from "../../utils/validate";
-
+import { getProviderConfig } from "../../config.js";
+import { DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT } from "../../constants.js";
+import { BaseProviderLlm } from "../../core/base-provider-llm.js";
+import type { AnthropicProviderConfig } from "../../types.js";
+import { clampPositive } from "../../utils/validate.js";
 /** Environment variable names for Anthropic configuration. */
 const ANTHROPIC_ENV = { API_KEY: "ANTHROPIC_API_KEY" } as const;
 
@@ -36,16 +35,16 @@ export const ANTHROPIC_MODEL_PATTERNS = [/claude-.*/];
  */
 let warnedThinkingToolChoiceDowngrade = false;
 
-import type { AnthropicGenerationParams } from "./converters/request";
+import type { AnthropicGenerationParams } from "./converters/request.js";
 import {
   applyAnthropicPromptCaching,
   convertAnthropicRequest,
-} from "./converters/request";
+} from "./converters/request.js";
 import {
   convertAnthropicResponse,
   convertAnthropicStreamEvent,
   createAnthropicStreamAccumulator,
-} from "./converters/response";
+} from "./converters/response.js";
 
 /**
  * Anthropic (Claude) LLM provider.

--- a/src/providers/anthropic/converters/request.ts
+++ b/src/providers/anthropic/converters/request.ts
@@ -25,7 +25,7 @@ import {
   FunctionCallingConfigMode,
   type Part,
 } from "@google/genai";
-import { normalizeSchema as normalizeSharedSchema } from "../../../converters/schema";
+import { normalizeSchema as normalizeSharedSchema } from "../../../converters/schema.js";
 
 /** Name of the synthetic tool used to emulate structured JSON output. */
 export const JSON_OUTPUT_TOOL_NAME = "json_output";

--- a/src/providers/anthropic/converters/response.ts
+++ b/src/providers/anthropic/converters/response.ts
@@ -16,8 +16,8 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import type { LlmResponse } from "@google/adk";
 import { FinishReason, type Part } from "@google/genai";
-import { safeJsonParse } from "../../../utils";
-import { JSON_OUTPUT_TOOL_NAME } from "./request";
+import { safeJsonParse } from "../../../utils/index.js";
+import { JSON_OUTPUT_TOOL_NAME } from "./request.js";
 
 /**
  * Maps an Anthropic `stop_reason` to the ADK/genai {@link FinishReason} enum.

--- a/src/providers/anthropic/index.ts
+++ b/src/providers/anthropic/index.ts
@@ -11,26 +11,26 @@
  */
 
 import { LLMRegistry } from "@google/adk";
-import { resetProviderConfig, setProviderConfig } from "../../config";
+import { resetProviderConfig, setProviderConfig } from "../../config.js";
 import type {
   AnthropicProviderConfig,
   AnthropicRegisterOptions,
-} from "../../types";
-import { AnthropicLlm } from "./anthropic-llm";
+} from "../../types.js";
+import { AnthropicLlm } from "./anthropic-llm.js";
 
 // Re-exports
-export { ANTHROPIC_MODEL_PATTERNS, AnthropicLlm } from "./anthropic-llm";
-export type { ConvertedAnthropicRequest } from "./converters/request";
-export { convertAnthropicRequest } from "./converters/request";
+export { ANTHROPIC_MODEL_PATTERNS, AnthropicLlm } from "./anthropic-llm.js";
+export type { ConvertedAnthropicRequest } from "./converters/request.js";
+export { convertAnthropicRequest } from "./converters/request.js";
 export type {
   AnthropicStreamAccumulator,
   AnthropicStreamResult,
-} from "./converters/response";
+} from "./converters/response.js";
 export {
   convertAnthropicResponse,
   convertAnthropicStreamEvent,
   createAnthropicStreamAccumulator,
-} from "./converters/response";
+} from "./converters/response.js";
 
 /**
  * Creates an Anthropic (Claude) LLM instance.

--- a/src/providers/custom/custom-llm.ts
+++ b/src/providers/custom/custom-llm.ts
@@ -14,10 +14,10 @@
  * @module providers/custom/custom-llm
  */
 
-import { DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT } from "../../constants";
-import { OpenAICompatibleLlm } from "../../core/openai-compatible-llm";
-import type { CustomLlmConfig } from "../../types";
-import { clampPositive, requireValidURL } from "../../utils/validate";
+import { DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT } from "../../constants.js";
+import { OpenAICompatibleLlm } from "../../core/openai-compatible-llm.js";
+import type { CustomLlmConfig } from "../../types.js";
+import { clampPositive, requireValidURL } from "../../utils/validate.js";
 
 /**
  * Configuration type with required baseURL for custom providers.

--- a/src/providers/custom/factory.ts
+++ b/src/providers/custom/factory.ts
@@ -10,8 +10,8 @@
  * @module providers/custom/factory
  */
 
-import type { CustomLlmConfig } from "../../types";
-import { CustomLlm, type CustomLlmProviderConfig } from "./custom-llm";
+import type { CustomLlmConfig } from "../../types.js";
+import { CustomLlm, type CustomLlmProviderConfig } from "./custom-llm.js";
 
 /**
  * Creates a custom LLM instance.

--- a/src/providers/custom/index.ts
+++ b/src/providers/custom/index.ts
@@ -32,5 +32,5 @@
  * @module providers/custom
  */
 
-export { CustomLlm, type CustomLlmProviderConfig } from "./custom-llm";
-export { Custom, createCustomLlm } from "./factory";
+export { CustomLlm, type CustomLlmProviderConfig } from "./custom-llm.js";
+export { Custom, createCustomLlm } from "./factory.js";

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -36,9 +36,9 @@
  * ```
  */
 
-export * from "./ai-gateway";
-export * from "./anthropic";
-export * from "./custom";
-export * from "./openai";
-export * from "./openrouter";
-export * from "./xai";
+export * from "./ai-gateway/index.js";
+export * from "./anthropic/index.js";
+export * from "./custom/index.js";
+export * from "./openai/index.js";
+export * from "./openrouter/index.js";
+export * from "./xai/index.js";

--- a/src/providers/openai/definition.ts
+++ b/src/providers/openai/definition.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 PAI
  * SPDX-License-Identifier: MIT
  */
-import type { ProviderDefinition } from "../../core/provider-definition";
+import type { ProviderDefinition } from "../../core/provider-definition.js";
 
 export const OPENAI_DEFINITION: ProviderDefinition = {
   id: "openai",

--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -3,11 +3,11 @@
  * Copyright 2025 PAI
  * SPDX-License-Identifier: MIT
  */
-import { createProviderClass, createProviderFactory } from "../../core/create-provider";
-import { createRegisterFunction } from "../../core/create-register";
-import { OPENAI_DEFINITION } from "./definition";
+import { createProviderClass, createProviderFactory } from "../../core/create-provider.js";
+import { createRegisterFunction } from "../../core/create-register.js";
+import { OPENAI_DEFINITION } from "./definition.js";
 
-export { OPENAI_DEFINITION } from "./definition";
+export { OPENAI_DEFINITION } from "./definition.js";
 
 export const OpenAILlm = createProviderClass(OPENAI_DEFINITION);
 export const OpenAI = createProviderFactory(OPENAI_DEFINITION);

--- a/src/providers/openrouter/definition.ts
+++ b/src/providers/openrouter/definition.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 PAI
  * SPDX-License-Identifier: MIT
  */
-import type { ProviderDefinition } from "../../core/provider-definition";
+import type { ProviderDefinition } from "../../core/provider-definition.js";
 
 export const OPENROUTER_DEFINITION: ProviderDefinition = {
   id: "openrouter",

--- a/src/providers/openrouter/index.ts
+++ b/src/providers/openrouter/index.ts
@@ -3,11 +3,11 @@
  * Copyright 2025 PAI
  * SPDX-License-Identifier: MIT
  */
-import { createProviderClass, createProviderFactory } from "../../core/create-provider";
-import { createRegisterFunction } from "../../core/create-register";
-import { OPENROUTER_DEFINITION } from "./definition";
+import { createProviderClass, createProviderFactory } from "../../core/create-provider.js";
+import { createRegisterFunction } from "../../core/create-register.js";
+import { OPENROUTER_DEFINITION } from "./definition.js";
 
-export { OPENROUTER_DEFINITION } from "./definition";
+export { OPENROUTER_DEFINITION } from "./definition.js";
 
 export const OpenRouterLlm = createProviderClass(OPENROUTER_DEFINITION);
 export const OpenRouter = createProviderFactory(OPENROUTER_DEFINITION);

--- a/src/providers/xai/definition.ts
+++ b/src/providers/xai/definition.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 PAI
  * SPDX-License-Identifier: MIT
  */
-import type { ProviderDefinition } from "../../core/provider-definition";
+import type { ProviderDefinition } from "../../core/provider-definition.js";
 
 export const XAI_DEFINITION: ProviderDefinition = {
   id: "xai",

--- a/src/providers/xai/index.ts
+++ b/src/providers/xai/index.ts
@@ -3,11 +3,11 @@
  * Copyright 2025 PAI
  * SPDX-License-Identifier: MIT
  */
-import { createProviderClass, createProviderFactory } from "../../core/create-provider";
-import { createRegisterFunction } from "../../core/create-register";
-import { XAI_DEFINITION } from "./definition";
+import { createProviderClass, createProviderFactory } from "../../core/create-provider.js";
+import { createRegisterFunction } from "../../core/create-register.js";
+import { XAI_DEFINITION } from "./definition.js";
 
-export { XAI_DEFINITION } from "./definition";
+export { XAI_DEFINITION } from "./definition.js";
 
 export const XAILlm = createProviderClass(XAI_DEFINITION);
 export const XAI = createProviderFactory(XAI_DEFINITION);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: MIT
  */
 
-export { safeJsonParse } from "./json";
-export { clampPositive, requireNonEmpty, requireValidURL } from "./validate";
+export { safeJsonParse } from "./json.js";
+export { clampPositive, requireNonEmpty, requireValidURL } from "./validate.js";

--- a/tests/agents/claude/claude-agent-sdk.test.ts
+++ b/tests/agents/claude/claude-agent-sdk.test.ts
@@ -1,0 +1,494 @@
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { ClaudeAgent } from "../../../src/agents/claude-agent.js";
+import {
+  ClaudeAgentSdkDriver,
+  mapPolicyToClaudeSdkPermission,
+} from "../../../src/agents/driver/claude-agent-sdk.js";
+import { ClaudeCliDriver } from "../../../src/agents/driver/claude-cli.js";
+import { CLAUDE_PROVIDER } from "../../../src/agents/provider/schema.js";
+import { CODEX_PROVIDER } from "../../../src/agents/provider/schema.js";
+import { ExternalAgent } from "../../../src/agents/external-agent.js";
+
+async function materializePrompt(prompt: unknown): Promise<string> {
+  if (typeof prompt === "string") {
+    return prompt;
+  }
+  if (prompt && typeof prompt === "object" && Symbol.asyncIterator in prompt) {
+    const parts: string[] = [];
+    for await (const message of prompt as AsyncIterable<{
+      message?: { content?: Array<{ type: string; text?: string }> };
+    }>) {
+      const blocks = message.message?.content ?? [];
+      for (const block of blocks) {
+        if (block.type === "text" && typeof block.text === "string") {
+          parts.push(block.text);
+        }
+      }
+    }
+    return parts.join("\n");
+  }
+  return String(prompt);
+}
+
+describe("ClaudeAgentSdkDriver", () => {
+  test("ClaudeAgent uses the SDK driver by default", () => {
+    const agent = new ClaudeAgent({ name: "claude" });
+
+    expect(agent.driver).toBeInstanceOf(ClaudeAgentSdkDriver);
+  });
+
+  test("ClaudeAgent respects an explicit CLI fallback driver", () => {
+    const driver = new ClaudeCliDriver({ command: "claude" });
+    const agent = new ClaudeAgent({ name: "claude", driver });
+
+    expect(agent.driver).toBe(driver);
+  });
+
+  test("builds SDK options for native auth, cwd, permissions, and allowed paths", () => {
+    const driver = new ClaudeAgentSdkDriver({
+      env: {
+        PATH: "/bin",
+        HOME: "/Users/example",
+        USER: "example",
+        SHELL: "/bin/zsh",
+        CLAUDE_CONFIG_DIR: "/Users/example/.claude",
+        ANTHROPIC_API_KEY: "anthropic-key",
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+        CLAUDE_CODE_EXECUTABLE: "/tmp/claude-bin",
+        CLAUDE_CODE_PATH: "/tmp/claude-path",
+        SECRET_NOT_ALLOWED: "nope",
+      },
+      pathToClaudeCodeExecutable: "/example/bin/claude",
+      settingSources: ["user", "project", "local"],
+      maxTurns: 3,
+      model: "sonnet",
+    });
+
+    const options = driver.buildOptions({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      workingDirectory: "/repo",
+      instruction: "Be concise.",
+      permissions: { mode: "workspace-write", allowedPaths: ["/repo"] },
+      credential: {
+        kind: "env",
+        env: {
+          ANTHROPIC_API_KEY: "anthropic-key",
+          CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+          CLAUDE_CODE_EXECUTABLE: "/tmp/claude-bin",
+          CLAUDE_CODE_PATH: "/tmp/claude-path",
+          SECRET_NOT_ALLOWED: "nope",
+        },
+      },
+    });
+
+    expect(options.cwd).toBe("/repo");
+    expect(options.permissionMode).toBe("acceptEdits");
+    expect(options.additionalDirectories).toEqual(["/repo"]);
+    expect(options.pathToClaudeCodeExecutable).toBe("/example/bin/claude");
+    expect(options.settingSources).toEqual(["user", "project", "local"]);
+    expect(options.maxTurns).toBe(3);
+    expect(options.model).toBe("sonnet");
+    expect(options.env?.PATH).toBe("/bin");
+    expect(options.env?.HOME).toBe("/Users/example");
+    expect(options.env?.CLAUDE_CONFIG_DIR).toBe("/Users/example/.claude");
+    expect(options.env?.ANTHROPIC_API_KEY).toBe("anthropic-key");
+    expect(options.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-token");
+    expect(options.env?.CLAUDE_CODE_EXECUTABLE).toBe("/tmp/claude-bin");
+    expect(options.env?.CLAUDE_CODE_PATH).toBe("/tmp/claude-path");
+    expect(options.env?.SECRET_NOT_ALLOWED).toBeUndefined();
+  });
+
+  test("detects Claude Code executable from explicit environment overrides", () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-sdk-driver-"));
+    const executable = join(dir, process.platform === "win32" ? "claude.exe" : "claude");
+    writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+    chmodSync(executable, 0o755);
+    const driver = new ClaudeAgentSdkDriver({ env: { CLAUDE_CODE_EXECUTABLE: executable } });
+
+    const resolution = driver.resolveClaudeExecutable({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+    });
+    const options = driver.buildOptions({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+    });
+
+    expect(resolution.path).toBe(executable);
+    expect(options.pathToClaudeCodeExecutable).toBe(executable);
+  });
+
+  test("detects Claude Code executable from configurable search paths", () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-sdk-search-path-"));
+    const executable = join(dir, process.platform === "win32" ? "claude.exe" : "claude");
+    writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+    chmodSync(executable, 0o755);
+    const driver = new ClaudeAgentSdkDriver({
+      env: { PATH: "" },
+      executableSearchPaths: [dir],
+    });
+
+    const resolution = driver.resolveClaudeExecutable({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+    });
+
+    expect(resolution.path).toBe(executable);
+    expect(resolution.checked).toContain(executable);
+  });
+
+  test("emits actionable Claude executable lookup errors", async () => {
+    const driver = new ClaudeAgentSdkDriver({
+      env: { CLAUDE_CODE_EXECUTABLE: "/missing/claude" },
+      sdk: {
+        query: () => {
+          throw new Error("Native CLI binary for darwin-arm64 not found. Reinstall @anthropic-ai/claude-agent-sdk without --omit=optional, or set options.pathToClaudeCodeExecutable.");
+        },
+      },
+    });
+
+    const events = [];
+    for await (const event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: "started", providerId: "claude", timestamp: expect.any(Number) },
+      {
+        type: "error",
+        message: expect.stringContaining("Set CLAUDE_CODE_EXECUTABLE=/absolute/path/to/claude"),
+        code: "CLAUDE_AGENT_SDK_ERROR",
+        recoverable: true,
+        timestamp: expect.any(Number),
+      },
+      { type: "completed", exitCode: 1, timestamp: expect.any(Number) },
+    ]);
+  });
+
+  test("maps bridge permissions to Claude SDK permission modes", () => {
+    expect(mapPolicyToClaudeSdkPermission({ mode: "read-only" })).toEqual({
+      permissionMode: "plan",
+    });
+    expect(mapPolicyToClaudeSdkPermission({ mode: "ask" })).toEqual({
+      permissionMode: "default",
+    });
+    expect(mapPolicyToClaudeSdkPermission({ mode: "workspace-write" })).toEqual({
+      permissionMode: "acceptEdits",
+    });
+    expect(mapPolicyToClaudeSdkPermission({ mode: "full-access" })).toEqual({
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+    });
+  });
+
+  test("normalizes assistant and result messages", () => {
+    const driver = new ClaudeAgentSdkDriver();
+
+    expect(
+      driver.normalizeMessage({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Hello" }] },
+      } as never),
+    ).toEqual([{ type: "output", content: "Hello", timestamp: expect.any(Number) }]);
+
+    expect(
+      driver.normalizeMessage({
+        type: "result",
+        subtype: "success",
+        result: "Done",
+      } as never),
+    ).toEqual([{ type: "completed", exitCode: 0, timestamp: expect.any(Number) }]);
+  });
+
+  test("suppresses system and rate-limit diagnostics by default", () => {
+    const driver = new ClaudeAgentSdkDriver();
+
+    expect(driver.normalizeMessage({ type: "system", subtype: "init" } as never)).toEqual([]);
+    expect(driver.normalizeMessage({ type: "rate_limit_event" } as never)).toEqual([]);
+  });
+
+  test("builds SDK MCP options for ADK subagent delegation", async () => {
+    let handler: ((args: Record<string, unknown>, extra: unknown) => Promise<unknown>) | undefined;
+    const sdk = {
+      query: async function* () {},
+      tool: (
+        name: string,
+        _description: string,
+        inputSchema: Record<string, unknown>,
+        toolHandler: (args: Record<string, unknown>, extra: unknown) => Promise<unknown>,
+      ) => {
+        expect(name).toBe("run_adk_subagent");
+        expect(inputSchema.agentName).toBeDefined();
+        expect(inputSchema.task).toBeDefined();
+        handler = toolHandler;
+        return { name };
+      },
+      createSdkMcpServer: (options: Record<string, unknown>) => options,
+    };
+    const driver = new ClaudeAgentSdkDriver({ sdk });
+    const subAgent = new ExternalAgent({ name: "CodexImplementer", provider: CODEX_PROVIDER });
+    const result = { agentName: "CodexImplementer", output: "done", events: 1 };
+    const options = await driver.buildOptionsForRun(
+      {
+        provider: CLAUDE_PROVIDER,
+        context: {} as never,
+        subAgents: [subAgent],
+        toolGateway: {
+          runSubAgent: async (input: unknown) => {
+            expect(input).toEqual({ agentName: "CodexImplementer", task: "patch" });
+            return result;
+          },
+        } as never,
+      },
+      sdk,
+    );
+
+    expect(options.mcpServers?.adk_bridge).toMatchObject({
+      name: "adk_bridge",
+      tools: [{ name: "run_adk_subagent" }],
+    });
+    expect(options.allowedTools).toContain("mcp__adk_bridge__run_adk_subagent");
+    await expect(handler?.({ agentName: "CodexImplementer", task: "patch" }, {})).resolves.toEqual({
+      content: [{ type: "text", text: "done" }],
+    });
+  });
+
+  test("buildPrompt includes prior session history alongside userContent", async () => {
+    let capturedPrompt: unknown;
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: ({ prompt }) => {
+          capturedPrompt = prompt;
+          return (async function* () {
+            yield { type: "result", subtype: "success", result: "ok" } as never;
+          })() as never;
+        },
+      },
+    });
+
+    for await (const _event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: {
+        agent: { name: "claude" },
+        branch: "root",
+        session: {
+          events: [
+            {
+              author: "user",
+              content: { role: "user", parts: [{ text: "first question" }] },
+            },
+            {
+              author: "claude",
+              content: { role: "model", parts: [{ text: "earlier reply" }] },
+            },
+          ],
+        },
+        userContent: { role: "user", parts: [{ text: "follow-up question" }] },
+      } as never,
+      permissions: { mode: "ask" },
+    })) {
+      // consume events
+      void _event;
+    }
+
+    const flattened = await materializePrompt(capturedPrompt);
+    expect(flattened).toContain("first question");
+    expect(flattened).toContain("earlier reply");
+    expect(flattened).toContain("follow-up question");
+  });
+
+  test("text-only single-turn invocation passes a string prompt", async () => {
+    let capturedPrompt: unknown;
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: ({ prompt }) => {
+          capturedPrompt = prompt;
+          return (async function* () {
+            yield { type: "result", subtype: "success", result: "ok" } as never;
+          })() as never;
+        },
+      },
+    });
+
+    for await (const _event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: {
+        agent: { name: "claude" },
+        branch: "root",
+        session: { events: [] },
+        userContent: { role: "user", parts: [{ text: "hello" }] },
+      } as never,
+      permissions: { mode: "ask" },
+    })) {
+      void _event;
+    }
+
+    expect(typeof capturedPrompt).toBe("string");
+    expect(capturedPrompt).toContain("hello");
+  });
+
+  test("multimodal history yields async iterable of SDK user messages", async () => {
+    let capturedPrompt: unknown;
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: ({ prompt }) => {
+          capturedPrompt = prompt;
+          return (async function* () {
+            yield { type: "result", subtype: "success", result: "ok" } as never;
+          })() as never;
+        },
+      },
+    });
+
+    for await (const _event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: {
+        agent: { name: "claude" },
+        branch: "root",
+        session: {
+          events: [
+            {
+              author: "user",
+              content: {
+                role: "user",
+                parts: [
+                  { text: "look at this" },
+                  { inlineData: { mimeType: "image/png", data: "AAAA" } },
+                ],
+              },
+            },
+          ],
+        },
+        userContent: {
+          role: "user",
+          parts: [
+            { text: "look at this" },
+            { inlineData: { mimeType: "image/png", data: "AAAA" } },
+          ],
+        },
+      } as never,
+      permissions: { mode: "ask" },
+    })) {
+      void _event;
+    }
+
+    expect(typeof capturedPrompt).not.toBe("string");
+    expect(capturedPrompt).toBeDefined();
+    const iterable = capturedPrompt as AsyncIterable<{
+      message: { content: Array<{ type: string; source?: { media_type?: string } }> };
+    }>;
+    const collected: Array<{
+      message: { content: Array<{ type: string; source?: { media_type?: string } }> };
+    }> = [];
+    for await (const message of iterable) {
+      collected.push(message);
+    }
+    expect(collected.length).toBeGreaterThan(0);
+    const allBlocks = collected.flatMap((m) => m.message.content);
+    const imageBlock = allBlocks.find((b) => b.type === "image");
+    expect(imageBlock).toBeDefined();
+    expect(imageBlock?.source?.media_type).toBe("image/png");
+  });
+
+  test("resumeSessionId sends only the current turn and forwards resume option", async () => {
+    let capturedPrompt: unknown;
+    let capturedOptions: { resume?: string } | undefined;
+    const driver = new ClaudeAgentSdkDriver({
+      resumeSessionId: "session-xyz",
+      sdk: {
+        query: ({ prompt, options }) => {
+          capturedPrompt = prompt;
+          capturedOptions = options as { resume?: string };
+          return (async function* () {
+            yield { type: "result", subtype: "success", result: "ok" } as never;
+          })() as never;
+        },
+      },
+    });
+
+    for await (const _event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: {
+        agent: { name: "claude" },
+        branch: "root",
+        session: {
+          events: [
+            {
+              author: "user",
+              content: { role: "user", parts: [{ text: "first" }] },
+            },
+            {
+              author: "claude",
+              content: { role: "model", parts: [{ text: "reply" }] },
+            },
+          ],
+        },
+        userContent: { role: "user", parts: [{ text: "follow-up" }] },
+      } as never,
+      permissions: { mode: "ask" },
+    })) {
+      void _event;
+    }
+
+    expect(capturedOptions?.resume).toBe("session-xyz");
+    expect(typeof capturedPrompt).not.toBe("string");
+    const iterable = capturedPrompt as AsyncIterable<{
+      message: { content: Array<{ type: string; text?: string }> };
+    }>;
+    const collected: Array<{
+      message: { content: Array<{ type: string; text?: string }> };
+    }> = [];
+    for await (const message of iterable) {
+      collected.push(message);
+    }
+    expect(collected).toHaveLength(1);
+    const text = collected[0].message.content
+      .filter((b) => b.type === "text")
+      .map((b) => b.text)
+      .join("");
+    expect(text).toBe("follow-up");
+  });
+
+  test("run uses injected SDK without importing the real package", async () => {
+    let called = false;
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: ({ prompt, options }) => {
+          called = true;
+          expect(prompt).toBe("Review this");
+          expect(options?.permissionMode).toBe("default");
+          return (async function* () {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: "Looks good." }] },
+            } as never;
+            yield { type: "result", subtype: "success", result: "Complete" } as never;
+          })() as never;
+        },
+      },
+    });
+
+    const events = [];
+    for await (const event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: { userContent: { parts: [{ text: "Review this" }] } } as never,
+      permissions: { mode: "ask" },
+    })) {
+      events.push(event);
+    }
+
+    expect(called).toBe(true);
+    expect(events.map((event) => event.type)).toEqual([
+      "started",
+      "output",
+      "completed",
+    ]);
+  });
+});

--- a/tests/agents/claude/claude-agent-sdk.test.ts
+++ b/tests/agents/claude/claude-agent-sdk.test.ts
@@ -2,7 +2,10 @@ import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
-import { ClaudeAgent } from "../../../src/agents/claude-agent.js";
+import {
+  ClaudeAgent,
+  CLAUDE_AGENT_DEFINITION,
+} from "../../../src/agents/claude-agent.js";
 import {
   ClaudeAgentSdkDriver,
   mapPolicyToClaudeSdkPermission,
@@ -173,9 +176,12 @@ describe("ClaudeAgentSdkDriver", () => {
   });
 
   test("maps bridge permissions to Claude SDK permission modes", () => {
-    expect(mapPolicyToClaudeSdkPermission({ mode: "read-only" })).toEqual({
-      permissionMode: "plan",
-    });
+    // PERM-1: read-only must NOT map to interactive planning mode ("plan"),
+    // which refuses tool execution; it maps to "default" so Q&A/read-only tools
+    // still run while write/edit stays gated.
+    const readOnly = mapPolicyToClaudeSdkPermission({ mode: "read-only" });
+    expect(readOnly).toEqual({ permissionMode: "default" });
+    expect(readOnly.permissionMode).not.toBe("plan");
     expect(mapPolicyToClaudeSdkPermission({ mode: "ask" })).toEqual({
       permissionMode: "default",
     });
@@ -491,4 +497,349 @@ describe("ClaudeAgentSdkDriver", () => {
       "completed",
     ]);
   });
+
+  // --- AUTH-1: SDK isolation via settingSources default ---
+  test("defaults settingSources to [] (SDK isolation), not omitted", () => {
+    const driver = new ClaudeAgentSdkDriver();
+
+    const options = driver.buildOptions({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "ask" },
+    });
+
+    // The key must be PRESENT (not stripped by removeUndefined) and empty,
+    // so the SDK does not load host user/project/local settings.
+    expect("settingSources" in options).toBe(true);
+    expect(options.settingSources).toEqual([]);
+  });
+
+  test("allows opting back into specific settingSources", () => {
+    const driver = new ClaudeAgentSdkDriver({ settingSources: ["project"] });
+
+    const options = driver.buildOptions({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "ask" },
+    });
+
+    expect(options.settingSources).toEqual(["project"]);
+  });
+
+  // --- LIFECYCLE-1: abortController + interrupt()/return() teardown ---
+  test("sets an abortController on options wired to the run abort signal", () => {
+    const driver = new ClaudeAgentSdkDriver();
+    const controller = new AbortController();
+
+    const options = driver.buildOptions({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "ask" },
+      abortSignal: controller.signal,
+    });
+
+    expect(options.abortController).toBeInstanceOf(AbortController);
+    expect(options.abortController?.signal.aborted).toBe(false);
+    controller.abort();
+    expect(options.abortController?.signal.aborted).toBe(true);
+  });
+
+  test("interrupts and returns the Query when the consumer breaks early", async () => {
+    let interrupted = false;
+    let returned = false;
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: () => {
+          const gen = (async function* () {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: "one" }] },
+            } as never;
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: "two" }] },
+            } as never;
+            yield { type: "result", subtype: "success", result: "done" } as never;
+          })();
+          return Object.assign(gen, {
+            interrupt: async () => {
+              interrupted = true;
+            },
+            return: async (value?: unknown) => {
+              returned = true;
+              return gen.return(value as never);
+            },
+          });
+        },
+      },
+    });
+
+    for await (const event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: { userContent: { parts: [{ text: "hi" }] } } as never,
+      permissions: { mode: "ask" },
+    })) {
+      if (event.type === "output") {
+        break; // early break after the first output
+      }
+    }
+
+    expect(interrupted).toBe(true);
+    expect(returned).toBe(true);
+  });
+
+  test("returns the Query on normal completion without interrupting", async () => {
+    let interrupted = false;
+    let returned = false;
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: () => {
+          const gen = (async function* () {
+            yield { type: "result", subtype: "success", result: "done" } as never;
+          })();
+          return Object.assign(gen, {
+            interrupt: async () => {
+              interrupted = true;
+            },
+            return: async (value?: unknown) => {
+              returned = true;
+              return gen.return(value as never);
+            },
+          });
+        },
+      },
+    });
+
+    for await (const _event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: { userContent: { parts: [{ text: "hi" }] } } as never,
+      permissions: { mode: "ask" },
+    })) {
+      void _event;
+    }
+
+    // Completed normally: no interrupt needed, but return() still finalizes.
+    expect(interrupted).toBe(false);
+    expect(returned).toBe(true);
+  });
+
+  // --- ERR-2: typed error classification ---
+  test("classifies assistant/result error subtypes as (non-)recoverable", () => {
+    const driver = new ClaudeAgentSdkDriver();
+
+    const cases: Array<{
+      message: ClaudeAgentSdkMessageInput;
+      recoverable: boolean;
+      code?: string;
+    }> = [
+      {
+        message: { type: "assistant", error: "authentication_failed" },
+        recoverable: false,
+        code: "CLAUDE_AUTH_ERROR",
+      },
+      {
+        message: { type: "assistant", error: "billing_error" },
+        recoverable: false,
+        code: "CLAUDE_BILLING_ERROR",
+      },
+      {
+        message: { type: "assistant", error: "rate_limit" },
+        recoverable: true,
+        code: "CLAUDE_RATE_LIMIT",
+      },
+      {
+        message: { type: "assistant", error: "server_error" },
+        recoverable: true,
+        code: "CLAUDE_SERVER_ERROR",
+      },
+      {
+        message: { type: "result", subtype: "error_max_turns", errors: ["max turns"] },
+        recoverable: false,
+        code: "error_max_turns",
+      },
+      {
+        message: {
+          type: "result",
+          subtype: "error_max_budget_usd",
+          errors: ["budget"],
+        },
+        recoverable: false,
+        code: "error_max_budget_usd",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const events = driver.normalizeMessage(testCase.message as never);
+      const errorEvent = events.find((event) => event.type === "error");
+      expect(errorEvent).toBeDefined();
+      if (errorEvent?.type === "error") {
+        expect(errorEvent.recoverable).toBe(testCase.recoverable);
+        if (testCase.code) {
+          expect(errorEvent.code).toBe(testCase.code);
+        }
+      }
+    }
+  });
+
+  test("run catch classifies auth errors as non-recoverable", async () => {
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: () => {
+          throw new Error("401 Unauthorized: invalid api key");
+        },
+      },
+    });
+
+    const events = [];
+    for await (const event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "ask" },
+    })) {
+      events.push(event);
+    }
+
+    const errorEvent = events.find((event) => event.type === "error");
+    expect(errorEvent).toBeDefined();
+    if (errorEvent?.type === "error") {
+      expect(errorEvent.recoverable).toBe(false);
+    }
+  });
+
+  // --- ERR-2 / ERR-1-guard: permission-denied enrichment ---
+  test("appends tool_name and decision_reason to permission-denied (keeps base message)", () => {
+    const driver = new ClaudeAgentSdkDriver();
+
+    const events = driver.normalizeMessage({
+      type: "system",
+      subtype: "permission_denied",
+      message: "Permission to run Bash was denied",
+      tool_name: "Bash",
+      decision_reason: "rule: deny dangerous commands",
+    } as never);
+
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.type).toBe("error");
+    if (event.type === "error") {
+      // Base message (ERR-1 refuted) MUST be preserved...
+      expect(event.message).toContain("Permission to run Bash was denied");
+      // ...and enriched with tool_name + decision_reason.
+      expect(event.message).toContain("Bash");
+      expect(event.message).toContain("rule: deny dangerous commands");
+      expect(event.code).toBe("CLAUDE_PERMISSION_DENIED");
+      expect(event.recoverable).toBe(false);
+    }
+  });
+
+  // --- ERR-3: result success fallback ---
+  test("falls back to result.result when no assistant text was streamed", async () => {
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: () =>
+          (async function* () {
+            yield {
+              type: "result",
+              subtype: "success",
+              result: "final aggregated answer",
+            } as never;
+          })() as never,
+      },
+    });
+
+    const outputs: string[] = [];
+    for await (const event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: { userContent: { parts: [{ text: "hi" }] } } as never,
+      permissions: { mode: "ask" },
+    })) {
+      if (event.type === "output") {
+        outputs.push(event.content);
+      }
+    }
+
+    expect(outputs).toContain("final aggregated answer");
+  });
+
+  test("does NOT duplicate output when assistant text already streamed", async () => {
+    const driver = new ClaudeAgentSdkDriver({
+      sdk: {
+        query: () =>
+          (async function* () {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: "streamed answer" }] },
+            } as never;
+            yield {
+              type: "result",
+              subtype: "success",
+              result: "streamed answer",
+            } as never;
+          })() as never,
+      },
+    });
+
+    const outputs: string[] = [];
+    for await (const event of driver.run({
+      provider: CLAUDE_PROVIDER,
+      context: { userContent: { parts: [{ text: "hi" }] } } as never,
+      permissions: { mode: "ask" },
+    })) {
+      if (event.type === "output") {
+        outputs.push(event.content);
+      }
+    }
+
+    expect(outputs).toEqual(["streamed answer"]);
+  });
+
+  // --- AUTH-2: plain-string system prompt opt-in ---
+  test("uses preset+append system prompt by default", () => {
+    const driver = new ClaudeAgentSdkDriver();
+
+    const options = driver.buildOptions({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "ask" },
+      instruction: "Be concise.",
+    });
+
+    expect(options.systemPrompt).toEqual({
+      type: "preset",
+      preset: "claude_code",
+      append: "Be concise.",
+    });
+  });
+
+  test("honors a configured plain-string system prompt", () => {
+    const driver = new ClaudeAgentSdkDriver({
+      systemPrompt: "You are a helpful Q&A assistant.",
+    });
+
+    const withInstruction = driver.buildOptions({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "ask" },
+      instruction: "Answer briefly.",
+    });
+    expect(typeof withInstruction.systemPrompt).toBe("string");
+    expect(withInstruction.systemPrompt).toContain(
+      "You are a helpful Q&A assistant.",
+    );
+    expect(withInstruction.systemPrompt).toContain("Answer briefly.");
+
+    const noInstruction = driver.buildOptions({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "ask" },
+    });
+    expect(noInstruction.systemPrompt).toBe("You are a helpful Q&A assistant.");
+  });
+
+  // --- STREAM-1: capability claim matches actual behavior ---
+  test("does not advertise token-level streaming", () => {
+    expect(CLAUDE_AGENT_DEFINITION.capabilities.streaming).toBe(false);
+  });
 });
+
+type ClaudeAgentSdkMessageInput = Record<string, unknown>;

--- a/tests/agents/claude/claude-cli.test.ts
+++ b/tests/agents/claude/claude-cli.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ClaudeCliDriver,
+  mapClaudePermissionArgs,
+} from "../../../src/agents/driver/claude-cli.js";
+import { CLAUDE_PROVIDER } from "../../../src/agents/provider/schema.js";
+
+describe("Claude CLI provider", () => {
+  test("declares native, OAuth, and cloud auth environment allowlist", () => {
+    expect(CLAUDE_PROVIDER.envAllowlist).toContain("ANTHROPIC_API_KEY");
+    expect(CLAUDE_PROVIDER.envAllowlist).toContain("ANTHROPIC_AUTH_TOKEN");
+    expect(CLAUDE_PROVIDER.envAllowlist).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(CLAUDE_PROVIDER.envAllowlist).toContain("CLAUDE_CONFIG_DIR");
+    expect(CLAUDE_PROVIDER.envAllowlist).toContain("CLAUDE_CODE_USE_BEDROCK");
+    expect(CLAUDE_PROVIDER.envAllowlist).toContain("CLAUDE_CODE_USE_VERTEX");
+    expect(CLAUDE_PROVIDER.envAllowlist).toContain("CLAUDE_CODE_USE_FOUNDRY");
+  });
+
+  test("CLI fallback driver can be constructed without auth side effects", () => {
+    const driver = new ClaudeCliDriver({ command: "claude" });
+
+    expect(driver.providerId).toBe(CLAUDE_PROVIDER.id);
+    expect(driver.command).toBe("claude");
+  });
+});
+
+describe("ClaudeCliDriver", () => {
+  test("builds claude stream-json command args", () => {
+    const driver = new ClaudeCliDriver();
+    const args = driver.buildArgs({
+      provider: CLAUDE_PROVIDER,
+      context: { userContent: { parts: [{ text: "Review this diff" }] } } as never,
+      instruction: "You are a reviewer.",
+      permissions: { mode: "ask" },
+    });
+
+    expect(args).toEqual([
+      "-p",
+      "You are a reviewer.\n\nReview this diff",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--permission-mode",
+      "default",
+    ]);
+  });
+
+  test("passes native auth home/config and only allowlisted credential env vars", () => {
+    const driver = new ClaudeCliDriver({
+      env: {
+        PATH: "/bin",
+        HOME: "/Users/example",
+        USER: "example",
+        SHELL: "/bin/zsh",
+        CLAUDE_CONFIG_DIR: "/Users/example/.claude",
+        ANTHROPIC_API_KEY: "anthropic-key",
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+        SECRET_NOT_ALLOWED: "nope",
+      },
+    });
+
+    const env = driver.buildEnv({
+      provider: CLAUDE_PROVIDER,
+      context: {} as never,
+      credential: {
+        kind: "env",
+        env: {
+          ANTHROPIC_API_KEY: "anthropic-key",
+          CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+          SECRET_NOT_ALLOWED: "nope",
+        },
+      },
+    });
+
+    expect(env.PATH).toBe("/bin");
+    expect(env.HOME).toBe("/Users/example");
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/Users/example/.claude");
+    expect(env.ANTHROPIC_API_KEY).toBe("anthropic-key");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-token");
+    expect(env.SECRET_NOT_ALLOWED).toBeUndefined();
+  });
+
+  test("normalizes Claude stream-json assistant events", () => {
+    const driver = new ClaudeCliDriver();
+    const event = driver.parseClaudeLine(
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Looks good." }] },
+      }),
+    );
+
+    expect(event).toMatchObject({
+      type: "output",
+      content: "Looks good.",
+    });
+  });
+
+  test("suppresses Claude lifecycle diagnostics", () => {
+    const driver = new ClaudeCliDriver();
+
+    expect(
+      driver.parseClaudeLine(
+        JSON.stringify({ type: "system", subtype: "init", session_id: "s1" }),
+      ),
+    ).toBeUndefined();
+    expect(
+      driver.parseClaudeLine(JSON.stringify({ type: "rate_limit_event" })),
+    ).toBeUndefined();
+  });
+
+  test("maps permission presets to Claude permission modes", () => {
+    expect(mapClaudePermissionArgs({ mode: "read-only" })).toEqual([
+      "--permission-mode",
+      "plan",
+    ]);
+    expect(mapClaudePermissionArgs({ mode: "ask" })).toEqual([
+      "--permission-mode",
+      "default",
+    ]);
+    expect(mapClaudePermissionArgs({ mode: "workspace-write" })).toEqual([
+      "--permission-mode",
+      "acceptEdits",
+    ]);
+    expect(mapClaudePermissionArgs({ mode: "full-access" })).toEqual([
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+  });
+});

--- a/tests/agents/claude/claude-message-mapper.test.ts
+++ b/tests/agents/claude/claude-message-mapper.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Content } from "@google/genai";
+import {
+  type ClaudeDocumentBlockParam,
+  type ClaudeImageBlockParam,
+  type ClaudeTextBlockParam,
+  type ClaudeToolResultBlockParam,
+  type ClaudeToolUseBlockParam,
+  contentsToSdkMessages,
+} from "../../../src/agents/driver/claude-message-mapper.js";
+
+describe("contentsToSdkMessages", () => {
+  test("single text-only user content emits one message with shouldQuery", () => {
+    const contents: Content[] = [
+      { role: "user", parts: [{ text: "hello" }] },
+    ];
+    const messages = contentsToSdkMessages(contents);
+    expect(messages).toHaveLength(1);
+    const message = messages[0];
+    expect(message.type).toBe("user");
+    expect(message.parent_tool_use_id).toBeNull();
+    expect(message.shouldQuery).toBe(true);
+    expect(message.isSynthetic).toBeUndefined();
+    expect(message.message.role).toBe("user");
+    expect(message.message.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  test("multi-turn history marks earlier messages synthetic and last shouldQuery", () => {
+    const contents: Content[] = [
+      { role: "user", parts: [{ text: "first" }] },
+      { role: "model", parts: [{ text: "reply" }] },
+    ];
+    const messages = contentsToSdkMessages(contents);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].isSynthetic).toBe(true);
+    expect(messages[0].shouldQuery).toBe(false);
+    expect(messages[0].message.role).toBe("user");
+    expect(messages[1].shouldQuery).toBe(true);
+    expect(messages[1].isSynthetic).toBeUndefined();
+    expect(messages[1].message.role).toBe("assistant");
+  });
+
+  test("inlineData PNG becomes base64 image block", () => {
+    const contents: Content[] = [
+      {
+        role: "user",
+        parts: [
+          {
+            inlineData: { mimeType: "image/png", data: "AAAA" },
+          },
+        ],
+      },
+    ];
+    const [message] = contentsToSdkMessages(contents);
+    const block = message.message.content[0] as ClaudeImageBlockParam;
+    expect(block.type).toBe("image");
+    expect(block.source.type).toBe("base64");
+    if (block.source.type === "base64") {
+      expect(block.source.media_type).toBe("image/png");
+      expect(block.source.data).toBe("AAAA");
+    }
+  });
+
+  test("inlineData PDF becomes base64 document block", () => {
+    const contents: Content[] = [
+      {
+        role: "user",
+        parts: [
+          {
+            inlineData: { mimeType: "application/pdf", data: "BBBB" },
+          },
+        ],
+      },
+    ];
+    const [message] = contentsToSdkMessages(contents);
+    const block = message.message.content[0] as ClaudeDocumentBlockParam;
+    expect(block.type).toBe("document");
+    expect(block.source.type).toBe("base64");
+    if (block.source.type === "base64") {
+      expect(block.source.media_type).toBe("application/pdf");
+      expect(block.source.data).toBe("BBBB");
+    }
+  });
+
+  test("fileData with https URL becomes URL document block", () => {
+    const contents: Content[] = [
+      {
+        role: "user",
+        parts: [
+          {
+            fileData: {
+              fileUri: "https://example.com/file.pdf",
+              mimeType: "application/pdf",
+            },
+          },
+        ],
+      },
+    ];
+    const [message] = contentsToSdkMessages(contents);
+    const block = message.message.content[0] as ClaudeDocumentBlockParam;
+    expect(block.type).toBe("document");
+    expect(block.source.type).toBe("url");
+    if (block.source.type === "url") {
+      expect(block.source.url).toBe("https://example.com/file.pdf");
+    }
+  });
+
+  test("fileData with gs:// URI falls back to text marker", () => {
+    const contents: Content[] = [
+      {
+        role: "user",
+        parts: [
+          {
+            fileData: { fileUri: "gs://bucket/file.bin", mimeType: "application/octet-stream" },
+          },
+        ],
+      },
+    ];
+    const [message] = contentsToSdkMessages(contents);
+    const block = message.message.content[0] as ClaudeTextBlockParam;
+    expect(block.type).toBe("text");
+    expect(block.text).toBe("[file: gs://bucket/file.bin (application/octet-stream)]");
+  });
+
+  test("functionCall on model content emits tool_use with assistant role", () => {
+    const contents: Content[] = [
+      {
+        role: "model",
+        parts: [
+          { functionCall: { id: "call-1", name: "lookup", args: { q: "x" } } },
+        ],
+      },
+    ];
+    const [message] = contentsToSdkMessages(contents);
+    expect(message.message.role).toBe("assistant");
+    const block = message.message.content[0] as ClaudeToolUseBlockParam;
+    expect(block.type).toBe("tool_use");
+    expect(block.id).toBe("call-1");
+    expect(block.name).toBe("lookup");
+    expect(block.input).toEqual({ q: "x" });
+  });
+
+  test("functionResponse forces user role and emits tool_result", () => {
+    const contents: Content[] = [
+      {
+        role: "model",
+        parts: [
+          {
+            functionResponse: {
+              id: "call-1",
+              name: "lookup",
+              response: { value: 42 },
+            },
+          },
+        ],
+      },
+    ];
+    const [message] = contentsToSdkMessages(contents);
+    expect(message.message.role).toBe("user");
+    const block = message.message.content[0] as ClaudeToolResultBlockParam;
+    expect(block.type).toBe("tool_result");
+    expect(block.tool_use_id).toBe("call-1");
+    expect(block.content).toBe('{"value":42}');
+  });
+
+  test("thought parts are dropped", () => {
+    const contents: Content[] = [
+      {
+        role: "model",
+        parts: [
+          { text: "kept" },
+          { thought: true, text: "hidden" },
+        ],
+      },
+    ];
+    const [message] = contentsToSdkMessages(contents);
+    expect(message.message.content).toEqual([{ type: "text", text: "kept" }]);
+  });
+
+  test("content with only thought parts is not emitted", () => {
+    const contents: Content[] = [
+      { role: "model", parts: [{ thought: true, text: "hidden" }] },
+      { role: "user", parts: [{ text: "real" }] },
+    ];
+    const messages = contentsToSdkMessages(contents);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message.role).toBe("user");
+  });
+
+  test("missing tool IDs are generated deterministically", () => {
+    const contents: Content[] = [
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "go", args: {} } }],
+      },
+    ];
+    const first = contentsToSdkMessages(contents);
+    const second = contentsToSdkMessages(contents);
+    const blockA = first[0].message.content[0] as ClaudeToolUseBlockParam;
+    const blockB = second[0].message.content[0] as ClaudeToolUseBlockParam;
+    expect(blockA.id).toBe("tool_0_0");
+    expect(blockA.id).toBe(blockB.id);
+  });
+});

--- a/tests/agents/codex/codex-cli.test.ts
+++ b/tests/agents/codex/codex-cli.test.ts
@@ -1,0 +1,223 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { InvocationContext } from "@google/adk";
+import {
+  CODEX_PROVIDER,
+  CodexAgent,
+  CodexCliDriver,
+  type CodexCliSpawn,
+  type ExternalAgentRunRequest,
+  mapPolicyToCodexArgs,
+} from "../../../src/agents/index.js";
+
+function context(input = "user request"): InvocationContext {
+  return { input } as unknown as InvocationContext;
+}
+
+function request(
+  overrides: Partial<ExternalAgentRunRequest> = {},
+): ExternalAgentRunRequest {
+  return {
+    provider: CODEX_PROVIDER,
+    context: context(),
+    instruction: "system instruction",
+    workingDirectory: "/repo",
+    ...overrides,
+  };
+}
+
+async function* chunks(lines: readonly string[]): AsyncIterable<string> {
+  for (const line of lines) {
+    yield `${line}\n`;
+  }
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of iterable) {
+    result.push(item);
+  }
+  return result;
+}
+
+describe("Codex CLI driver", () => {
+  test("builds codex exec --json command with safe default permissions", async () => {
+    const calls: Array<{
+      command: string;
+      args: readonly string[];
+      cwd?: string;
+    }> = [];
+    const spawn: CodexCliSpawn = (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd });
+      return { stdout: chunks([]), exited: Promise.resolve(0) };
+    };
+
+    const driver = new CodexCliDriver({ spawn });
+    await collect(driver.run(request()));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("codex");
+    expect(calls[0].cwd).toBe("/repo");
+    expect(calls[0].args).toEqual([
+      "--ask-for-approval",
+      "never",
+      "exec",
+      "--json",
+      "--sandbox",
+      "read-only",
+      "system instruction\n\nuser request",
+    ]);
+  });
+
+  test("passes only Codex allowlisted credential environment values", async () => {
+    let capturedEnv: Record<string, string> | undefined;
+    const spawn: CodexCliSpawn = (_command, _args, options) => {
+      capturedEnv = options.env;
+      return { stdout: chunks([]), exited: Promise.resolve(0) };
+    };
+
+    const driver = new CodexCliDriver({
+      spawn,
+      env: {
+        PATH: "/bin",
+        HOME: "/Users/example",
+        USER: "example",
+        SHELL: "/bin/zsh",
+        XDG_CONFIG_HOME: "/Users/example/.config",
+        OPENAI_API_KEY: "blocked",
+        SECRET_TOKEN: "blocked",
+      },
+    });
+
+    await collect(
+      driver.run(
+        request({
+          credential: {
+            kind: "env",
+            env: {
+              CODEX_API_KEY: "codex-key",
+              CODEX_HOME: "/tmp/codex-home",
+              CODEX_EXECUTABLE: "/tmp/codex-bin",
+              CODEX_CLI_PATH: "/tmp/codex-cli",
+              CODEX_CA_CERTIFICATE: "/tmp/ca.pem",
+              SSL_CERT_FILE: "/tmp/ssl.pem",
+              OPENAI_API_KEY: "blocked",
+              SECRET_TOKEN: "blocked",
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(capturedEnv).toEqual({
+      PATH: "/bin",
+      HOME: "/Users/example",
+      USER: "example",
+      SHELL: "/bin/zsh",
+      XDG_CONFIG_HOME: "/Users/example/.config",
+      CODEX_API_KEY: "codex-key",
+      CODEX_HOME: "/tmp/codex-home",
+      CODEX_EXECUTABLE: "/tmp/codex-bin",
+      CODEX_CLI_PATH: "/tmp/codex-cli",
+      CODEX_CA_CERTIFICATE: "/tmp/ca.pem",
+      SSL_CERT_FILE: "/tmp/ssl.pem",
+    });
+  });
+
+  test("normalizes Codex JSONL events", async () => {
+    const spawn: CodexCliSpawn = () => ({
+      stdout: chunks([
+        JSON.stringify({ type: "thread.started", id: "run-1" }),
+        JSON.stringify({ type: "response.output_text.delta", delta: "hello" }),
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "item-1", type: "agent_message", text: "final" },
+        }),
+        JSON.stringify({
+          type: "tool_call.created",
+          name: "shell",
+          input: { cmd: "ls" },
+        }),
+        JSON.stringify({ type: "turn.completed", exit_code: 0 }),
+      ]),
+      exited: Promise.resolve(0),
+    });
+
+    const events = await collect(new CodexCliDriver({ spawn }).run(request()));
+
+    expect(events).toContainEqual({
+      type: "started",
+      providerId: "codex",
+      runId: "run-1",
+      timestamp: undefined,
+    });
+    expect(events).toContainEqual({
+      type: "output",
+      content: "hello",
+      stream: "stdout",
+      timestamp: undefined,
+    });
+    expect(events).toContainEqual({
+      type: "output",
+      content: "final",
+      stream: "stdout",
+      timestamp: undefined,
+    });
+    expect(events).toContainEqual({
+      type: "tool_call",
+      name: "shell",
+      input: { cmd: "ls" },
+      timestamp: undefined,
+    });
+    expect(events).toContainEqual({
+      type: "completed",
+      exitCode: 0,
+      timestamp: undefined,
+    });
+  });
+
+  test("maps bridge permissions to current Codex global and exec flags", () => {
+    expect(mapPolicyToCodexArgs()).toEqual([
+      "--ask-for-approval",
+      "never",
+      "exec",
+      "--json",
+      "--sandbox",
+      "read-only",
+    ]);
+    expect(mapPolicyToCodexArgs({ mode: "ask" })).toEqual([
+      "--ask-for-approval",
+      "on-request",
+      "exec",
+      "--json",
+      "--sandbox",
+      "workspace-write",
+    ]);
+    expect(mapPolicyToCodexArgs({ mode: "workspace-write" })).toEqual([
+      "--ask-for-approval",
+      "never",
+      "exec",
+      "--json",
+      "--sandbox",
+      "workspace-write",
+    ]);
+    expect(mapPolicyToCodexArgs({ mode: "full-access" })).toEqual([
+      "--dangerously-bypass-approvals-and-sandbox",
+      "exec",
+      "--json",
+    ]);
+  });
+
+  test("CodexAgent accepts an explicit CLI fallback driver", () => {
+    const driver = new CodexCliDriver();
+    const agent = new CodexAgent({ name: "codex", driver });
+
+    expect(agent.provider).toEqual(CODEX_PROVIDER);
+    expect(agent.driver).toBe(driver);
+  });
+});

--- a/tests/agents/codex/codex-input-mapper.test.ts
+++ b/tests/agents/codex/codex-input-mapper.test.ts
@@ -1,0 +1,176 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  summarizeHistoryForColdStart,
+  userContentToCodexInput,
+} from "../../../src/agents/driver/codex-input-mapper.js";
+
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00,
+]);
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+
+function freshTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "codex-mapper-test-"));
+}
+
+describe("userContentToCodexInput", () => {
+  test("single text part becomes a plain string with a no-op cleanup", async () => {
+    const mapping = userContentToCodexInput({
+      role: "user",
+      parts: [{ text: "hello" }],
+    });
+    expect(mapping.input).toBe("hello");
+    // cleanup is safe even when no tmp files exist.
+    await mapping.cleanup();
+  });
+
+  test("two text parts produce an array of two text entries", async () => {
+    const mapping = userContentToCodexInput({
+      role: "user",
+      parts: [{ text: "alpha" }, { text: "beta" }],
+    });
+    expect(mapping.input).toEqual([
+      { type: "text", text: "alpha" },
+      { type: "text", text: "beta" },
+    ]);
+    await mapping.cleanup();
+  });
+
+  test("PNG inlineData writes a tmp file and cleanup removes it", async () => {
+    const dir = freshTmpDir();
+    const mapping = userContentToCodexInput(
+      {
+        role: "user",
+        parts: [
+          {
+            inlineData: {
+              mimeType: "image/png",
+              data: PNG_BYTES.toString("base64"),
+            },
+          },
+          { text: "describe" },
+        ],
+      },
+      { tmpDir: dir, idPrefix: "png" },
+    );
+
+    expect(Array.isArray(mapping.input)).toBe(true);
+    const parts = mapping.input as Array<
+      { type: "text"; text: string } | { type: "local_image"; path: string }
+    >;
+    expect(parts[0].type).toBe("local_image");
+    const imagePath = (parts[0] as { path: string }).path;
+    expect(imagePath.endsWith(".png")).toBe(true);
+    expect(existsSync(imagePath)).toBe(true);
+    expect(readFileSync(imagePath)).toEqual(PNG_BYTES);
+
+    await mapping.cleanup();
+    expect(existsSync(imagePath)).toBe(false);
+  });
+
+  test("JPEG inlineData uses a .jpg extension", async () => {
+    const dir = freshTmpDir();
+    const mapping = userContentToCodexInput(
+      {
+        role: "user",
+        parts: [
+          {
+            inlineData: {
+              mimeType: "image/jpeg",
+              data: JPEG_BYTES.toString("base64"),
+            },
+          },
+        ],
+      },
+      { tmpDir: dir, idPrefix: "jpeg" },
+    );
+
+    const parts = mapping.input as Array<{ type: string; path?: string }>;
+    expect(parts[0].type).toBe("local_image");
+    expect(parts[0].path?.endsWith(".jpg")).toBe(true);
+    await mapping.cleanup();
+  });
+
+  test("mixed text + image preserves input order", async () => {
+    const dir = freshTmpDir();
+    const mapping = userContentToCodexInput(
+      {
+        role: "user",
+        parts: [
+          { text: "before" },
+          {
+            inlineData: {
+              mimeType: "image/png",
+              data: PNG_BYTES.toString("base64"),
+            },
+          },
+          { text: "after" },
+        ],
+      },
+      { tmpDir: dir, idPrefix: "mix" },
+    );
+    const parts = mapping.input as Array<{ type: string }>;
+    expect(parts.map((p) => p.type)).toEqual(["text", "local_image", "text"]);
+    await mapping.cleanup();
+  });
+
+  test("fileData becomes a [file: ...] marker", () => {
+    const mapping = userContentToCodexInput({
+      role: "user",
+      parts: [
+        {
+          fileData: {
+            mimeType: "application/pdf",
+            fileUri: "gs://bucket/doc.pdf",
+          },
+        },
+        { text: "summarize" },
+      ],
+    });
+    const parts = mapping.input as Array<{ type: string; text?: string }>;
+    expect(parts[0].text).toBe("[file: gs://bucket/doc.pdf (application/pdf)]");
+  });
+
+  test("functionCall becomes a [tool_call ...] marker", () => {
+    const mapping = userContentToCodexInput({
+      role: "user",
+      parts: [
+        { functionCall: { name: "search", args: { q: "ADK" } } },
+        { text: "go" },
+      ],
+    });
+    const parts = mapping.input as Array<{ type: string; text?: string }>;
+    expect(parts[0].text).toBe(`[tool_call search({"q":"ADK"})]`);
+  });
+
+  test("thought parts are dropped", () => {
+    const mapping = userContentToCodexInput({
+      role: "user",
+      parts: [
+        { text: "reasoning omitted", thought: true },
+        { text: "ask" },
+      ],
+    });
+    expect(mapping.input).toBe("ask");
+  });
+});
+
+describe("summarizeHistoryForColdStart", () => {
+  test("returns empty string for an empty list", () => {
+    expect(summarizeHistoryForColdStart([])).toBe("");
+  });
+
+  test("includes all roles except the last current-turn content", () => {
+    const transcript = summarizeHistoryForColdStart([
+      { role: "user", parts: [{ text: "Q1" }] },
+      { role: "model", parts: [{ text: "A1" }] },
+      { role: "user", parts: [{ text: "Q2 (current)" }] },
+    ]);
+    expect(transcript).toContain("Q1");
+    expect(transcript).toContain("A1");
+    expect(transcript).not.toContain("Q2 (current)");
+  });
+});

--- a/tests/agents/codex/codex-sdk.test.ts
+++ b/tests/agents/codex/codex-sdk.test.ts
@@ -1,0 +1,620 @@
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { CodexAgent } from "../../../src/agents/codex-agent.js";
+import { CodexCliDriver } from "../../../src/agents/driver/codex-cli.js";
+import {
+  CodexSdkDriver,
+  mapPolicyToCodexSdkThreadOptions,
+} from "../../../src/agents/driver/codex-sdk.js";
+import { CODEX_PROVIDER } from "../../../src/agents/provider/schema.js";
+
+async function* sdkEvents(events: readonly Record<string, unknown>[]) {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+describe("CodexSdkDriver", () => {
+  test("CodexAgent uses the SDK driver by default", () => {
+    const agent = new CodexAgent({ name: "codex" });
+
+    expect(agent.driver).toBeInstanceOf(CodexSdkDriver);
+  });
+
+  test("CodexAgent respects an explicit CLI fallback driver", () => {
+    const driver = new CodexCliDriver({ command: "codex" });
+    const agent = new CodexAgent({ name: "codex", driver });
+
+    expect(agent.driver).toBe(driver);
+  });
+
+  test("builds client options with native auth env and allowlisted credentials", () => {
+    const driver = new CodexSdkDriver({
+      env: {
+        PATH: "/bin",
+        HOME: "/Users/example",
+        USER: "example",
+        SHELL: "/bin/zsh",
+        XDG_CONFIG_HOME: "/Users/example/.config",
+        OPENAI_API_KEY: "blocked",
+        SECRET_NOT_ALLOWED: "blocked",
+      },
+      codexPathOverride: "/example/bin/codex",
+      baseUrl: "https://example.test/v1",
+      config: { show_raw_agent_reasoning: true },
+    });
+
+    const options = driver.buildClientOptions({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+      credential: {
+        kind: "env",
+        env: {
+          CODEX_API_KEY: "codex-key",
+          CODEX_HOME: "/tmp/codex-home",
+          CODEX_EXECUTABLE: "/tmp/codex-bin",
+          CODEX_CLI_PATH: "/tmp/codex-cli",
+          CODEX_CA_CERTIFICATE: "/tmp/ca.pem",
+          SSL_CERT_FILE: "/tmp/ssl.pem",
+          OPENAI_API_KEY: "blocked",
+        },
+      },
+    });
+
+    expect(options).toEqual({
+      codexPathOverride: "/example/bin/codex",
+      baseUrl: "https://example.test/v1",
+      apiKey: "codex-key",
+      config: { show_raw_agent_reasoning: true },
+      env: {
+        PATH: "/bin",
+        HOME: "/Users/example",
+        USER: "example",
+        SHELL: "/bin/zsh",
+        XDG_CONFIG_HOME: "/Users/example/.config",
+        CODEX_API_KEY: "codex-key",
+        CODEX_HOME: "/tmp/codex-home",
+        CODEX_EXECUTABLE: "/tmp/codex-bin",
+        CODEX_CLI_PATH: "/tmp/codex-cli",
+        CODEX_CA_CERTIFICATE: "/tmp/ca.pem",
+        SSL_CERT_FILE: "/tmp/ssl.pem",
+      },
+    });
+  });
+
+  test("detects Codex binary from explicit environment overrides", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-sdk-driver-"));
+    const executable = join(dir, process.platform === "win32" ? "codex.exe" : "codex");
+    writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+    chmodSync(executable, 0o755);
+    const driver = new CodexSdkDriver({ env: { CODEX_EXECUTABLE: executable } });
+
+    const resolution = driver.resolveCodexBinary({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+    });
+    const options = driver.buildClientOptions({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+    });
+
+    expect(resolution.path).toBe(executable);
+    expect(options.codexPathOverride).toBe(executable);
+  });
+
+  test("emits actionable Codex binary lookup errors", async () => {
+    const driver = new CodexSdkDriver({
+      env: { CODEX_EXECUTABLE: "/missing/codex" },
+      Codex: class {
+        startThread() {
+          throw new Error("Unable to locate Codex CLI binaries. Ensure @openai/codex is installed with optional dependencies.");
+        }
+        resumeThread() {
+          throw new Error("not used");
+        }
+      },
+    });
+
+    const events = [];
+    for await (const event of driver.run({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: "started", providerId: "codex", timestamp: expect.any(Number) },
+      {
+        type: "error",
+        message: expect.stringContaining("Set CODEX_EXECUTABLE=/absolute/path/to/codex"),
+        code: "CODEX_SDK_ERROR",
+        recoverable: true,
+        timestamp: expect.any(Number),
+      },
+      { type: "completed", exitCode: 1, timestamp: expect.any(Number) },
+    ]);
+  });
+
+  test("maps bridge permissions to Codex SDK thread options", () => {
+    expect(mapPolicyToCodexSdkThreadOptions()).toEqual({
+      sandboxMode: "read-only",
+      approvalPolicy: "never",
+    });
+    expect(mapPolicyToCodexSdkThreadOptions({ mode: "ask" })).toEqual({
+      sandboxMode: "workspace-write",
+      approvalPolicy: "on-request",
+    });
+    expect(mapPolicyToCodexSdkThreadOptions({ mode: "workspace-write" })).toEqual({
+      sandboxMode: "workspace-write",
+      approvalPolicy: "never",
+    });
+    expect(mapPolicyToCodexSdkThreadOptions({ mode: "full-access" })).toEqual({
+      sandboxMode: "danger-full-access",
+      approvalPolicy: "never",
+    });
+    expect(
+      mapPolicyToCodexSdkThreadOptions({
+        mode: "read-only",
+        allowNetwork: true,
+        allowedPaths: ["/repo"],
+      }),
+    ).toEqual({
+      sandboxMode: "read-only",
+      approvalPolicy: "never",
+      networkAccessEnabled: true,
+      additionalDirectories: ["/repo"],
+    });
+  });
+
+  test("run uses injected SDK and normalizes streamed events", async () => {
+    let startThreadOptions: unknown;
+    let runInput: unknown;
+    const driver = new CodexSdkDriver({
+      sdk: {
+        startThread: (options) => {
+          startThreadOptions = options;
+          return {
+            runStreamed: async (input) => {
+              runInput = input;
+              return {
+                events: sdkEvents([
+                  { type: "thread.started", thread_id: "thread-1" },
+                  {
+                    type: "item.completed",
+                    item: { id: "item-1", type: "agent_message", text: "Done" },
+                  },
+                  {
+                    type: "item.completed",
+                    item: {
+                      id: "item-2",
+                      type: "command_execution",
+                      command: "pwd",
+                      status: "completed",
+                      exit_code: 0,
+                    },
+                  },
+                  { type: "turn.completed", usage: { input_tokens: 1 } },
+                ]),
+              };
+            },
+          };
+        },
+        resumeThread: () => {
+          throw new Error("not used");
+        },
+      },
+    });
+
+    const events = [];
+    for await (const event of driver.run({
+      provider: CODEX_PROVIDER,
+      context: { userContent: { parts: [{ text: "Review this" }] } } as never,
+      instruction: "Be concise.",
+      workingDirectory: "/repo",
+      permissions: { mode: "read-only" },
+    })) {
+      events.push(event);
+    }
+
+    expect(startThreadOptions).toMatchObject({
+      workingDirectory: "/repo",
+      sandboxMode: "read-only",
+      approvalPolicy: "never",
+    });
+    expect(runInput).toBe("Be concise.\n\nReview this");
+    expect(events).toEqual([
+      { type: "started", providerId: "codex", timestamp: expect.any(Number) },
+      { type: "output", content: "Done", stream: "stdout", timestamp: expect.any(Number) },
+      {
+        type: "tool_call",
+        name: "command_execution",
+        input: { command: "pwd", status: "completed", exitCode: 0 },
+        callId: "item-2",
+        metadata: {
+          itemType: "command_execution",
+          status: "completed",
+          command: "pwd",
+          title: "Codex: command_execution call",
+        },
+        timestamp: expect.any(Number),
+      },
+      {
+        type: "tool_result",
+        name: "command_execution",
+        result: { command: "pwd", status: "completed", exitCode: 0 },
+        callId: "item-2",
+        metadata: {
+          itemType: "command_execution",
+          status: "completed",
+          command: "pwd",
+          exitCode: 0,
+          title: "Codex: command_execution completed",
+        },
+        timestamp: expect.any(Number),
+      },
+      { type: "completed", exitCode: 0, timestamp: expect.any(Number) },
+    ]);
+  });
+
+  test("buildPrompt includes prior session history alongside userContent", async () => {
+    let capturedInput = "";
+    const driver = new CodexSdkDriver({
+      sdk: {
+        startThread: () => ({
+          runStreamed: async (input) => {
+            capturedInput = String(input);
+            return {
+              events: sdkEvents([{ type: "turn.completed" }]),
+            };
+          },
+        }),
+        resumeThread: () => {
+          throw new Error("not used");
+        },
+      },
+    });
+
+    for await (const _event of driver.run({
+      provider: CODEX_PROVIDER,
+      context: {
+        agent: { name: "codex" },
+        branch: "root",
+        session: {
+          events: [
+            {
+              author: "user",
+              content: { role: "user", parts: [{ text: "first question" }] },
+            },
+            {
+              author: "codex",
+              content: { role: "model", parts: [{ text: "earlier reply" }] },
+            },
+          ],
+        },
+        userContent: { role: "user", parts: [{ text: "follow-up question" }] },
+      } as never,
+      permissions: { mode: "read-only" },
+    })) {
+      void _event;
+    }
+
+    expect(capturedInput).toContain("first question");
+    expect(capturedInput).toContain("earlier reply");
+    expect(capturedInput).toContain("follow-up question");
+  });
+
+  test("normalizes mcp_tool_call progress without duplicate function calls", () => {
+    const driver = new CodexSdkDriver();
+
+    expect(
+      driver.normalizeEvent({
+        type: "item.updated",
+        item: {
+          id: "mcp-1",
+          type: "mcp_tool_call",
+          tool: "search_docs",
+          status: "in_progress",
+          server: "docs",
+          arguments: { query: "ADK" },
+        },
+      }),
+    ).toEqual([
+      {
+        type: "output",
+        content: "Codex MCP tool in_progress: search_docs",
+        partial: true,
+        turnComplete: false,
+        metadata: {
+          itemType: "mcp_tool_call",
+          toolName: "search_docs",
+          status: "in_progress",
+          title: "Codex: search_docs in_progress",
+        },
+        timestamp: expect.any(Number),
+      },
+    ]);
+
+    expect(
+      driver.normalizeEvent({
+        type: "item.completed",
+        item: {
+          id: "mcp-1",
+          type: "mcp_tool_call",
+          tool: "search_docs",
+          status: "completed",
+          server: "docs",
+          arguments: { query: "ADK" },
+          result: { hits: 2 },
+        },
+      }),
+    ).toEqual([
+      {
+        type: "tool_call",
+        name: "search_docs",
+        input: {
+          server: "docs",
+          arguments: { query: "ADK" },
+          status: "completed",
+        },
+        callId: "mcp-1",
+        metadata: {
+          itemType: "mcp_tool_call",
+          status: "completed",
+          title: "Codex: search_docs call",
+        },
+        timestamp: expect.any(Number),
+      },
+      {
+        type: "tool_result",
+        name: "search_docs",
+        result: {
+          server: "docs",
+          status: "completed",
+          result: { hits: 2 },
+          error: undefined,
+        },
+        callId: "mcp-1",
+        error: undefined,
+        metadata: {
+          itemType: "mcp_tool_call",
+          status: "completed",
+          title: "Codex: search_docs completed",
+        },
+        timestamp: expect.any(Number),
+      },
+    ]);
+  });
+
+  test("first invocation emits state_delta carrying the new thread id", async () => {
+    let startCalls = 0;
+    let resumeCalls = 0;
+    let runInput: unknown;
+    const driver = new CodexSdkDriver({
+      sdk: {
+        startThread: () => {
+          startCalls++;
+          return {
+            id: "thread-test-123",
+            runStreamed: async (input) => {
+              runInput = input;
+              return {
+                events: sdkEvents([
+                  { type: "thread.started", thread_id: "thread-test-123" },
+                  {
+                    type: "item.completed",
+                    item: { id: "item-1", type: "agent_message", text: "Hi" },
+                  },
+                  { type: "turn.completed", usage: { input_tokens: 1 } },
+                ]),
+              };
+            },
+          } as never;
+        },
+        resumeThread: () => {
+          resumeCalls++;
+          throw new Error("should not resume");
+        },
+      },
+    });
+
+    const session = { state: {} as Record<string, unknown>, events: [] };
+    const events = [];
+    for await (const event of driver.run({
+      provider: CODEX_PROVIDER,
+      agent: { name: "codex" } as never,
+      context: {
+        agent: { name: "codex" },
+        session,
+        userContent: { role: "user", parts: [{ text: "hello" }] },
+      } as never,
+      permissions: { mode: "read-only" },
+    })) {
+      events.push(event);
+    }
+
+    expect(startCalls).toBe(1);
+    expect(resumeCalls).toBe(0);
+    expect(runInput).toBe("hello");
+    const stateDeltaEvent = events.find((e) => e.type === "state_delta");
+    expect(stateDeltaEvent).toEqual({
+      type: "state_delta",
+      stateDelta: { "codex_thread:codex": "thread-test-123" },
+      timestamp: expect.any(Number),
+    });
+
+    // Drive the state_delta through ExternalAgent and confirm the resulting
+    // ADK Event carries actions.stateDelta so ADK's session machinery would
+    // apply the delta.
+    const { ExternalAgent } = await import(
+      "../../../src/agents/external-agent.js"
+    );
+    const adkEvent = new (class extends ExternalAgent {
+      expose(ev: unknown, ctx: unknown) {
+        return (this as unknown as {
+          toAdkEvent: (e: unknown, c: unknown) => unknown;
+        }).toAdkEvent(ev, ctx);
+      }
+    })({ name: "codex", provider: CODEX_PROVIDER }).expose(stateDeltaEvent, {
+      invocationId: "inv-1",
+      branch: "root",
+    });
+    expect((adkEvent as { actions?: { stateDelta?: unknown } }).actions?.stateDelta)
+      .toEqual({ "codex_thread:codex": "thread-test-123" });
+  });
+
+  test("second invocation resumes the saved thread and sends only the current turn", async () => {
+    let startCalls = 0;
+    let resumeId: string | undefined;
+    let runInput: unknown;
+    const driver = new CodexSdkDriver({
+      sdk: {
+        startThread: () => {
+          startCalls++;
+          throw new Error("should not start a new thread");
+        },
+        resumeThread: (id) => {
+          resumeId = id;
+          return {
+            id,
+            runStreamed: async (input) => {
+              runInput = input;
+              return {
+                events: sdkEvents([
+                  {
+                    type: "item.completed",
+                    item: { id: "item-2", type: "agent_message", text: "ok" },
+                  },
+                  { type: "turn.completed", usage: { input_tokens: 1 } },
+                ]),
+              };
+            },
+          } as never;
+        },
+      },
+    });
+
+    const events = [];
+    for await (const event of driver.run({
+      provider: CODEX_PROVIDER,
+      agent: { name: "codex" } as never,
+      context: {
+        agent: { name: "codex" },
+        session: {
+          state: { "codex_thread:codex": "saved-thread-9" },
+          events: [
+            {
+              author: "user",
+              content: { role: "user", parts: [{ text: "first question" }] },
+            },
+            {
+              author: "codex",
+              content: { role: "model", parts: [{ text: "earlier reply" }] },
+            },
+          ],
+        },
+        userContent: { role: "user", parts: [{ text: "follow-up" }] },
+      } as never,
+      permissions: { mode: "read-only" },
+    })) {
+      events.push(event);
+    }
+
+    expect(startCalls).toBe(0);
+    expect(resumeId).toBe("saved-thread-9");
+    expect(runInput).toBe("follow-up");
+    expect(String(runInput)).not.toContain("first question");
+    expect(String(runInput)).not.toContain("earlier reply");
+    expect(events.some((e) => e.type === "state_delta")).toBe(false);
+  });
+
+  test("cold start with history prepends transcript before the current turn", async () => {
+    let capturedInput: unknown;
+    const driver = new CodexSdkDriver({
+      sdk: {
+        startThread: () => ({
+          id: "thread-cold-1",
+          runStreamed: async (input) => {
+            capturedInput = input;
+            return {
+              events: sdkEvents([{ type: "turn.completed" }]),
+            };
+          },
+        }) as never,
+        resumeThread: () => {
+          throw new Error("not used");
+        },
+      },
+    });
+
+    for await (const _event of driver.run({
+      provider: CODEX_PROVIDER,
+      agent: { name: "codex" } as never,
+      context: {
+        agent: { name: "codex" },
+        branch: "root",
+        session: {
+          state: {},
+          events: [
+            {
+              author: "user",
+              content: { role: "user", parts: [{ text: "first question" }] },
+            },
+            {
+              author: "codex",
+              content: { role: "model", parts: [{ text: "earlier reply" }] },
+            },
+          ],
+        },
+        userContent: { role: "user", parts: [{ text: "follow-up question" }] },
+      } as never,
+      permissions: { mode: "read-only" },
+    })) {
+      void _event;
+    }
+
+    expect(typeof capturedInput).toBe("string");
+    const text = String(capturedInput);
+    expect(text).toContain("first question");
+    expect(text).toContain("earlier reply");
+    expect(text).toContain("follow-up question");
+    // Transcript prefix must precede the current turn text.
+    expect(text.indexOf("first question")).toBeLessThan(
+      text.indexOf("follow-up question"),
+    );
+  });
+
+  test("normalizes failures and item errors", () => {
+    const driver = new CodexSdkDriver();
+
+    expect(
+      driver.normalizeEvent({
+        type: "item.completed",
+        item: { id: "item-1", type: "error", message: "bad item" },
+      }),
+    ).toEqual([
+      {
+        type: "error",
+        message: "bad item",
+        code: "CODEX_ITEM_ERROR",
+        recoverable: true,
+        timestamp: expect.any(Number),
+      },
+    ]);
+
+    expect(
+      driver.normalizeEvent({ type: "turn.failed", error: { message: "failed" } }),
+    ).toEqual([
+      {
+        type: "error",
+        message: "failed",
+        code: "CODEX_TURN_FAILED",
+        recoverable: true,
+        timestamp: expect.any(Number),
+      },
+      { type: "completed", exitCode: 1, timestamp: expect.any(Number) },
+    ]);
+  });
+});

--- a/tests/agents/codex/codex-sdk.test.ts
+++ b/tests/agents/codex/codex-sdk.test.ts
@@ -130,8 +130,10 @@ describe("CodexSdkDriver", () => {
       {
         type: "error",
         message: expect.stringContaining("Set CODEX_EXECUTABLE=/absolute/path/to/codex"),
-        code: "CODEX_SDK_ERROR",
-        recoverable: true,
+        // A missing-binary condition is non-recoverable: retrying without
+        // installing the binary is futile (CODEX-5).
+        code: "MISSING_BINARY",
+        recoverable: false,
         timestamp: expect.any(Number),
       },
       { type: "completed", exitCode: 1, timestamp: expect.any(Number) },
@@ -616,5 +618,300 @@ describe("CodexSdkDriver", () => {
       },
       { type: "completed", exitCode: 1, timestamp: expect.any(Number) },
     ]);
+  });
+
+  // ===========================================================================
+  // CODEX-3: env passthrough (proxy/cert/CODEX_HOME) + CODEX_ACCESS_TOKEN
+  // ===========================================================================
+
+  test("CODEX_ENV_ALLOWLIST includes CODEX_ACCESS_TOKEN", () => {
+    expect(CODEX_PROVIDER.envAllowlist).toContain("CODEX_ACCESS_TOKEN");
+  });
+
+  test("buildEnv forwards ambient proxy/cert/CODEX_HOME vars and CODEX_ACCESS_TOKEN", () => {
+    const driver = new CodexSdkDriver({
+      env: {
+        PATH: "/bin",
+        HOME: "/home/example",
+        HTTPS_PROXY: "http://proxy.internal:3128",
+        https_proxy: "http://proxy.internal:3128",
+        HTTP_PROXY: "http://proxy.internal:3128",
+        http_proxy: "http://proxy.internal:3128",
+        NO_PROXY: "localhost,127.0.0.1",
+        no_proxy: "localhost,127.0.0.1",
+        SSL_CERT_FILE: "/etc/ssl/cert.pem",
+        SSL_CERT_DIR: "/etc/ssl/certs",
+        CODEX_HOME: "/home/example/.codex",
+        IRRELEVANT: "dropped",
+      },
+    });
+
+    const env = driver.buildEnv({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+      credential: {
+        kind: "env",
+        env: { CODEX_ACCESS_TOKEN: "tok-123" },
+      },
+    });
+
+    expect(env).toMatchObject({
+      PATH: "/bin",
+      HOME: "/home/example",
+      HTTPS_PROXY: "http://proxy.internal:3128",
+      https_proxy: "http://proxy.internal:3128",
+      HTTP_PROXY: "http://proxy.internal:3128",
+      http_proxy: "http://proxy.internal:3128",
+      NO_PROXY: "localhost,127.0.0.1",
+      no_proxy: "localhost,127.0.0.1",
+      SSL_CERT_FILE: "/etc/ssl/cert.pem",
+      SSL_CERT_DIR: "/etc/ssl/certs",
+      CODEX_HOME: "/home/example/.codex",
+      CODEX_ACCESS_TOKEN: "tok-123",
+    });
+    expect(env.IRRELEVANT).toBeUndefined();
+  });
+
+  test("credential CODEX_HOME overrides the ambient CODEX_HOME", () => {
+    const driver = new CodexSdkDriver({
+      env: { CODEX_HOME: "/ambient/.codex" },
+    });
+
+    const env = driver.buildEnv({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+      credential: { kind: "env", env: { CODEX_HOME: "/credential/.codex" } },
+    });
+
+    expect(env.CODEX_HOME).toBe("/credential/.codex");
+  });
+
+  // ===========================================================================
+  // CODEX-4: thread.started captures the id immediately (resumability survives
+  // a mid-turn throw).
+  // ===========================================================================
+
+  test("emits state_delta from thread.started even when the stream throws mid-turn", async () => {
+    const driver = new CodexSdkDriver({
+      sdk: {
+        startThread: () =>
+          ({
+            // `id` is null until a turn completes; resumability must come from
+            // the thread.started event, not this accessor.
+            id: null,
+            runStreamed: async () => ({
+              // eslint-disable-next-line require-yield
+              events: (async function* () {
+                yield { type: "thread.started", thread_id: "thread-mid-fail" };
+                throw new Error("boom mid-turn");
+              })(),
+            }),
+          }) as never,
+        resumeThread: () => {
+          throw new Error("not used");
+        },
+      },
+    });
+
+    const events = [];
+    for await (const event of driver.run({
+      provider: CODEX_PROVIDER,
+      agent: { name: "codex" } as never,
+      context: {
+        agent: { name: "codex" },
+        session: { state: {} },
+        userContent: { role: "user", parts: [{ text: "hi" }] },
+      } as never,
+      permissions: { mode: "read-only" },
+    })) {
+      events.push(event);
+    }
+
+    const stateDelta = events.find((e) => e.type === "state_delta");
+    expect(stateDelta).toEqual({
+      type: "state_delta",
+      stateDelta: { "codex_thread:codex": "thread-mid-fail" },
+      timestamp: expect.any(Number),
+    });
+    // The mid-turn throw is still surfaced as an error + completed(1).
+    expect(events.some((e) => e.type === "error")).toBe(true);
+    // Exactly one state_delta (no duplicate from the post-loop accessor).
+    expect(events.filter((e) => e.type === "state_delta")).toHaveLength(1);
+  });
+
+  // ===========================================================================
+  // CODEX-5: error classification — auth/missing-binary non-recoverable;
+  // transport recoverable.
+  // ===========================================================================
+
+  test.each([
+    ["401 Unauthorized: invalid api key", false, "AUTH_ERROR"],
+    ["Request failed: 403 Forbidden", false, "AUTH_ERROR"],
+    [
+      "Unable to locate Codex CLI binaries. Ensure @openai/codex is installed.",
+      false,
+      "MISSING_BINARY",
+    ],
+    ["billing_error: insufficient credit", false, "BILLING_ERROR"],
+    ["rate limit exceeded, please retry", true, "RATE_LIMIT"],
+    ["connection timed out", true, "TRANSPORT_ERROR"],
+  ])(
+    "run() classifies thrown error %p as recoverable=%p (%s)",
+    async (message, recoverable, code) => {
+      const driver = new CodexSdkDriver({
+        Codex: class {
+          startThread() {
+            throw new Error(message as string);
+          }
+          resumeThread() {
+            throw new Error("not used");
+          }
+        },
+      });
+
+      const events = [];
+      for await (const event of driver.run({
+        provider: CODEX_PROVIDER,
+        context: {} as never,
+      })) {
+        events.push(event);
+      }
+
+      const error = events.find((e) => e.type === "error") as
+        | { recoverable: boolean; code: string }
+        | undefined;
+      expect(error).toBeDefined();
+      expect(error?.recoverable).toBe(recoverable as boolean);
+      expect(error?.code).toBe(code as string);
+    },
+  );
+
+  test("turn.failed with a 401 message is non-recoverable", () => {
+    const driver = new CodexSdkDriver();
+    const [error] = driver.normalizeEvent({
+      type: "turn.failed",
+      error: { message: "401 unauthorized — invalid credentials" },
+    });
+    expect(error).toMatchObject({
+      type: "error",
+      recoverable: false,
+      code: "AUTH_ERROR",
+    });
+  });
+
+  // ===========================================================================
+  // CODEX-7: web search forwarded only when network access is enabled.
+  // ===========================================================================
+
+  test("drops webSearch options when allowNetwork is false", () => {
+    const driver = new CodexSdkDriver({
+      webSearchMode: "live",
+      webSearchEnabled: true,
+    });
+
+    const options = driver.buildThreadOptions({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "read-only", allowNetwork: false },
+    });
+
+    expect(options.webSearchMode).toBeUndefined();
+    expect(options.webSearchEnabled).toBeUndefined();
+  });
+
+  test("forwards webSearch options when allowNetwork is true", () => {
+    const driver = new CodexSdkDriver({
+      webSearchMode: "live",
+      webSearchEnabled: true,
+    });
+
+    const options = driver.buildThreadOptions({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+      permissions: { mode: "read-only", allowNetwork: true },
+    });
+
+    expect(options.networkAccessEnabled).toBe(true);
+    expect(options.webSearchMode).toBe("live");
+    expect(options.webSearchEnabled).toBe(true);
+  });
+});
+
+// ===========================================================================
+// CODEX-1: example credential guard keys on real Codex signals (not "codex on
+// PATH"); driver adds no OPENAI_API_KEY fallback to credential resolution.
+// ===========================================================================
+
+describe("basic-agent-codex credential guard (CODEX-1)", () => {
+  const CRED_KEYS = [
+    "CODEX_API_KEY",
+    "OPENAI_API_KEY",
+    "CODEX_EXECUTABLE",
+    "CODEX_CLI_PATH",
+    "CODEX_HOME",
+  ] as const;
+
+  function withClearedEnv<T>(fn: () => T): T {
+    const saved: Record<string, string | undefined> = {};
+    for (const key of CRED_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    try {
+      return fn();
+    } finally {
+      for (const key of CRED_KEYS) {
+        if (saved[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = saved[key];
+        }
+      }
+    }
+  }
+
+  test("returns true for a readable auth.json with no PATH binary, false for none", async () => {
+    const { codexCredentialsAvailable } = await import(
+      "../../../examples/basic-agent-codex/agent.ts"
+    );
+
+    await withClearedEnv(async () => {
+      // No credential at all → false (an absent CODEX_HOME points at
+      // ~/.codex/auth.json which does not exist in CI).
+      process.env.CODEX_HOME = join(
+        mkdtempSync(join(tmpdir(), "codex-empty-home-")),
+      );
+      expect(codexCredentialsAvailable()).toBe(false);
+
+      // A readable auth.json under $CODEX_HOME → true, even with no PATH binary.
+      const home = mkdtempSync(join(tmpdir(), "codex-home-"));
+      writeFileSync(join(home, "auth.json"), '{"OPENAI_API_KEY":"x"}');
+      process.env.CODEX_HOME = home;
+      expect(codexCredentialsAvailable()).toBe(true);
+    });
+  });
+
+  test("returns true when CODEX_API_KEY is set", async () => {
+    const { codexCredentialsAvailable } = await import(
+      "../../../examples/basic-agent-codex/agent.ts"
+    );
+    await withClearedEnv(() => {
+      process.env.CODEX_HOME = mkdtempSync(join(tmpdir(), "codex-empty-"));
+      process.env.CODEX_API_KEY = "key-abc";
+      expect(codexCredentialsAvailable()).toBe(true);
+    });
+  });
+
+  test("driver credential resolution has no OPENAI_API_KEY fallback", () => {
+    // Only OPENAI_API_KEY present in env — the driver must NOT pick it up as the
+    // Codex apiKey (CODEX-2 refuted: OPENAI_API_KEY is not a Codex CLI var).
+    const driver = new CodexSdkDriver({
+      env: { OPENAI_API_KEY: "openai-only" },
+    });
+    const options = driver.buildClientOptions({
+      provider: CODEX_PROVIDER,
+      context: {} as never,
+    });
+    expect(options.apiKey).toBeUndefined();
   });
 });

--- a/tests/agents/env.test.ts
+++ b/tests/agents/env.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EnvCredentialProvider, readAllowedEnv } from "../../src/agents/index.js";
+
+describe("environment credential allowlist", () => {
+  test("reads only allowlisted non-empty variables", () => {
+    const env = {
+      OPENAI_API_KEY: "allowed",
+      SECRET_TOKEN: "blocked",
+      EMPTY: "",
+    };
+
+    expect(readAllowedEnv(env, ["OPENAI_API_KEY", "EMPTY", "MISSING"])).toEqual({
+      OPENAI_API_KEY: "allowed",
+    });
+  });
+
+  test("credential provider does not read unallowlisted values", async () => {
+    const provider = new EnvCredentialProvider({
+      ANTHROPIC_API_KEY: "allowed",
+      UNRELATED_SECRET: "blocked",
+    });
+
+    await expect(
+      provider.getCredential({
+        providerId: "claude",
+        envAllowlist: ["ANTHROPIC_API_KEY"],
+      }),
+    ).resolves.toEqual({
+      kind: "env",
+      label: "claude:env",
+      env: { ANTHROPIC_API_KEY: "allowed" },
+    });
+  });
+
+  test("credential provider returns undefined when nothing is allowed", async () => {
+    const provider = new EnvCredentialProvider({ SECRET_TOKEN: "blocked" });
+
+    await expect(
+      provider.getCredential({ providerId: "codex", envAllowlist: ["OPENAI_API_KEY"] }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/agents/error-classification.test.ts
+++ b/tests/agents/error-classification.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import { classifyRecoverable } from "../../src/agents/runtime/error-classification.js";
+import * as agents from "../../src/agents/index.js";
+
+describe("classifyRecoverable", () => {
+  test("is exported from the agents public surface", () => {
+    expect(agents.classifyRecoverable).toBe(classifyRecoverable);
+  });
+
+  describe("known subtypes (table-driven)", () => {
+    const cases: ReadonlyArray<[string, boolean, string]> = [
+      // auth -> non-recoverable
+      ["authentication_failed", false, "CLAUDE_AUTH_ERROR"],
+      ["oauth_org_not_allowed", false, "CLAUDE_AUTH_ERROR"],
+      ["CLAUDE_AUTH_STATUS", false, "CLAUDE_AUTH_STATUS"],
+      ["CODEX_AUTH_ERROR", false, "CODEX_AUTH_ERROR"],
+      // billing / quota -> non-recoverable
+      ["billing_error", false, "CLAUDE_BILLING_ERROR"],
+      ["error_max_budget_usd", false, "error_max_budget_usd"],
+      ["quota_exhausted", false, "CODEX_QUOTA_EXHAUSTED"],
+      // client/config -> non-recoverable
+      ["invalid_request", false, "CLAUDE_INVALID_REQUEST"],
+      ["error_max_turns", false, "error_max_turns"],
+      [
+        "error_max_structured_output_retries",
+        false,
+        "error_max_structured_output_retries",
+      ],
+      ["max_output_tokens", false, "max_output_tokens"],
+      // missing binary -> non-recoverable
+      ["missing_binary", false, "CODEX_MISSING_BINARY"],
+      // transient / transport / rate-limit -> recoverable
+      ["rate_limit", true, "CLAUDE_RATE_LIMIT"],
+      ["server_error", true, "CLAUDE_SERVER_ERROR"],
+      ["transient", true, "TRANSIENT_ERROR"],
+      ["transport", true, "TRANSPORT_ERROR"],
+    ];
+
+    for (const [subtype, recoverable, code] of cases) {
+      test(`${subtype} -> recoverable=${recoverable}, code=${code}`, () => {
+        expect(classifyRecoverable({ subtype })).toEqual({ recoverable, code });
+      });
+    }
+  });
+
+  describe("message heuristics", () => {
+    const cases: ReadonlyArray<[string, boolean, string]> = [
+      ["Rate limit exceeded, retry after 5s", true, "RATE_LIMIT"],
+      ["HTTP 429 Too Many Requests", true, "RATE_LIMIT"],
+      ["401 Unauthorized: invalid API key", false, "AUTH_ERROR"],
+      ["authentication failed for provider", false, "AUTH_ERROR"],
+      ["billing error: insufficient credit", false, "BILLING_ERROR"],
+      ["Your quota is exhausted", false, "BILLING_ERROR"],
+      ["Unable to locate Codex CLI binaries", false, "MISSING_BINARY"],
+      ["spawn codex ENOENT", false, "MISSING_BINARY"],
+      ["request timed out after 30s", true, "TRANSPORT_ERROR"],
+      ["ECONNRESET while streaming", true, "TRANSPORT_ERROR"],
+      ["503 Service Unavailable", true, "TRANSPORT_ERROR"],
+    ];
+
+    for (const [message, recoverable, code] of cases) {
+      test(`"${message}" -> recoverable=${recoverable}, code=${code}`, () => {
+        expect(classifyRecoverable({ message })).toEqual({ recoverable, code });
+      });
+    }
+  });
+
+  test("known subtype takes precedence over message heuristic", () => {
+    // subtype says auth (non-recoverable) even though message looks transient
+    expect(
+      classifyRecoverable({
+        subtype: "authentication_failed",
+        message: "connection timed out",
+      }),
+    ).toEqual({ recoverable: false, code: "CLAUDE_AUTH_ERROR" });
+  });
+
+  test("rate-limit message is not mis-bucketed as quota/billing", () => {
+    expect(classifyRecoverable({ message: "rate limit quota reached" })).toEqual({
+      recoverable: true,
+      code: "RATE_LIMIT",
+    });
+  });
+
+  test("unknown input falls back to recoverable + UNKNOWN_ERROR by default", () => {
+    expect(classifyRecoverable({ message: "something weird happened" })).toEqual({
+      recoverable: true,
+      code: "UNKNOWN_ERROR",
+    });
+    expect(classifyRecoverable({})).toEqual({
+      recoverable: true,
+      code: "UNKNOWN_ERROR",
+    });
+  });
+
+  test("fallbackCode and defaultRecoverable overrides are honored", () => {
+    expect(
+      classifyRecoverable({
+        message: "totally novel failure",
+        fallbackCode: "CODEX_SDK_ERROR",
+        defaultRecoverable: false,
+      }),
+    ).toEqual({ recoverable: false, code: "CODEX_SDK_ERROR" });
+  });
+
+  test("unknown subtype falls through to message heuristic", () => {
+    expect(
+      classifyRecoverable({
+        subtype: "some_unmapped_subtype",
+        message: "401 unauthorized",
+      }),
+    ).toEqual({ recoverable: false, code: "AUTH_ERROR" });
+  });
+});

--- a/tests/agents/exports.test.ts
+++ b/tests/agents/exports.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import { BaseAgent } from "@google/adk";
+import * as root from "../../src/index.js";
+import * as agents from "../../src/agents/index.js";
+import packageJson from "../../package.json";
+
+describe("agents public exports", () => {
+  test("root export behavior remains LLM-focused", () => {
+    expect(root.AIGateway).toBeFunction();
+    expect(root.OpenRouter).toBeFunction();
+    expect(root.OpenAI).toBeFunction();
+    expect(root.Anthropic).toBeFunction();
+    expect(root.XAI).toBeFunction();
+    expect(root.Custom).toBeFunction();
+    expect("CodexAgent" in root).toBe(false);
+    expect("ClaudeAgent" in root).toBe(false);
+    expect("GeminiCliAgent" in root).toBe(false);
+    expect("ExternalAgent" in root).toBe(false);
+    expect("EnvCredentialProvider" in root).toBe(false);
+  });
+
+  test("./agents exposes external agent symbols", () => {
+    expect(agents.BaseAgent).toBe(BaseAgent);
+    expect(agents.ExternalAgent).toBeFunction();
+    expect(agents.createExternalAgent).toBeFunction();
+    expect(agents.createExternalAgentConfig).toBeFunction();
+    expect(agents.ExternalAgentDefinitionRegistry).toBeFunction();
+    expect(agents.externalAgentDefinitionRegistry).toBeDefined();
+    expect(agents.CodexAgent).toBeFunction();
+    expect(agents.ClaudeAgent).toBeFunction();
+    expect(agents.GeminiCliAgent).toBeFunction();
+    expect(agents.CODEX_AGENT_DEFINITION.provider).toBe(agents.CODEX_PROVIDER);
+    expect(agents.CLAUDE_AGENT_DEFINITION.provider).toBe(agents.CLAUDE_PROVIDER);
+    expect(agents.GEMINI_CLI_AGENT_DEFINITION.provider).toBe(agents.GEMINI_CLI_PROVIDER);
+    expect(agents.ExternalAgentProviderRegistry).toBeFunction();
+    expect(agents.EnvCredentialProvider).toBeFunction();
+    expect(agents.NoopCredentialProvider).toBeFunction();
+    expect(agents.SubprocessJsonlDriver).toBeFunction();
+    expect(agents.CodexSdkDriver).toBeFunction();
+    expect(agents.PlaceholderExternalAgentDriver).toBeFunction();
+    expect(agents.readAllowedEnv).toBeFunction();
+    expect(agents.mapPermissionModeToPolicy).toBeFunction();
+    expect(agents.mapPermissionPolicyToFlags).toBeFunction();
+    expect(agents.deriveSubAgentPermissionPolicy).toBeFunction();
+    expect(agents.ToolGateway).toBeFunction();
+  });
+
+  test("provider-backed agents preserve expected public shape", () => {
+    const codex = new agents.CodexAgent({ name: "codex" });
+    const claude = new agents.ClaudeAgent({ name: "claude" });
+    const gemini = new agents.GeminiCliAgent({ name: "gemini" });
+
+    expect(codex).toBeInstanceOf(agents.ExternalAgent);
+    expect(codex).toBeInstanceOf(BaseAgent);
+    expect(codex.provider).toEqual(agents.CODEX_PROVIDER);
+    expect(claude.provider).toEqual(agents.CLAUDE_PROVIDER);
+    expect(gemini.provider).toEqual(agents.GEMINI_CLI_PROVIDER);
+
+    const root = new agents.ClaudeAgent({ name: "root", subAgents: [codex, gemini] });
+    expect(root.subAgents).toEqual([codex, gemini]);
+  });
+
+  test("package exports preserves root and adds agents subpath", () => {
+    expect(packageJson.exports["."]).toEqual({
+      types: "./dist/index.d.ts",
+      import: "./dist/index.js",
+    });
+    expect(packageJson.exports["./agents"]).toEqual({
+      types: "./dist/agents/index.d.ts",
+      import: "./dist/agents/index.js",
+    });
+  });
+});

--- a/tests/agents/external-agent.test.ts
+++ b/tests/agents/external-agent.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BaseAgent,
+  createEvent,
+  createEventActions,
+  InMemorySessionService,
+  Runner,
+  type InvocationContext,
+} from "@google/adk";
+import { trace } from "@opentelemetry/api";
+import {
+  ExternalAgent,
+  type ExternalAgentDriver,
+  type ExternalAgentEvent,
+  type ExternalAgentRunRequest,
+} from "../../src/agents/index.js";
+import { CODEX_PROVIDER } from "../../src/agents/provider/schema.js";
+
+class StateAgent extends BaseAgent {
+  constructor(name = "state_agent") {
+    super({ name });
+  }
+
+  protected async *runAsyncImpl(context: InvocationContext) {
+    yield createEvent({
+      invocationId: context.invocationId,
+      author: this.name,
+      branch: context.branch,
+      content: { role: "model", parts: [{ text: "child output" }] },
+      actions: createEventActions({ stateDelta: { architectureSummary: "done" } }),
+    });
+  }
+
+  protected async *runLiveImpl() {}
+}
+
+class StaticDriver implements ExternalAgentDriver {
+  readonly providerId = CODEX_PROVIDER.id;
+  request?: ExternalAgentRunRequest;
+
+  constructor(private readonly events: ExternalAgentEvent[]) {}
+
+  async *run(request: ExternalAgentRunRequest): AsyncIterable<ExternalAgentEvent> {
+    this.request = request;
+    yield* this.events;
+  }
+}
+
+class DelegatingDriver implements ExternalAgentDriver {
+  readonly providerId = CODEX_PROVIDER.id;
+
+  async *run(request: ExternalAgentRunRequest): AsyncIterable<ExternalAgentEvent> {
+    yield { type: "output", content: "starting", partial: true };
+    const result = await request.toolGateway?.runSubAgent({
+      agentName: "state_agent",
+      task: "summarize architecture",
+    });
+    yield { type: "output", content: result?.output ?? "missing" };
+  }
+}
+
+type CapturedSpan = {
+  name: string;
+  attributes: Record<string, unknown>;
+};
+
+function installTraceCapture(): CapturedSpan[] {
+  const spans: CapturedSpan[] = [];
+  trace.disable();
+  trace.setGlobalTracerProvider({
+    getTracer() {
+      return {
+        startSpan(name: string) {
+          const span = { name, attributes: {} };
+          spans.push(span);
+          return {
+            setAttributes(attributes: Record<string, unknown>) {
+              Object.assign(span.attributes, attributes);
+              return this;
+            },
+            setAttribute(key: string, value: unknown) {
+              span.attributes[key] = value;
+              return this;
+            },
+            end() {},
+          };
+        },
+      };
+    },
+  } as never);
+  return spans;
+}
+
+async function collect(agent: ExternalAgent, context: Partial<InvocationContext> = {}) {
+  const events = [];
+  for await (const event of agent.runAsync({
+    invocationId: "inv-1",
+    branch: "root.external",
+    ...context,
+  } as InvocationContext)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("ExternalAgent ADK event formatting", () => {
+  test("passes runtime bridge context to the configured driver", async () => {
+    const driver = new StaticDriver([{ type: "completed", exitCode: 0 }]);
+    const subAgent = new ExternalAgent({
+      name: "codex_subagent",
+      provider: CODEX_PROVIDER,
+      driver: new StaticDriver([]),
+    });
+    const agent = new ExternalAgent({
+      name: "codex_agent",
+      provider: CODEX_PROVIDER,
+      driver,
+      subAgents: [subAgent],
+    });
+
+    await collect(agent);
+
+    expect(driver.request?.agent).toBe(agent);
+    expect(driver.request?.rootAgent).toBe(agent);
+    expect(driver.request?.subAgents).toEqual([subAgent]);
+    expect(driver.request?.toolGateway).toBeDefined();
+    expect(driver.request?.runtimeSession).toMatchObject({
+      id: "inv-1",
+      rootAgentName: "codex_agent",
+    });
+  });
+
+  test("renders output as model text content with invocation metadata", async () => {
+    const agent = new ExternalAgent({
+      name: "codex_agent",
+      provider: CODEX_PROVIDER,
+      driver: new StaticDriver([{ type: "output", content: "Hello" }]),
+    });
+
+    const events = await collect(agent);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      invocationId: "inv-1",
+      author: "codex_agent",
+      branch: "root.external",
+      content: { role: "model", parts: [{ text: "Hello" }] },
+    });
+  });
+
+  test("renders partial output as non-terminal streaming ADK events", async () => {
+    const agent = new ExternalAgent({
+      name: "codex_agent",
+      provider: CODEX_PROVIDER,
+      driver: new StaticDriver([
+        { type: "output", content: "partial", partial: true },
+        { type: "output", content: "final" },
+      ]),
+    });
+
+    const events = await collect(agent);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      partial: true,
+      turnComplete: false,
+      content: { role: "model", parts: [{ text: "partial" }] },
+    });
+    expect(events[1]).toMatchObject({
+      partial: undefined,
+      turnComplete: true,
+      content: { role: "model", parts: [{ text: "final" }] },
+    });
+  });
+
+  test("does not render started or completed lifecycle events", async () => {
+    const agent = new ExternalAgent({
+      name: "codex_agent",
+      provider: CODEX_PROVIDER,
+      driver: new StaticDriver([
+        { type: "started", providerId: "codex" },
+        { type: "output", content: "Visible" },
+        { type: "completed", exitCode: 0 },
+      ]),
+    });
+
+    const events = await collect(agent);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].content?.parts?.[0]?.text).toBe("Visible");
+  });
+
+  test("traces synthetic ADK llm_request with native ADK model attributes", async () => {
+    const spans = installTraceCapture();
+    const agent = new ExternalAgent({
+      name: "codex_agent",
+      provider: CODEX_PROVIDER,
+      driver: new StaticDriver([{ type: "output", content: "Hello" }]),
+    });
+
+    await collect(agent, {
+      userContent: { role: "user", parts: [{ text: "Review this diff" }] },
+    });
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].attributes).toMatchObject({
+      "gen_ai.system": "gcp.vertex.agent",
+      "gen_ai.request.model": CODEX_PROVIDER.id,
+      "gcp.vertex.agent.provider_id": CODEX_PROVIDER.id,
+      "gcp.vertex.agent.event_title": "codex_agent: final response",
+    });
+    expect(JSON.parse(spans[0].attributes["gcp.vertex.agent.llm_request"] as string)).toEqual({
+      model: CODEX_PROVIDER.id,
+      contents: [{ role: "user", parts: [{ text: "Review this diff" }] }],
+    });
+  });
+
+  test("renders errors using ADK errorCode and errorMessage fields", async () => {
+    const agent = new ExternalAgent({
+      name: "codex_agent",
+      provider: CODEX_PROVIDER,
+      driver: new StaticDriver([
+        {
+          type: "error",
+          code: "CODEX_ERROR",
+          message: "Something failed",
+          recoverable: true,
+        },
+      ]),
+    });
+
+    const events = await collect(agent);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      invocationId: "inv-1",
+      author: "codex_agent",
+      branch: "root.external",
+      errorCode: "CODEX_ERROR",
+      errorMessage: "Something failed",
+    });
+    expect(events[0].content).toBeUndefined();
+  });
+
+  test("renders tool calls as ADK functionCall parts", async () => {
+    const agent = new ExternalAgent({
+      name: "codex_agent",
+      provider: CODEX_PROVIDER,
+      driver: new StaticDriver([
+        { type: "tool_call", name: "shell", input: { command: "pwd" } },
+        { type: "tool_call", name: "raw", input: "value" },
+      ]),
+    });
+
+    const events = await collect(agent);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].content).toEqual({
+      role: "model",
+      parts: [{ functionCall: { name: "shell", args: { command: "pwd" } } }],
+    });
+    expect(events[1].content).toEqual({
+      role: "model",
+      parts: [{ functionCall: { name: "raw", args: { input: "value" } } }],
+    });
+  });
+
+  test("renders tool results as ADK functionResponse parts", async () => {
+    const agent = new ExternalAgent({
+      name: "codex_agent",
+      provider: CODEX_PROVIDER,
+      driver: new StaticDriver([
+        {
+          type: "tool_result",
+          name: "shell",
+          callId: "call-1",
+          result: { stdout: "ok" },
+        },
+      ]),
+    });
+
+    const events = await collect(agent);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].content).toEqual({
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            id: "call-1",
+            name: "shell",
+            response: { stdout: "ok" },
+          },
+        },
+      ],
+    });
+  });
+
+  test("emits native ToolGateway function events through Runner sessions and state", async () => {
+    const sessionService = new InMemorySessionService();
+    const session = await sessionService.createSession({
+      appName: "app",
+      userId: "user",
+    });
+    const agent = new ExternalAgent({
+      name: "root_external",
+      provider: CODEX_PROVIDER,
+      driver: new DelegatingDriver(),
+      subAgents: [new StateAgent()],
+    });
+    const runner = new Runner({ appName: "app", agent, sessionService });
+
+    const streamed = [];
+    for await (const event of runner.runAsync({
+      userId: "user",
+      sessionId: session.id,
+      newMessage: { role: "user", parts: [{ text: "understand architecture" }] },
+    })) {
+      streamed.push(event);
+    }
+
+    const updated = await sessionService.getSession({
+      appName: "app",
+      userId: "user",
+      sessionId: session.id,
+    });
+
+    expect(streamed.some((event) => event.partial)).toBe(true);
+    expect(updated?.events.some((event) => event.partial)).toBe(false);
+    expect(
+      updated?.events.some((event) =>
+        event.content?.parts?.some((part) => part.functionCall?.name === "run_adk_subagent"),
+      ),
+    ).toBe(true);
+    expect(
+      updated?.events.some(
+        (event) =>
+          event.author === "state_agent" &&
+          event.content?.parts?.[0]?.text === "child output" &&
+          event.customMetadata?.subAgentEvent === true,
+      ),
+    ).toBe(true);
+    expect(
+      updated?.events.some((event) =>
+        event.content?.parts?.some((part) => part.functionResponse?.name === "run_adk_subagent"),
+      ),
+    ).toBe(true);
+    const functionCallIndex = updated?.events.findIndex((event) =>
+      event.content?.parts?.some((part) => part.functionCall?.name === "run_adk_subagent"),
+    );
+    const childEventIndex = updated?.events.findIndex(
+      (event) => event.author === "state_agent" && event.customMetadata?.subAgentEvent === true,
+    );
+    const functionResponseIndex = updated?.events.findIndex((event) =>
+      event.content?.parts?.some((part) => part.functionResponse?.name === "run_adk_subagent"),
+    );
+    expect(functionCallIndex).toBeGreaterThanOrEqual(0);
+    expect(childEventIndex).toBeGreaterThan(functionCallIndex ?? -1);
+    expect(functionResponseIndex).toBeGreaterThan(childEventIndex ?? -1);
+    expect(updated?.state.architectureSummary).toBe("done");
+  });
+});

--- a/tests/agents/external-agents-config.test.ts
+++ b/tests/agents/external-agents-config.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  isPathAllowed,
+  normalizeAllowedDirectory,
+  parseArchitectureAnalysisPaths,
+} from "../../examples/external-agents/config.js";
+
+describe("external-agents path config", () => {
+  test("accepts, normalizes, and deduplicates absolute directories", () => {
+    const dir = mkdtempSync(join(tmpdir(), "external-agent-paths-"));
+    try {
+      expect(parseArchitectureAnalysisPaths(`${dir}, ${dir}`)).toEqual([
+        realpathSync(dir),
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects relative paths", () => {
+    expect(() => parseArchitectureAnalysisPaths("relative/path")).toThrow(
+      /absolute paths/,
+    );
+  });
+
+  test("rejects missing paths", () => {
+    expect(() => parseArchitectureAnalysisPaths("/definitely/missing/path")).toThrow(
+      /does not exist/,
+    );
+  });
+
+  test("rejects files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "external-agent-file-"));
+    const file = join(dir, "file.txt");
+    writeFileSync(file, "not a directory");
+    try {
+      expect(() => normalizeAllowedDirectory(file)).toThrow(/must be directories/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("checks requested paths by real directory containment", () => {
+    const root = mkdtempSync(join(tmpdir(), "external-agent-root-"));
+    const child = join(root, "child");
+    const sibling = mkdtempSync(join(tmpdir(), "external-agent-root-sibling-"));
+    mkdirSync(child);
+    try {
+      const allowed = [realpathSync(root)];
+      expect(isPathAllowed(root, allowed)).toBe(true);
+      expect(isPathAllowed(child, allowed)).toBe(true);
+      expect(isPathAllowed(sibling, allowed)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(sibling, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/agents/gemini/gemini-cli.test.ts
+++ b/tests/agents/gemini/gemini-cli.test.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  GeminiCliAgent,
+  GeminiCliDriver,
+  GEMINI_CLI_ENV_ALLOWLIST,
+  GEMINI_CLI_PROVIDER,
+  buildGeminiArgs,
+  mapGeminiPermissionArgs,
+  type GeminiCliSpawn,
+} from "../../../src/agents/index.js";
+import type { ExternalAgentRunRequest } from "../../../src/agents/index.js";
+
+function request(
+  overrides: Partial<ExternalAgentRunRequest> = {},
+): ExternalAgentRunRequest {
+  return {
+    provider: GEMINI_CLI_PROVIDER,
+    context: {} as ExternalAgentRunRequest["context"],
+    instruction: "say hello",
+    ...overrides,
+  };
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of iterable) {
+    result.push(item);
+  }
+  return result;
+}
+
+describe("Gemini CLI provider", () => {
+  test("declares the complete auth/config environment allowlist", () => {
+    expect(GEMINI_CLI_PROVIDER).toEqual({
+      id: "gemini-cli",
+      name: "Gemini CLI",
+      command: "gemini",
+      envAllowlist: GEMINI_CLI_ENV_ALLOWLIST,
+    });
+    expect(GEMINI_CLI_ENV_ALLOWLIST).toEqual([
+      "GEMINI_API_KEY",
+      "GOOGLE_API_KEY",
+      "GOOGLE_GENAI_USE_VERTEXAI",
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_PROJECT_ID",
+      "GOOGLE_CLOUD_LOCATION",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+    ]);
+  });
+
+  test("agent wires the Gemini provider and runtime driver without auth side effects", () => {
+    const agent = new GeminiCliAgent({ name: "gemini" });
+
+    expect(agent.provider).toBe(GEMINI_CLI_PROVIDER);
+    expect(agent.driver).toBeInstanceOf(GeminiCliDriver);
+  });
+});
+
+describe("GeminiCliDriver", () => {
+  test("builds gemini stream-json command args", async () => {
+    const calls: Array<Parameters<GeminiCliSpawn>> = [];
+    const spawn: GeminiCliSpawn = (command, args, options) => {
+      calls.push([command, args, options]);
+      return {
+        stdout: [
+          new TextEncoder().encode('{"type":"content","text":"hello"}\n'),
+        ],
+        exited: Promise.resolve(0),
+      };
+    };
+
+    const driver = new GeminiCliDriver({
+      spawn,
+      env: { PATH: "/bin", HOME: "/home/test", SECRET_TOKEN: "blocked" },
+    });
+
+    const events = await collect(
+      driver.run(request({ workingDirectory: "/repo" })),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe("gemini");
+    expect(calls[0]?.[1]).toEqual([
+      "-p",
+      "say hello",
+      "--output-format",
+      "stream-json",
+      "--approval-mode=default",
+      "--sandbox",
+    ]);
+    expect(calls[0]?.[2]).toEqual({
+      cwd: "/repo",
+      env: { PATH: "/bin", HOME: "/home/test" },
+    });
+    expect(events.map((event) => event.type)).toEqual([
+      "started",
+      "output",
+      "completed",
+    ]);
+    expect(events[1]).toMatchObject({ type: "output", content: "hello" });
+  });
+
+  test("passes only allowlisted credential environment variables", async () => {
+    const calls: Array<Parameters<GeminiCliSpawn>> = [];
+    const spawn: GeminiCliSpawn = (command, args, options) => {
+      calls.push([command, args, options]);
+      return { stdout: [], exited: Promise.resolve(0) };
+    };
+
+    const driver = new GeminiCliDriver({
+      spawn,
+      env: {
+        PATH: "/bin",
+        HOME: "/home/test",
+        AWS_SECRET_ACCESS_KEY: "blocked",
+      },
+    });
+
+    await collect(
+      driver.run(
+        request({
+          credential: {
+            kind: "env",
+            label: "gemini-cli:env",
+            env: {
+              GEMINI_API_KEY: "gemini-key",
+              GOOGLE_APPLICATION_CREDENTIALS: "/tmp/adc.json",
+              AWS_SECRET_ACCESS_KEY: "blocked",
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(calls[0]?.[2].env).toEqual({
+      PATH: "/bin",
+      HOME: "/home/test",
+      GEMINI_API_KEY: "gemini-key",
+      GOOGLE_APPLICATION_CREDENTIALS: "/tmp/adc.json",
+    });
+  });
+
+  test("normalizes Gemini stream-json events", async () => {
+    const spawn: GeminiCliSpawn = () => ({
+      stdout: [
+        '{"type":"content","text":"hello"}\n',
+        '{"type":"tool_call","name":"read_file","input":{"path":"README.md"}}\n',
+        '{"type":"error","error":{"message":"nope","code":"E_NOPE"}}\n',
+      ],
+      exited: Promise.resolve(0),
+    });
+    const driver = new GeminiCliDriver({ spawn });
+
+    await expect(collect(driver.run(request()))).resolves.toEqual([
+      expect.objectContaining({ type: "started", providerId: "gemini-cli" }),
+      expect.objectContaining({ type: "output", content: "hello" }),
+      expect.objectContaining({
+        type: "tool_call",
+        name: "read_file",
+        input: { path: "README.md" },
+      }),
+      expect.objectContaining({
+        type: "error",
+        message: "nope",
+        code: "E_NOPE",
+      }),
+      expect.objectContaining({ type: "completed", exitCode: 0 }),
+    ]);
+  });
+
+  test("maps permission presets without defaulting to yolo", () => {
+    expect(buildGeminiArgs("prompt")).toEqual([
+      "-p",
+      "prompt",
+      "--output-format",
+      "stream-json",
+      "--approval-mode=default",
+      "--sandbox",
+    ]);
+    expect(mapGeminiPermissionArgs({ mode: "read-only" })).toEqual([
+      "--approval-mode=plan",
+      "--sandbox",
+    ]);
+    expect(mapGeminiPermissionArgs({ mode: "ask" })).toEqual([
+      "--approval-mode=default",
+      "--sandbox",
+    ]);
+    expect(
+      mapGeminiPermissionArgs({
+        mode: "workspace-write",
+        allowedPaths: ["/repo", "/tmp"],
+      }),
+    ).toEqual([
+      "--approval-mode=auto_edit",
+      "--sandbox",
+      "--include-directories",
+      "/repo",
+      "--include-directories",
+      "/tmp",
+    ]);
+    expect(mapGeminiPermissionArgs({ mode: "full-access" })).toEqual([
+      "--approval-mode=yolo",
+    ]);
+  });
+});

--- a/tests/agents/permissions.test.ts
+++ b/tests/agents/permissions.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  deriveSubAgentPermissionPolicy,
+  mapPermissionModeToPolicy,
+  mapPermissionPolicyToFlags,
+} from "../../src/agents/index.js";
+
+describe("permission mapping", () => {
+  test("maps read-only policy to provider flags", () => {
+    expect(
+      mapPermissionPolicyToFlags({ mode: "read-only", allowedPaths: ["/tmp/project"] }),
+    ).toEqual({
+      readOnly: true,
+      requireApproval: false,
+      network: undefined,
+      paths: ["/tmp/project"],
+    });
+  });
+
+  test("maps ask policy to approval flags", () => {
+    expect(mapPermissionPolicyToFlags({ mode: "ask", allowNetwork: false })).toEqual({
+      requireApproval: true,
+      network: false,
+      paths: undefined,
+    });
+  });
+
+  test("creates policy from mode", () => {
+    expect(mapPermissionModeToPolicy("workspace-write")).toEqual({
+      mode: "workspace-write",
+    });
+  });
+});
+
+describe("deriveSubAgentPermissionPolicy", () => {
+  test("does not let child permissions exceed parent mode", () => {
+    expect(
+      deriveSubAgentPermissionPolicy(
+        { mode: "read-only" },
+        { mode: "full-access", allowNetwork: true },
+      ),
+    ).toEqual({ mode: "read-only", allowNetwork: false });
+
+    expect(
+      deriveSubAgentPermissionPolicy(
+        { mode: "workspace-write" },
+        { mode: "full-access" },
+      ),
+    ).toEqual({ mode: "workspace-write", allowNetwork: false });
+  });
+
+  test("does not expand allowed paths", () => {
+    expect(
+      deriveSubAgentPermissionPolicy(
+        { mode: "workspace-write", allowedPaths: ["/repo", "/tmp"] },
+        { mode: "workspace-write", allowedPaths: ["/repo", "/etc"] },
+      ),
+    ).toEqual({
+      mode: "workspace-write",
+      allowNetwork: false,
+      allowedPaths: ["/repo"],
+    });
+  });
+});

--- a/tests/agents/provider-registry.test.ts
+++ b/tests/agents/provider-registry.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  CLAUDE_AGENT_DEFINITION,
+  CLAUDE_PROVIDER,
+  CODEX_AGENT_DEFINITION,
+  CODEX_PROVIDER,
+  createDefaultExternalAgentDefinitionRegistry,
+  createDefaultExternalAgentProviderRegistry,
+  ExternalAgent,
+  ExternalAgentDefinitionRegistry,
+  ExternalAgentProviderRegistry,
+  GEMINI_CLI_AGENT_DEFINITION,
+  GEMINI_CLI_PROVIDER,
+} from "../../src/agents/index.js";
+
+describe("ExternalAgentProviderRegistry", () => {
+  test("registers and looks up providers", () => {
+    const registry = new ExternalAgentProviderRegistry();
+    registry.register(CODEX_PROVIDER);
+
+    expect(registry.has("codex")).toBe(true);
+    expect(registry.get("codex")).toEqual(CODEX_PROVIDER);
+    expect(registry.list()).toEqual([CODEX_PROVIDER]);
+  });
+
+  test("default registry contains built-in placeholders", () => {
+    const registry = createDefaultExternalAgentProviderRegistry();
+
+    expect(registry.get("codex")).toEqual(CODEX_PROVIDER);
+    expect(registry.get("claude")).toEqual(CLAUDE_PROVIDER);
+    expect(registry.get("gemini-cli")).toEqual(GEMINI_CLI_PROVIDER);
+  });
+});
+
+describe("ExternalAgentDefinitionRegistry", () => {
+  test("registers and looks up agent definitions", () => {
+    const registry = new ExternalAgentDefinitionRegistry();
+    registry.register(CODEX_AGENT_DEFINITION);
+
+    expect(registry.has("codex")).toBe(true);
+    expect(registry.get("codex")).toEqual(CODEX_AGENT_DEFINITION);
+    expect(registry.list()).toEqual([CODEX_AGENT_DEFINITION]);
+  });
+
+  test("default definition registry contains built-in agents", () => {
+    const registry = createDefaultExternalAgentDefinitionRegistry();
+
+    expect(registry.get("codex")).toEqual(CODEX_AGENT_DEFINITION);
+    expect(registry.get("claude")).toEqual(CLAUDE_AGENT_DEFINITION);
+    expect(registry.get("gemini-cli")).toEqual(GEMINI_CLI_AGENT_DEFINITION);
+  });
+
+  test("creates agents through the shared definition schema", () => {
+    const registry = createDefaultExternalAgentDefinitionRegistry();
+    const agent = registry.create("codex", { name: "codex" });
+
+    expect(agent).toBeInstanceOf(ExternalAgent);
+    expect(agent.provider).toEqual(CODEX_PROVIDER);
+    expect(agent.driver.providerId).toBe("codex");
+  });
+});

--- a/tests/agents/runtime/content-collector.test.ts
+++ b/tests/agents/runtime/content-collector.test.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2025 PAI
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { InvocationContext } from "@google/adk";
+import type { Content } from "@google/genai";
+import {
+  collectContents,
+  flattenContentsToPrompt,
+} from "../../../src/agents/runtime/content-collector.js";
+
+type EventLike = {
+  author?: string;
+  branch?: string;
+  partial?: boolean;
+  content?: Content;
+};
+
+function makeContext(opts: {
+  agentName?: string;
+  branch?: string;
+  events?: EventLike[];
+  userContent?: Content;
+}): InvocationContext {
+  return {
+    agent: opts.agentName ? { name: opts.agentName } : undefined,
+    branch: opts.branch,
+    session: { events: opts.events ?? [] },
+    userContent: opts.userContent,
+  } as unknown as InvocationContext;
+}
+
+describe("collectContents / flattenContentsToPrompt", () => {
+  test("empty session with userContent text", () => {
+    const ctx = makeContext({
+      userContent: { role: "user", parts: [{ text: "hi" }] },
+    });
+    const contents = collectContents(ctx);
+    expect(contents).toEqual([{ role: "user", parts: [{ text: "hi" }] }]);
+    expect(flattenContentsToPrompt(contents)).toBe("user:\nhi");
+  });
+
+  test("multi-turn alternating user/model events", () => {
+    const ctx = makeContext({
+      agentName: "alice",
+      events: [
+        {
+          author: "user",
+          content: { role: "user", parts: [{ text: "hi" }] },
+        },
+        {
+          author: "alice",
+          content: { role: "model", parts: [{ text: "hello" }] },
+        },
+      ],
+    });
+    const contents = collectContents(ctx);
+    expect(contents).toEqual([
+      { role: "user", parts: [{ text: "hi" }] },
+      { role: "model", parts: [{ text: "hello" }] },
+    ]);
+    expect(flattenContentsToPrompt(contents)).toBe("user:\nhi\n\nassistant:\nhello");
+  });
+
+  test("foreign-agent text event is rewritten under user role", () => {
+    const ctx = makeContext({
+      agentName: "main",
+      events: [
+        {
+          author: "billing-bot",
+          content: { role: "model", parts: [{ text: "refund issued" }] },
+        },
+      ],
+    });
+    const rendered = flattenContentsToPrompt(collectContents(ctx));
+    expect(rendered).toContain("user:");
+    expect(rendered).toContain("[billing-bot said: refund issued]");
+  });
+
+  test("foreign-agent functionCall event is rewritten as text marker", () => {
+    const ctx = makeContext({
+      agentName: "main",
+      events: [
+        {
+          author: "billing-bot",
+          content: {
+            role: "model",
+            parts: [{ functionCall: { name: "refund", args: { amount: 50 } } }],
+          },
+        },
+      ],
+    });
+    const rendered = flattenContentsToPrompt(collectContents(ctx));
+    expect(rendered).toContain(
+      "[billing-bot called tool refund with parameters {\"amount\":50}]",
+    );
+  });
+
+  test("branch filtering keeps ancestor branches, excludes siblings", () => {
+    const ctx = makeContext({
+      agentName: "child",
+      branch: "root.child",
+      events: [
+        {
+          author: "user",
+          branch: "root",
+          content: { role: "user", parts: [{ text: "keep" }] },
+        },
+        {
+          author: "user",
+          branch: "root.sibling",
+          content: { role: "user", parts: [{ text: "drop" }] },
+        },
+      ],
+    });
+    const rendered = flattenContentsToPrompt(collectContents(ctx));
+    expect(rendered).toContain("keep");
+    expect(rendered).not.toContain("drop");
+  });
+
+  test("inlineData image part flattens to image marker", () => {
+    const ctx = makeContext({
+      agentName: "main",
+      events: [
+        {
+          author: "user",
+          content: {
+            role: "user",
+            parts: [{ inlineData: { mimeType: "image/png", data: "base64..." } }],
+          },
+        },
+      ],
+    });
+    const rendered = flattenContentsToPrompt(collectContents(ctx));
+    expect(rendered).toContain("[image: image/png]");
+  });
+
+  test("functionCall and functionResponse split by another event are reordered", () => {
+    const ctx = makeContext({
+      agentName: "main",
+      events: [
+        {
+          author: "main",
+          content: {
+            role: "model",
+            parts: [{ functionCall: { id: "c1", name: "lookup", args: {} } }],
+          },
+        },
+        {
+          author: "user",
+          content: { role: "user", parts: [{ text: "interleaved" }] },
+        },
+        {
+          author: "user",
+          content: {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "c1",
+                  name: "lookup",
+                  response: { ok: true },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const contents = collectContents(ctx);
+    // Expect order: functionCall, functionResponse, interleaved-text.
+    const firstParts = contents[0].parts ?? [];
+    const secondParts = contents[1].parts ?? [];
+    const thirdParts = contents[2].parts ?? [];
+    expect(firstParts[0]?.functionCall?.id).toBe("c1");
+    expect(secondParts[0]?.functionResponse?.id).toBe("c1");
+    expect(thirdParts[0]?.text).toBe("interleaved");
+  });
+
+  test("thought parts are dropped from the flattened prompt", () => {
+    const ctx = makeContext({
+      agentName: "main",
+      events: [
+        {
+          author: "main",
+          content: {
+            role: "model",
+            parts: [
+              { text: "visible answer" },
+              { text: "secret reasoning", thought: true },
+            ],
+          },
+        },
+      ],
+    });
+    const rendered = flattenContentsToPrompt(collectContents(ctx));
+    expect(rendered).toContain("visible answer");
+    expect(rendered).not.toContain("secret reasoning");
+  });
+
+  test("flattenContentsToPrompt is deterministic across repeated calls", () => {
+    const ctx = makeContext({
+      agentName: "main",
+      events: [
+        {
+          author: "user",
+          content: { role: "user", parts: [{ text: "one" }] },
+        },
+        {
+          author: "main",
+          content: { role: "model", parts: [{ text: "two" }] },
+        },
+        {
+          author: "user",
+          content: {
+            role: "user",
+            parts: [{ functionResponse: { id: "x", name: "t", response: { a: 1 } } }],
+          },
+        },
+      ],
+      userContent: { role: "user", parts: [{ text: "three" }] },
+    });
+    const first = flattenContentsToPrompt(collectContents(ctx));
+    const second = flattenContentsToPrompt(collectContents(ctx));
+    expect(first).toBe(second);
+  });
+});

--- a/tests/agents/tool-gateway.test.ts
+++ b/tests/agents/tool-gateway.test.ts
@@ -1,0 +1,501 @@
+import {
+  BaseAgent,
+  BaseLlm,
+  createEvent,
+  createEventActions,
+  FunctionTool,
+  LlmAgent,
+  PluginManager,
+  type BaseLlmConnection,
+  type InvocationContext,
+  type LlmRequest,
+  type LlmResponse,
+} from "@google/adk";
+import { describe, expect, test } from "bun:test";
+import {
+  ExternalAgent,
+  type ExternalAgentDriver,
+  type ExternalAgentRunRequest,
+  ToolGateway,
+} from "../../src/agents/index.js";
+import { CODEX_PROVIDER } from "../../src/agents/provider/schema.js";
+
+class CaptureDriver implements ExternalAgentDriver {
+  readonly providerId = CODEX_PROVIDER.id;
+  request?: ExternalAgentRunRequest;
+
+  async *run(request: ExternalAgentRunRequest) {
+    this.request = request;
+    yield { type: "output" as const, content: "child" };
+  }
+}
+
+class TextAgent extends BaseAgent {
+  constructor(name = "worker") {
+    super({ name });
+  }
+
+  protected async *runAsyncImpl(context: InvocationContext) {
+    const task = context.userContent?.parts?.[0]?.text ?? "";
+    yield createEvent({
+      invocationId: context.invocationId,
+      author: this.name,
+      content: { role: "model", parts: [{ text: `OK: ${task}` }] },
+    });
+    yield createEvent({ invocationId: context.invocationId, author: this.name });
+  }
+
+  protected async *runLiveImpl() {}
+}
+
+class FunctionResponseAgent extends BaseAgent {
+  constructor(
+    private readonly eventsToYield: ReturnType<typeof createEvent>[],
+    name = "worker",
+  ) {
+    super({ name });
+  }
+
+  protected async *runAsyncImpl() {
+    yield* this.eventsToYield;
+  }
+
+  protected async *runLiveImpl() {}
+}
+
+class FakeLlm extends BaseLlm {
+  readonly requests: LlmRequest[] = [];
+
+  constructor() {
+    super({ model: "fake-model" });
+  }
+
+  async *generateContentAsync(llmRequest: LlmRequest): AsyncGenerator<LlmResponse, void> {
+    this.requests.push(llmRequest);
+    yield { content: { role: "model", parts: [{ text: "child saw task" }] } };
+  }
+
+  async connect(): Promise<BaseLlmConnection> {
+    throw new Error("FakeLlm.connect is not implemented");
+  }
+}
+
+class ToolCallingFakeLlm extends BaseLlm {
+  readonly requests: LlmRequest[] = [];
+
+  constructor() {
+    super({ model: "fake-tool-model" });
+  }
+
+  async *generateContentAsync(llmRequest: LlmRequest): AsyncGenerator<LlmResponse, void> {
+    this.requests.push(llmRequest);
+    const hasToolResponse = llmRequest.contents.some((content) =>
+      content.parts?.some((part) => part.functionResponse?.name === "lookup_status")
+    );
+    if (hasToolResponse) {
+      yield { content: { role: "model", parts: [{ text: "final after tool" }] } };
+      return;
+    }
+    yield {
+      content: {
+        role: "model",
+        parts: [
+          {
+            functionCall: {
+              id: "call-1",
+              name: "lookup_status",
+              args: { service: "auth" },
+            },
+          },
+        ],
+      },
+    };
+  }
+
+  async connect(): Promise<BaseLlmConnection> {
+    throw new Error("ToolCallingFakeLlm.connect is not implemented");
+  }
+}
+
+function parentContext(agent: BaseAgent): InvocationContext {
+  return {
+    invocationId: "inv-1",
+    agent,
+    userContent: { role: "user", parts: [{ text: "parent" }] },
+    session: {
+      id: "session-1",
+      appName: "app",
+      userId: "user",
+      state: {},
+      events: [],
+      lastUpdateTime: 1,
+    },
+    pluginManager: new PluginManager(),
+  } as InvocationContext;
+}
+
+describe("ToolGateway", () => {
+  test("runs a named ADK subagent and returns visible text only", async () => {
+    const worker = new TextAgent("worker");
+    const root = new TextAgent("root");
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: parentContext(root),
+    });
+
+    const result = await gateway.runSubAgent({ agentName: "worker", task: "do it" });
+
+    expect(result).toEqual({
+      agentName: "worker",
+      output: "OK: do it",
+      events: 2,
+      summary: {
+        events: 2,
+        textEvents: 1,
+        toolCalls: 0,
+        errors: 0,
+        durationMs: expect.any(Number),
+      },
+    });
+  });
+
+  test("emits native function call, subagent events, and function response events by default", async () => {
+    const worker = new TextAgent("worker");
+    const root = new TextAgent("root");
+    const emitted = [];
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: parentContext(root),
+      eventSink: (event) => emitted.push(event),
+    });
+
+    await gateway.runSubAgent({ agentName: "worker", task: "do it" });
+
+    expect(emitted).toHaveLength(4);
+    expect(emitted[0].content?.parts?.[0]?.functionCall).toMatchObject({
+      name: "run_adk_subagent",
+      args: { agentName: "worker", task: "do it" },
+    });
+    expect(emitted[1]).toMatchObject({
+      author: "worker",
+      customMetadata: {
+        title: "worker: final response",
+        externalAgent: true,
+        subAgentEvent: true,
+        parentToolName: "run_adk_subagent",
+        parentToolCallId: expect.any(String),
+        rootAgentName: "root",
+        subAgentName: "worker",
+      },
+      content: { role: "model", parts: [{ text: "OK: do it" }] },
+    });
+    expect(emitted[3].content?.parts?.[0]?.functionResponse).toMatchObject({
+      name: "run_adk_subagent",
+      response: {
+        agentName: "worker",
+        output: "OK: do it",
+        events: 2,
+        summary: {
+          events: 2,
+          textEvents: 1,
+          toolCalls: 0,
+          errors: 0,
+          durationMs: expect.any(Number),
+        },
+      },
+    });
+  });
+
+  test("can hide subagent events for quiet summaries", async () => {
+    const worker = new TextAgent("worker");
+    const root = new TextAgent("root");
+    const emitted = [];
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: parentContext(root),
+      exposeSubAgentEvents: false,
+      eventSink: (event) => emitted.push(event),
+    });
+
+    await gateway.runSubAgent({ agentName: "worker", task: "do it" });
+
+    expect(emitted).toHaveLength(2);
+    expect(emitted[1].content?.parts?.[0]?.functionResponse).toMatchObject({
+      name: "run_adk_subagent",
+      response: {
+        agentName: "worker",
+        output: "OK: do it",
+        events: 2,
+        summary: {
+          events: 2,
+          textEvents: 1,
+          toolCalls: 0,
+          errors: 0,
+          durationMs: expect.any(Number),
+        },
+      },
+    });
+  });
+
+  test("passes delegated task to real LlmAgent through child session contents", async () => {
+    const fakeLlm = new FakeLlm();
+    const worker = new LlmAgent({ name: "worker", model: fakeLlm });
+    const root = new TextAgent("root");
+    const context = parentContext(root);
+    context.session.events.push(
+      createEvent({
+        invocationId: "previous",
+        author: "user",
+        content: { role: "user", parts: [{ text: "previous task" }] },
+      }),
+    );
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: context,
+    });
+
+    const result = await gateway.runSubAgent({ agentName: "worker", task: "delegated task" });
+
+    expect(result.output).toBe("child saw task");
+    expect(fakeLlm.requests).toHaveLength(1);
+    expect(fakeLlm.requests[0].contents.at(-1)).toEqual({
+      role: "user",
+      parts: [{ text: "delegated task" }],
+    });
+    expect(context.session.events).toHaveLength(1);
+    expect(context.session.events[0].content?.parts?.[0]?.text).toBe("previous task");
+  });
+
+  test("persists child LlmAgent events in the child session for multi-step tool calls", async () => {
+    const fakeLlm = new ToolCallingFakeLlm();
+    const lookupStatus = new FunctionTool({
+      name: "lookup_status",
+      description: "Look up service status.",
+      parameters: {
+        type: "OBJECT",
+        properties: {
+          service: { type: "STRING" },
+        },
+      } as never,
+      execute: () => ({ status: "degraded" }),
+    });
+    const worker = new LlmAgent({ name: "worker", model: fakeLlm, tools: [lookupStatus] });
+    const root = new TextAgent("root");
+    const context = parentContext(root);
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: context,
+    });
+
+    const result = await gateway.runSubAgent({ agentName: "worker", task: "check auth" });
+
+    expect(result.output).toBe("final after tool");
+    expect(result.summary.toolCalls).toBe(1);
+    expect(fakeLlm.requests).toHaveLength(2);
+    expect(fakeLlm.requests[1].contents.some((content) =>
+      content.parts?.some((part) => part.functionResponse?.name === "lookup_status")
+    )).toBe(true);
+    expect(context.session.events).toHaveLength(0);
+  });
+
+  test("prefers visible text over function response fallback output", async () => {
+    const worker = new FunctionResponseAgent([
+      createEvent({
+        invocationId: "inv-1",
+        author: "worker",
+        content: {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "call-1",
+                name: "tool",
+                response: { output: "tool output" },
+              },
+            },
+          ],
+        },
+      }),
+      createEvent({
+        invocationId: "inv-1",
+        author: "worker",
+        content: { role: "model", parts: [{ text: "final text" }] },
+      }),
+    ]);
+    const root = new TextAgent("root");
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: parentContext(root),
+    });
+
+    const result = await gateway.runSubAgent({ agentName: "worker", task: "do it" });
+
+    expect(result.output).toBe("final text");
+  });
+
+  test("uses function response output when subagent emits no visible text", async () => {
+    const worker = new FunctionResponseAgent([
+      createEvent({
+        invocationId: "inv-1",
+        author: "worker",
+        content: {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "call-1",
+                name: "tool",
+                response: { output: "tool output" },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+    const root = new TextAgent("root");
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: parentContext(root),
+    });
+
+    const result = await gateway.runSubAgent({ agentName: "worker", task: "do it" });
+
+    expect(result.output).toBe("tool output");
+    expect(result.summary.textEvents).toBe(0);
+  });
+
+  test("ignores partial streaming chunks when aggregating subagent output", async () => {
+    const worker = new FunctionResponseAgent([
+      createEvent({
+        invocationId: "inv-1",
+        author: "worker",
+        content: { role: "model", parts: [{ text: "L" }] },
+        partial: true,
+      }),
+      createEvent({
+        invocationId: "inv-1",
+        author: "worker",
+        content: { role: "model", parts: [{ text: "amento" }] },
+        partial: true,
+      }),
+      createEvent({
+        invocationId: "inv-1",
+        author: "worker",
+        content: { role: "model", parts: [{ text: "Lamento completo" }] },
+        turnComplete: true,
+      }),
+    ]);
+    const root = new TextAgent("root");
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: parentContext(root),
+    });
+
+    const result = await gateway.runSubAgent({ agentName: "worker", task: "do it" });
+
+    expect(result.output).toBe("Lamento completo");
+    expect(result.summary.textEvents).toBe(1);
+    expect(result.events).toBe(3);
+  });
+
+  test("propagates subagent state through the synthetic function response", async () => {
+    class StateAgent extends BaseAgent {
+      constructor() {
+        super({ name: "worker" });
+      }
+
+      protected async *runAsyncImpl(context: InvocationContext) {
+        yield createEvent({
+          invocationId: context.invocationId,
+          author: this.name,
+          content: { role: "model", parts: [{ text: "stateful" }] },
+          actions: createEventActions({ stateDelta: { architectureSummary: "done" } }),
+        });
+      }
+
+      protected async *runLiveImpl() {}
+    }
+
+    const root = new TextAgent("root");
+    const emitted = [];
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [new StateAgent()],
+      parentContext: parentContext(root),
+      eventSink: (event) => emitted.push(event),
+    });
+
+    const result = await gateway.runSubAgent({ agentName: "worker", task: "do it" });
+
+    expect(result.stateDelta).toEqual({ architectureSummary: "done" });
+    expect(emitted).toHaveLength(3);
+    expect(emitted[1]).toMatchObject({
+      author: "worker",
+      customMetadata: {
+        subAgentEvent: true,
+        subAgentName: "worker",
+        parentToolName: "run_adk_subagent",
+      },
+    });
+    expect(emitted[2].actions.stateDelta).toEqual({ architectureSummary: "done" });
+    expect(emitted[2].content?.parts?.[0]?.functionResponse?.response).toEqual({
+      agentName: "worker",
+      output: "stateful",
+      events: 1,
+      summary: {
+        events: 1,
+        textEvents: 1,
+        toolCalls: 0,
+        errors: 0,
+        durationMs: expect.any(Number),
+      },
+    });
+  });
+
+  test("applies inherited permission override to ExternalAgent subagents", async () => {
+    const driver = new CaptureDriver();
+    const worker = new ExternalAgent({
+      name: "worker",
+      provider: CODEX_PROVIDER,
+      driver,
+      permissions: { mode: "full-access", allowNetwork: true },
+    });
+    const root = new TextAgent("root");
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [worker],
+      parentContext: parentContext(root),
+      parentPermissions: { mode: "read-only" },
+    });
+
+    await gateway.runSubAgent({ agentName: "worker", task: "do it" });
+
+    expect(driver.request?.permissions).toEqual({
+      mode: "read-only",
+      allowNetwork: false,
+    });
+  });
+
+  test("returns a controlled error for unknown subagents", async () => {
+    const root = new TextAgent("root");
+    const gateway = new ToolGateway({
+      rootAgent: root,
+      subAgents: [],
+      parentContext: parentContext(root),
+    });
+
+    const result = await gateway.runSubAgent({ agentName: "missing", task: "do it" });
+
+    expect(result.error).toBe("Unknown ADK subagent: missing");
+    expect(result.output).toBe("");
+    expect(result.events).toBe(0);
+  });
+});

--- a/tests/compat/nodenext-consumer/index.ts
+++ b/tests/compat/nodenext-consumer/index.ts
@@ -1,0 +1,7 @@
+import { OpenAI, OpenRouter } from "../../../dist/index.js";
+import { CodexAgent, GeminiCliAgent } from "../../../dist/agents/index.js";
+
+void OpenAI;
+void OpenRouter;
+void CodexAgent;
+void GeminiCliAgent;

--- a/tests/compat/nodenext-consumer/tsconfig.json
+++ b/tests/compat/nodenext-consumer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": [],
+    "noEmit": true
+  },
+  "include": ["./index.ts"]
+}

--- a/tests/converters/request.test.ts
+++ b/tests/converters/request.test.ts
@@ -8,7 +8,7 @@ import {
   convertRequest,
   convertStructuredOutput,
   convertToolChoice,
-} from "../../src/converters/request";
+} from "../../src/converters/request.js";
 
 function createLlmRequest(overrides: Partial<LlmRequest> = {}): LlmRequest {
   return {

--- a/tests/converters/response.test.ts
+++ b/tests/converters/response.test.ts
@@ -5,7 +5,7 @@ import {
   convertResponse,
   convertStreamChunk,
   createStreamAccumulator,
-} from "../../src/converters/response";
+} from "../../src/converters/response.js";
 
 type ChatCompletion = OpenAI.ChatCompletion;
 type ChatCompletionChunk = OpenAI.ChatCompletionChunk;

--- a/tests/converters/schema.test.ts
+++ b/tests/converters/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeSchema } from "../../src/converters/schema";
+import { normalizeSchema } from "../../src/converters/schema.js";
 
 describe("normalizeSchema", () => {
   it("normalizes nested OBJECT/STRING/ARRAY types to lowercase", () => {

--- a/tests/core/base-provider-llm.test.ts
+++ b/tests/core/base-provider-llm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { BaseProviderLlm } from "../../src/core/base-provider-llm";
+import { BaseProviderLlm } from "../../src/core/base-provider-llm.js";
 import type { LlmRequest, LlmResponse } from "@google/adk";
 
 // Concrete subclass for testing the abstract base

--- a/tests/core/openai-compatible-llm.request.test.ts
+++ b/tests/core/openai-compatible-llm.request.test.ts
@@ -13,8 +13,8 @@
 import { describe, expect, it } from "bun:test";
 import type { LlmRequest, LlmResponse } from "@google/adk";
 import type OpenAI from "openai";
-import { OpenAICompatibleLlm } from "../../src/core/openai-compatible-llm";
-import { OPENAI_DEFINITION } from "../../src/providers/openai/definition";
+import { OpenAICompatibleLlm } from "../../src/core/openai-compatible-llm.js";
+import { OPENAI_DEFINITION } from "../../src/providers/openai/definition.js";
 
 type CreateParams = Parameters<
   OpenAI["chat"]["completions"]["create"]

--- a/tests/helpers/provider-test-helpers.ts
+++ b/tests/helpers/provider-test-helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { getProviderConfig, resetAllConfigs } from "../../src/config";
+import { getProviderConfig, resetAllConfigs } from "../../src/config.js";
 
 // ---------------------------------------------------------------------------
 // Registration test suite

--- a/tests/providers/ai-gateway/ai-gateway-llm.test.ts
+++ b/tests/providers/ai-gateway/ai-gateway-llm.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { resetConfig } from "../../../src/config";
-import { AI_GATEWAY_DEFINITION } from "../../../src/providers/ai-gateway/definition";
-import { AIGatewayLlm } from "../../../src/providers/ai-gateway";
+import { resetConfig } from "../../../src/config.js";
+import { AI_GATEWAY_DEFINITION } from "../../../src/providers/ai-gateway/definition.js";
+import { AIGatewayLlm } from "../../../src/providers/ai-gateway/index.js";
 import {
   describeModelPatterns,
   describeConnectError,
-} from "../../helpers/provider-test-helpers";
+} from "../../helpers/provider-test-helpers.js";
 
 describe("AIGatewayLlm", () => {
   beforeEach(() => {

--- a/tests/providers/ai-gateway/factory.test.ts
+++ b/tests/providers/ai-gateway/factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { OpenAICompatibleLlm } from "../../../src/core/openai-compatible-llm";
-import { AIGateway } from "../../../src/providers/ai-gateway";
-import { describeProviderFactory } from "../../helpers/provider-test-helpers";
+import { OpenAICompatibleLlm } from "../../../src/core/openai-compatible-llm.js";
+import { AIGateway } from "../../../src/providers/ai-gateway/index.js";
+import { describeProviderFactory } from "../../helpers/provider-test-helpers.js";
 
 describeProviderFactory({
   name: "AIGateway",

--- a/tests/providers/ai-gateway/register.test.ts
+++ b/tests/providers/ai-gateway/register.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { getConfig } from "../../../src/config";
+import { getConfig } from "../../../src/config.js";
 import {
   _resetAIGatewayRegistration,
   isAIGatewayRegistered,
   registerAIGateway,
-} from "../../../src/providers/ai-gateway";
+} from "../../../src/providers/ai-gateway/index.js";
 
 describe("registerAIGateway", () => {
   beforeEach(() => {

--- a/tests/providers/anthropic/anthropic-llm.test.ts
+++ b/tests/providers/anthropic/anthropic-llm.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { resetAllConfigs } from "../../../src/config";
+import { resetAllConfigs } from "../../../src/config.js";
 import {
   ANTHROPIC_MODEL_PATTERNS,
   AnthropicLlm,
-} from "../../../src/providers/anthropic";
+} from "../../../src/providers/anthropic/index.js";
 import {
   describeConnectError,
   describeModelPatterns,
-} from "../../helpers/provider-test-helpers";
+} from "../../helpers/provider-test-helpers.js";
 
 describe("AnthropicLlm", () => {
   beforeEach(() => {

--- a/tests/providers/anthropic/converters/request.test.ts
+++ b/tests/providers/anthropic/converters/request.test.ts
@@ -8,7 +8,7 @@ import {
   convertAnthropicRequest,
   convertAnthropicStructuredOutput,
   convertAnthropicToolChoice,
-} from "../../../../src/providers/anthropic/converters/request";
+} from "../../../../src/providers/anthropic/converters/request.js";
 
 function createLlmRequest(overrides: Partial<LlmRequest> = {}): LlmRequest {
   return {

--- a/tests/providers/anthropic/converters/response.test.ts
+++ b/tests/providers/anthropic/converters/response.test.ts
@@ -5,7 +5,7 @@ import {
   convertAnthropicResponse,
   convertAnthropicStreamEvent,
   createAnthropicStreamAccumulator,
-} from "../../../../src/providers/anthropic/converters/response";
+} from "../../../../src/providers/anthropic/converters/response.js";
 
 // Helper to create Anthropic Message with required fields
 function createMessage(overrides: {

--- a/tests/providers/anthropic/factory.test.ts
+++ b/tests/providers/anthropic/factory.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { resetAllConfigs } from "../../../src/config";
-import { Anthropic, AnthropicLlm } from "../../../src/providers/anthropic";
+import { resetAllConfigs } from "../../../src/config.js";
+import { Anthropic, AnthropicLlm } from "../../../src/providers/anthropic/index.js";
 
 describe("Anthropic factory", () => {
   beforeEach(() => {

--- a/tests/providers/anthropic/register.test.ts
+++ b/tests/providers/anthropic/register.test.ts
@@ -2,8 +2,8 @@ import {
   _resetAnthropicRegistration,
   isAnthropicRegistered,
   registerAnthropic,
-} from "../../../src/providers/anthropic";
-import { describeProviderRegistration } from "../../helpers/provider-test-helpers";
+} from "../../../src/providers/anthropic/index.js";
+import { describeProviderRegistration } from "../../helpers/provider-test-helpers.js";
 
 describeProviderRegistration({
   name: "Anthropic",

--- a/tests/providers/custom/custom-llm.test.ts
+++ b/tests/providers/custom/custom-llm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { CustomLlm } from "../../../src/providers/custom/custom-llm";
+import { CustomLlm } from "../../../src/providers/custom/custom-llm.js";
 
 describe("CustomLlm", () => {
   describe("supportedModels", () => {
@@ -87,7 +87,7 @@ describe("CustomLlm", () => {
           new CustomLlm({
             model: "llama3",
             baseURL: "not-a-url",
-          } as import("../../../src/providers/custom/custom-llm").CustomLlmProviderConfig),
+          } as import("../../../src/providers/custom/custom-llm.js").CustomLlmProviderConfig),
       ).toThrow("Invalid baseURL");
     });
   });

--- a/tests/providers/custom/factory.test.ts
+++ b/tests/providers/custom/factory.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { CustomLlm } from "../../../src/providers/custom/custom-llm";
-import { Custom, createCustomLlm } from "../../../src/providers/custom/factory";
+import { CustomLlm } from "../../../src/providers/custom/custom-llm.js";
+import { Custom, createCustomLlm } from "../../../src/providers/custom/factory.js";
 
 describe("createCustomLlm", () => {
   it("creates a CustomLlm instance", () => {

--- a/tests/providers/openai/factory.test.ts
+++ b/tests/providers/openai/factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { OpenAICompatibleLlm } from "../../../src/core/openai-compatible-llm";
-import { OpenAI } from "../../../src/providers/openai";
-import { describeProviderFactory } from "../../helpers/provider-test-helpers";
+import { OpenAICompatibleLlm } from "../../../src/core/openai-compatible-llm.js";
+import { OpenAI } from "../../../src/providers/openai/index.js";
+import { describeProviderFactory } from "../../helpers/provider-test-helpers.js";
 
 describeProviderFactory({
   name: "OpenAI",

--- a/tests/providers/openai/openai-llm.test.ts
+++ b/tests/providers/openai/openai-llm.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { resetAllConfigs } from "../../../src/config";
-import { OPENAI_DEFINITION } from "../../../src/providers/openai/definition";
-import { OpenAILlm } from "../../../src/providers/openai";
+import { resetAllConfigs } from "../../../src/config.js";
+import { OPENAI_DEFINITION } from "../../../src/providers/openai/definition.js";
+import { OpenAILlm } from "../../../src/providers/openai/index.js";
 import {
   describeModelPatterns,
   describeConnectError,
-} from "../../helpers/provider-test-helpers";
+} from "../../helpers/provider-test-helpers.js";
 
 describe("OpenAILlm", () => {
   beforeEach(() => {

--- a/tests/providers/openai/register.test.ts
+++ b/tests/providers/openai/register.test.ts
@@ -2,8 +2,8 @@ import {
   _resetOpenAIRegistration,
   isOpenAIRegistered,
   registerOpenAI,
-} from "../../../src/providers/openai";
-import { describeProviderRegistration } from "../../helpers/provider-test-helpers";
+} from "../../../src/providers/openai/index.js";
+import { describeProviderRegistration } from "../../helpers/provider-test-helpers.js";
 
 describeProviderRegistration({
   name: "OpenAI",

--- a/tests/providers/openrouter/factory.test.ts
+++ b/tests/providers/openrouter/factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { OpenAICompatibleLlm } from "../../../src/core/openai-compatible-llm";
-import { OpenRouter } from "../../../src/providers/openrouter";
-import { describeProviderFactory } from "../../helpers/provider-test-helpers";
+import { OpenAICompatibleLlm } from "../../../src/core/openai-compatible-llm.js";
+import { OpenRouter } from "../../../src/providers/openrouter/index.js";
+import { describeProviderFactory } from "../../helpers/provider-test-helpers.js";
 
 describeProviderFactory({
   name: "OpenRouter",

--- a/tests/providers/openrouter/openrouter-llm.test.ts
+++ b/tests/providers/openrouter/openrouter-llm.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { resetAllConfigs } from "../../../src/config";
-import { OPENROUTER_DEFINITION } from "../../../src/providers/openrouter/definition";
-import { OpenRouterLlm } from "../../../src/providers/openrouter";
+import { resetAllConfigs } from "../../../src/config.js";
+import { OPENROUTER_DEFINITION } from "../../../src/providers/openrouter/definition.js";
+import { OpenRouterLlm } from "../../../src/providers/openrouter/index.js";
 import {
   describeModelPatterns,
   describeConnectError,
-} from "../../helpers/provider-test-helpers";
+} from "../../helpers/provider-test-helpers.js";
 
 describe("OpenRouterLlm", () => {
   beforeEach(() => {

--- a/tests/providers/openrouter/register.test.ts
+++ b/tests/providers/openrouter/register.test.ts
@@ -2,8 +2,8 @@ import {
   _resetOpenRouterRegistration,
   isOpenRouterRegistered,
   registerOpenRouter,
-} from "../../../src/providers/openrouter";
-import { describeProviderRegistration } from "../../helpers/provider-test-helpers";
+} from "../../../src/providers/openrouter/index.js";
+import { describeProviderRegistration } from "../../helpers/provider-test-helpers.js";
 
 describeProviderRegistration({
   name: "OpenRouter",

--- a/tests/providers/xai/factory.test.ts
+++ b/tests/providers/xai/factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { OpenAICompatibleLlm } from "../../../src/core/openai-compatible-llm";
-import { XAI } from "../../../src/providers/xai";
-import { describeProviderFactory } from "../../helpers/provider-test-helpers";
+import { OpenAICompatibleLlm } from "../../../src/core/openai-compatible-llm.js";
+import { XAI } from "../../../src/providers/xai/index.js";
+import { describeProviderFactory } from "../../helpers/provider-test-helpers.js";
 
 describeProviderFactory({
   name: "XAI",

--- a/tests/providers/xai/register.test.ts
+++ b/tests/providers/xai/register.test.ts
@@ -2,8 +2,8 @@ import {
   _resetXAIRegistration,
   isXAIRegistered,
   registerXAI,
-} from "../../../src/providers/xai";
-import { describeProviderRegistration } from "../../helpers/provider-test-helpers";
+} from "../../../src/providers/xai/index.js";
+import { describeProviderRegistration } from "../../helpers/provider-test-helpers.js";
 
 describeProviderRegistration({
   name: "XAI",

--- a/tests/providers/xai/xai-llm.test.ts
+++ b/tests/providers/xai/xai-llm.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { resetAllConfigs } from "../../../src/config";
-import { XAI_DEFINITION } from "../../../src/providers/xai/definition";
-import { XAILlm } from "../../../src/providers/xai";
+import { resetAllConfigs } from "../../../src/config.js";
+import { XAI_DEFINITION } from "../../../src/providers/xai/definition.js";
+import { XAILlm } from "../../../src/providers/xai/index.js";
 import {
   describeModelPatterns,
   describeConnectError,
-} from "../../helpers/provider-test-helpers";
+} from "../../helpers/provider-test-helpers.js";
 
 describe("XAILlm", () => {
   beforeEach(() => {

--- a/tests/utils/json.test.ts
+++ b/tests/utils/json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { safeJsonParse } from "../../src/utils/json";
+import { safeJsonParse } from "../../src/utils/json.js";
 
 describe("safeJsonParse", () => {
   it("parses normal JSON unchanged", () => {

--- a/tests/utils/validate.test.ts
+++ b/tests/utils/validate.test.ts
@@ -3,7 +3,7 @@ import {
   clampPositive,
   requireNonEmpty,
   requireValidURL,
-} from "../../src/utils/validate";
+} from "../../src/utils/validate.js";
 
 describe("requireNonEmpty", () => {
   it("returns value when non-empty", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",
@@ -11,8 +11,8 @@
     "noEmit": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["bun-types"],
+    "types": ["bun-types"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"],
+  "exclude": ["node_modules", "dist", "tests"]
 }


### PR DESCRIPTION
## Release v0.6.0

Promotes `release/0.6.0` to `main`. Bundles the external agents bridge (merged via #80) and the version/CHANGELOG bump.

### Added
- **External agents bridge** (`adk-llm-bridge/agents`): wraps full external coding agents as native ADK agents — `ClaudeAgent` (Claude Agent SDK), `CodexAgent` (Codex SDK/CLI), `GeminiCliAgent` (Gemini CLI) — with a driver abstraction (SDK / CLI / subprocess), credential providers, permission mapping, runtime sessions, a tool gateway, and a native `ExternalAgentEvent` stream.
- Examples: `basic-agent-claude`, `basic-agent-codex`, `basic-agent-gemini`, and the combined `external-agents` showcase.

### Changed
- Version `0.5.3` → `0.6.0`; CHANGELOG updated.
- SDK pins: `@openai/codex-sdk` `^0.141.0`, `@anthropic-ai/claude-agent-sdk` `^0.3.183`.

### Fixed
- **Codex driver:** availability via `CODEX_API_KEY`/`auth.json` (not `PATH`); typed error classification (auth/billing non-recoverable); `thread.started` capture for resumability; proxy/cert/`CODEX_HOME`/`CODEX_ACCESS_TOKEN` env passthrough.
- **Claude driver:** read-only → `permissionMode: "default"` (not `"plan"`); `settingSources: []` isolation by default; `abortController` + `interrupt()`/`return()` lifecycle; typed error classification.

### Verification
- `bun run ci` green: typecheck:all + lint + **590 tests / 0 fail** + build + publint/attw.
- No-credential smokes for all three examples exit 0 with their "set <KEY> to run" hint (Codex now skips cleanly).

Supersedes #71 (the v0.5.0-based draft, now closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)